### PR TITLE
Add tableData and shape parameters to match core Table API

### DIFF
--- a/table-paging/src/commonMain/kotlin/ua/wwind/table/paging/Table.kt
+++ b/table-paging/src/commonMain/kotlin/ua/wwind/table/paging/Table.kt
@@ -4,10 +4,13 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import ua.wwind.paging.core.PagingData
 import ua.wwind.paging.core.getOrNull
@@ -24,13 +27,46 @@ import ua.wwind.table.state.TableState
 import ua.wwind.table.strings.DefaultStrings
 import ua.wwind.table.strings.StringProvider
 
+/**
+ * Composable data table with paging support.
+ *
+ * This overload wraps [PagingData] and delegates to the core [Table] composable.
+ *
+ * - Columns are described by [columns] (`ColumnSpec`).
+ * - Data is provided via [items] (`PagingData`).
+ * - Sorting, filters, ordering and selection are controlled by [state].
+ *
+ * Generic parameters:
+ * - [T] actual row item type.
+ * - [C] column key type.
+ * - [E] table data type - shared state accessible in headers, footers, and edit cells.
+ *
+ * @param items paging data container with loaded items
+ * @param state mutable table state (sorting, filters, order, selection)
+ * @param columns list of visible/available column specifications
+ * @param tableData current table data instance - accessible in headers, footers, and edit cells
+ * @param modifier layout modifier for the whole table
+ * @param placeholderRow optional row content shown when an item is null
+ * @param rowKey stable key for rows; defaults to index
+ * @param onRowClick row primary action handler
+ * @param onRowLongClick optional long-press handler
+ * @param contextMenu optional context menu host, invoked with item and absolute position
+ * @param customization styling hooks for rows and cells
+ * @param colors container/content colors
+ * @param strings string provider for UI text
+ * @param verticalState list scroll state
+ * @param horizontalState horizontal scroll state of the whole table
+ * @param icons header icons used for sort and filter affordances
+ * @param shape surface shape of the table
+ */
 @OptIn(ExperimentalTableApi::class)
 @Composable
 @Suppress("LongParameterList", "ktlint:standard:function-naming")
-public fun <T : Any, C> Table(
+public fun <T : Any, C, E> Table(
     items: PagingData<T>?,
     state: TableState<C>,
-    columns: ImmutableList<ColumnSpec<T, C, Unit>>,
+    columns: ImmutableList<ColumnSpec<T, C, E>>,
+    tableData: E,
     modifier: Modifier = Modifier,
     placeholderRow: (@Composable () -> Unit)? = null,
     rowKey: (item: T?, index: Int) -> Any = { _, i -> i },
@@ -43,6 +79,7 @@ public fun <T : Any, C> Table(
     verticalState: LazyListState = rememberLazyListState(),
     horizontalState: ScrollState = rememberScrollState(),
     icons: TableHeaderIcons = TableHeaderDefaults.icons(),
+    shape: Shape = RoundedCornerShape(4.dp),
 ) {
     val itemsCount = remember(items) { items?.data?.size ?: 0 }
     val itemAt = remember(items) { { index: Int -> items?.data?.get(index)?.getOrNull() } }
@@ -52,6 +89,7 @@ public fun <T : Any, C> Table(
         itemAt = itemAt,
         state = state,
         columns = columns,
+        tableData = tableData,
         modifier = modifier,
         placeholderRow = placeholderRow,
         rowKey = rowKey,
@@ -64,5 +102,6 @@ public fun <T : Any, C> Table(
         verticalState = verticalState,
         horizontalState = horizontalState,
         icons = icons,
+        shape = shape,
     )
 }


### PR DESCRIPTION
## Summary
Align `table-paging` Table API with `table-core` Table API by adding missing parameters and generic type.

## Changes
- Add generic type parameter `E` for custom table data support
- Add `tableData: E` parameter for shared state in headers/footers/cells
- Add `shape: Shape` parameter for table border customization
- Update `columns` type from `ColumnSpec<T, C, Unit>` to `ColumnSpec<T, C, E>`
- Add KDoc documentation

## Breaking Changes
- Function signature changed: `tableData` is now a required parameter
- `columns` generic type changed from `Unit` to `E`

## Migration
Before:
```kotlin
Table(items, state, columns, modifier)
```

After:
```kotlin
Table(items, state, columns, tableData = Unit, modifier)
```
