### PR TITLE
 Add close button and fix dropdown scrollbar crash

### DIFF
--- a/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialog.kt
+++ b/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialog.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Close
@@ -22,6 +23,7 @@ import androidx.compose.material.icons.rounded.DragIndicator
 import androidx.compose.material.icons.rounded.Save
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -60,22 +62,13 @@ import sh.calvin.reorderable.rememberReorderableLazyListState
 import ua.wwind.table.format.component.FormatDialogTabRow
 import ua.wwind.table.format.component.RuleTab
 import ua.wwind.table.format.component.TabData
+import ua.wwind.table.format.data.EditFormatRule
+import ua.wwind.table.format.data.FormatDialogSettings
 import ua.wwind.table.format.data.TableFormatRule
 import ua.wwind.table.format.scrollbar.VerticalScrollbarRenderer
 import ua.wwind.table.format.scrollbar.VerticalScrollbarState
 import ua.wwind.table.strings.StringProvider
 import ua.wwind.table.strings.UiString
-
-private data class EditFormatRule<E : Enum<E>, FILTER>(
-    val index: Int,
-    val item: TableFormatRule<E, FILTER>,
-    val isNew: Boolean = false,
-)
-
-public data class FormatDialogSettings(
-    val copiedItemHighlightDuration: Long = 3000,
-    val copiedItemHighlightColor: Color = Color.Unspecified,
-)
 
 @OptIn(FlowPreview::class)
 @Composable
@@ -107,12 +100,31 @@ public fun <E : Enum<E>, FILTER> FormatDialog(
     AlertDialog(
         onDismissRequest = onDismissRequest,
         confirmButton = {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = spacedBy(16.dp, Alignment.End),
-            ) {
-                editItem?.let { (index, item, isNew) ->
+            if (editItem == null) {
+                FloatingActionButton(
+                    onClick = {
+                        val id = rules.maxByOrNull { it.id }?.id?.inc() ?: 0L
+                        editItem =
+                            EditFormatRule(
+                                rules.lastIndex + 1,
+                                getNewRule(id),
+                                true,
+                            )
+                    },
+                    shape = CircleShape,
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Add,
+                        contentDescription = "Add",
+                    )
+                }
+            }
+            editItem?.let { (index, item, isNew) ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = spacedBy(16.dp, Alignment.End),
+                ) {
                     if (!isNew) {
                         IconButton(
                             onClick = {
@@ -194,14 +206,11 @@ public fun <E : Enum<E>, FILTER> FormatDialog(
                 )
                 if (editItem == null) {
                     IconButton(
-                        onClick = {
-                            val id = rules.maxByOrNull { it.id }?.id?.inc() ?: 0L
-                            editItem = EditFormatRule(rules.lastIndex + 1, getNewRule(id), true)
-                        },
+                        onClick = onDismissRequest,
                     ) {
                         Icon(
-                            imageVector = Icons.Rounded.Add,
-                            contentDescription = "Add",
+                            imageVector = Icons.Rounded.Close,
+                            contentDescription = "Сlose",
                         )
                     }
                 }

--- a/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialogDesignTab.kt
+++ b/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialogDesignTab.kt
@@ -42,7 +42,6 @@ public fun <E : Enum<E>, FILTER> FormatDialogDesignTab(
                 onChange(item.copy(cellStyle = item.cellStyle.copy(textStyle = value)))
             },
             modifier = Modifier.fillMaxWidth(),
-            scrollbarRenderer = scrollbarRenderer,
         )
         FormatColorField(
             color = item.cellStyle.contentColor?.toColor(),
@@ -76,7 +75,6 @@ public fun <E : Enum<E>, FILTER> FormatDialogDesignTab(
                 onChange(item.copy(cellStyle = item.cellStyle.copy(vertical = value)))
             },
             modifier = Modifier.fillMaxWidth(),
-            scrollbarRenderer = scrollbarRenderer,
         )
         FormatDropdownField(
             currentValue = item.cellStyle.horizontal,
@@ -89,7 +87,6 @@ public fun <E : Enum<E>, FILTER> FormatDialogDesignTab(
                 onChange(item.copy(cellStyle = item.cellStyle.copy(horizontal = value)))
             },
             modifier = Modifier.fillMaxWidth(),
-            scrollbarRenderer = scrollbarRenderer,
         )
     }
 }

--- a/table-format/src/commonMain/kotlin/ua/wwind/table/format/component/FormatDropdownField.kt
+++ b/table-format/src/commonMain/kotlin/ua/wwind/table/format/component/FormatDropdownField.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -29,8 +28,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import ua.wwind.table.filter.component.collectAsEffect
-import ua.wwind.table.format.scrollbar.VerticalScrollbarRenderer
-import ua.wwind.table.format.scrollbar.VerticalScrollbarState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Suppress("LongParameterList", "LongMethod")
@@ -45,7 +42,6 @@ internal fun <E : Enum<E>> FormatDropdownField(
     modifier: Modifier = Modifier,
     checked: ((E) -> Boolean)? = null,
     enabled: Boolean = true,
-    scrollbarRenderer: VerticalScrollbarRenderer? = null,
 ) {
     val scrollState = rememberScrollState()
     var expanded by remember { mutableStateOf(false) }
@@ -123,10 +119,6 @@ internal fun <E : Enum<E>> FormatDropdownField(
                         )
                     }
                 }
-                scrollbarRenderer?.Render(
-                    modifier = Modifier.align(Alignment.TopEnd).fillMaxHeight(),
-                    state = VerticalScrollbarState.Scroll(scrollState),
-                )
             }
         }
     }

--- a/table-format/src/commonMain/kotlin/ua/wwind/table/format/data/EditFormatRule.kt
+++ b/table-format/src/commonMain/kotlin/ua/wwind/table/format/data/EditFormatRule.kt
@@ -1,0 +1,10 @@
+package ua.wwind.table.format.data
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+internal data class EditFormatRule<E : Enum<E>, FILTER>(
+    val index: Int,
+    val item: TableFormatRule<E, FILTER>,
+    val isNew: Boolean = false,
+)

--- a/table-format/src/commonMain/kotlin/ua/wwind/table/format/data/FormatDialogSettings.kt
+++ b/table-format/src/commonMain/kotlin/ua/wwind/table/format/data/FormatDialogSettings.kt
@@ -1,0 +1,10 @@
+package ua.wwind.table.format.data
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+
+@Immutable
+public data class FormatDialogSettings(
+    val copiedItemHighlightDuration: Long = 3000,
+    val copiedItemHighlightColor: Color = Color.Unspecified,
+)

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/ConditionalFormattingDialog.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/ConditionalFormattingDialog.kt
@@ -5,7 +5,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import ua.wwind.table.filter.data.TableFilterState
 import ua.wwind.table.format.FormatDialog
-import ua.wwind.table.format.FormatDialogSettings
+import ua.wwind.table.format.data.FormatDialogSettings
 import ua.wwind.table.format.data.TableFormatRule
 import ua.wwind.table.sample.column.PersonColumn
 import ua.wwind.table.strings.DefaultStrings


### PR DESCRIPTION
## Summary

- **Added close button** to the format dialog (top-right corner when no item is being edited)
- **Relocated add button** from top-right corner to floating action button at the bottom of the dialog
- **Fixed crash** caused by VerticalScrollbarRenderer in dropdown menus - removed scrollbar from dropdown fields

### Changes

- `FormatDialog.kt`: Added FAB for adding new rules, replaced top-right add button with close button
- `FormatDropdownField.kt`: Removed scrollbarRenderer parameter that caused crashes
- `FormatDialogDesignTab.kt`: Removed scrollbarRenderer usage from text style, vertical, and horizontal fields
- Refactored `EditFormatRule` and `FormatDialogSettings` into separate files in `data` package
