### PR TITLE
Drag a row group as a single unit; fix a table width that ignored column visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-### 1.11.0 — 2026-07-15
+### 1.11.0 — 2026-07-16
 
 - Added: `rowGroups` parameter on `Table`/`EditableTable`, taking `TableRowGroups(ranges, onMove, header)`.
     - A range of adjacent rows can be dragged as a single unit, with the drag handle typically placed on the group's
@@ -26,6 +26,17 @@ All notable changes to this project will be documented in this file.
     - `TableDefaults.colors()` takes it as a trailing optional parameter, so existing calls keep compiling and binding
       as before, positional ones included.
     - `TableDimensions.rowGroupSpacing` defaults to `8.dp`, so existing `TableDimensions` construction is unaffected.
+- Fixed: table width no longer freezes when `ColumnSpec.visible` changes after the first render.
+    - `TableState.tableWidth` derives from the visible column list, but that list was a plain field, so
+      Compose never saw it change and served a cached width instead. Columns shown again stayed off
+      screen and out of horizontal scroll range, while the header — which measures independently —
+      laid them out, leaving header and rows misaligned.
+    - The stale width was only flushed by an unrelated write to `columnWidths`, so the symptom
+      disappeared as soon as a column was resized, and never appeared at all where `autoWidth` writes
+      those widths on every column change.
+- Added: the module's first tests, covering row groups, the row-to-unit index, the table width across
+  column hide, show and resize, and a composition-level cover that flips `ColumnSpec.visible` on a
+  live `Table` and asserts the revealed column's cell reaches the screen.
 
 Compare: [v1.10.0...v1.11.0](https://github.com/White-Wind-LLC/table/compare/v1.10.0...v1.11.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+### 1.11.0 — 2026-07-15
+
+- Added: `rowGroups` parameter on `Table`/`EditableTable`, taking `TableRowGroups(ranges, onMove, header)`.
+    - A range of adjacent rows can be dragged as a single unit, with the drag handle typically placed on the group's
+      first row and an optional header rendered above the block.
+    - `onMove` reports moves as row ranges (`from: IntRange`, `to: IntRange`) rather than single indices; it is
+      required when row reorder is enabled and `ranges` is non-empty.
+    - When `onMove` is set it supersedes `onRowMove`, which is then no longer invoked.
+    - `TableRowGroups` is `@Stable` and compares by identity — hold it in `remember` to keep `Table` skippable.
+    - Ignored while `state.groupBy` is active: the two describe different structures over one list, so `groupBy` wins
+      and a warning is logged.
+    - Works for both regular lazy tables and embedded table bodies; in a lazy table `onMove` fires during the drag,
+      in an embedded table once on drop.
+- Added: `List.rowGroupsOf` and `MutableList.moveRowGroup` helpers.
+    - `rowGroupsOf` derives drag-unit ranges from a flat row list, collapsing runs of adjacent rows that share a
+      non-null group id.
+    - `moveRowGroup` applies a range move to a `MutableList` with the same semantics as the `onMove` callback.
+- Added: `TableDimensions.rowGroupSpacing` and `TableColors.rowGroupContainerColor` for row group visuals.
+    - `rowGroupSpacing` (default `8.dp`) is the vertical band around a group block; `rowGroupContainerColor` tints it.
+- Changed: `TableColors` gained a required `rowGroupContainerColor` constructor parameter.
+    - Direct constructor calls must supply the new parameter.
+    - `TableDefaults.colors()` takes it as a trailing optional parameter, so existing calls keep compiling and binding
+      as before, positional ones included.
+    - `TableDimensions.rowGroupSpacing` defaults to `8.dp`, so existing `TableDimensions` construction is unaffected.
+
+Compare: [v1.10.0...v1.11.0](https://github.com/White-Wind-LLC/table/compare/v1.10.0...v1.11.0)
+
 ### 1.10.0 — 2026-06-24
 
 - Updated: Kotlin to 2.4.0 (from 2.3.21).

--- a/docs/content/guides/row-reordering.md
+++ b/docs/content/guides/row-reordering.md
@@ -87,3 +87,233 @@ fun ReorderablePeopleTable() {
     )
 }
 ```
+
+## Dragging a group of rows
+
+A range of **adjacent** rows can be declared as one drag unit: dragging it carries the whole block
+instead of a single row. Pass a `TableRowGroups` as `rowGroups` to `Table` or `EditableTable`:
+
+```kotlin
+@Stable
+public class TableRowGroups(
+    // Which rows form each block: sorted, non-empty, non-overlapping, within `itemsCount`.
+    public val ranges: ImmutableList<IntRange>,
+    // A block was moved; `from.first` is the leader row.
+    public val onMove: ((from: IntRange, to: IntRange) -> Unit)? = null,
+    // Content for the band above a block.
+    public val header: (@Composable (rows: IntRange) -> Unit)? = null,
+)
+```
+
+Whether a group exists, what it is called, and how it is created or dissolved stay in your own data
+and UI. The table only moves the block and draws a band around it.
+
+- **Ranges are derived state.** Compute them from the same data the table renders with
+  `rowGroupsOf`; never maintain range state by hand.
+- **Hold the `TableRowGroups` in `remember`.** It is `@Stable` and compares **by identity** — a
+  fresh instance on every recomposition makes the `rowGroups` argument look changed and stops
+  `Table` from skipping. This is stricter than `TableSettings`, which is a data class whose
+  structural equality forgives a new instance.
+- **`onMove` is required** when row reorder is enabled and `ranges` is non-empty; a `require` fails
+  loudly otherwise, rather than letting the drag break silently. With row reorder disabled, groups
+  still render their band and no callback is needed.
+- **`onMove` supersedes `onRowMove`.** Once `onMove` is non-null, every drag — including one of a
+  plain ungrouped row — is reported through it, and `onRowMove` is not invoked at all.
+
+### Deriving the ranges
+
+`rowGroupsOf` collapses each run of **adjacent** rows sharing the same non-null id into one range;
+rows with a `null` id are never grouped. Two disjoint runs of the same id therefore produce **two**
+ranges — a drag unit has to be contiguous on screen, so adjacency, not the id alone, defines a
+block. This is why a filter that hides a row in the middle of a group splits it into two blocks.
+
+Ranges must be derived from the same data snapshot as `itemAt`. In a scrolling table `onMove` fires
+*during* the drag and the ranges must recompute in the same recomposition as the list, so key the
+`remember` on the rendered data:
+
+```kotlin
+remember(people) { people.rowGroupsOf { it.groupId } }
+```
+
+Because `remember` keys compare by equality, this wants a list that is **replaced** on each change
+(a new `List` from your state holder). A long-lived `mutableStateListOf` mutated in place never
+invalidates such a key, and the ranges would silently lag the rows.
+
+### Applying the move
+
+Both ends of a move are ranges. **Do not collapse `to` to a single index.** A downward move inserts
+the block *after* `to.last`; passing only the target's leader row drops the block *inside* the
+target group and splits it. An upward move inserts at `to.first`, where the leader happens to be
+correct — so the bug looks direction-specific and survives casual testing.
+
+`moveRowGroup` implements the correct semantics for a `MutableList`:
+
+```kotlin
+onMove = { from, to ->
+    people = people.toMutableList().apply { moveRowGroup(from = from, to = to) }
+}
+```
+
+When the move must be applied depends on the table's mode, and the difference comes from the
+underlying [Reorderable](https://github.com/Calvin-LL/Reorderable) library rather than from this
+one — it already applies to `onRowMove` today:
+
+- **Scrolling table** (`embedded = false`): `onMove` fires **repeatedly during** the drag, and the
+  consumer must apply the move to its list **synchronously**. The block follows the cursor only
+  because the data moves under it.
+- **Embedded table** (`embedded = true`): `onMove` fires **once, on drop**, so the move is applied
+  at settle time.
+
+### Putting the handle on the leader row
+
+The library does not place the drag handle — any handle inside the block drags the whole block. The
+usual choice is to render it only on the group's first row, which you detect with the same adjacency
+rule `rowGroupsOf` uses:
+
+```kotlin
+cell { person, rows ->
+    val index = rows.indexOfFirst { it.id == person.id }
+    val isLeader =
+        person.groupId == null || index <= 0 || rows[index - 1].groupId != person.groupId
+    if (isLeader) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.fillMaxSize().draggableHandle(),
+        ) {
+            Icon(Icons.Default.Reorder, contentDescription = "Drag group")
+        }
+    }
+}
+```
+
+### The header band
+
+`header` renders in the band above each block and is offset by the horizontal scroll, so it stays in
+the viewport while the table scrolls sideways. The library adds **no click handling** of its own —
+attach your own `Modifier.clickable` inside the slot for renaming, dissolving, or anything else:
+
+```kotlin
+header = { rows ->
+    Text(
+        text = people[rows.first].groupId.orEmpty(),
+        modifier = Modifier
+            .clickable { renameGroup(people[rows.first].groupId) }
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+    )
+}
+```
+
+### Visuals
+
+- `TableDimensions.rowGroupSpacing` (default `8.dp`) — the vertical gap around a block.
+- `TableColors.rowGroupContainerColor` — the tint painted behind it.
+
+Rows keep their own dividers, the group's last row included; the block adds none. The tinted band is
+purely the group's **margin**, which is what makes it legible — each row paints its own opaque
+surface, so only the gap shows the tint.
+
+A block always **opens** with a band — the header when configured, otherwise a `rowGroupSpacing`
+gap — and **closes** with a gap only when the next unit is not a group. Two adjacent blocks
+therefore get exactly one band between them instead of two stacked into a single fat slab, and a
+block at either end of the list still keeps its outer band.
+
+### Interaction with `groupBy`
+
+`rowGroups` and `state.groupBy` describe two different structures over one list, so they do not
+compose: while `groupBy` is active, `rowGroups` is **ignored**, a warning is logged, and rows render
+ungrouped with no band. `groupBy` wins because refusing a grouping menu click with an exception
+would be worse. Note that grouping interactions are already disabled while row reorder mode is
+active, so the two only meet when reorder is off.
+
+### Example
+
+```kotlin
+data class Person(val id: Int, val name: String, val groupId: String? = null)
+
+enum class PersonColumn { Handle, Name }
+
+@OptIn(ExperimentalTableApi::class)
+@Composable
+fun GroupedPeopleTable() {
+    // Every change replaces the list, so `remember(people)` recomputes the ranges along with it.
+    var people by remember {
+        mutableStateOf(
+            listOf(
+                Person(1, "Alice"),
+                Person(2, "Bob", groupId = "Team A"),
+                Person(3, "Carol", groupId = "Team A"),
+                Person(4, "Dave"),
+            ),
+        )
+    }
+
+    // The current list is passed as table data, so cells can locate their own row.
+    val columns =
+        remember {
+            tableColumns<Person, PersonColumn, List<Person>> {
+                column(PersonColumn.Handle, valueOf = { it.id }) {
+                    width(48.dp, 48.dp)
+                    resizable(false)
+                    cell { person, rows ->
+                        val index = rows.indexOfFirst { it.id == person.id }
+                        val isLeader =
+                            person.groupId == null ||
+                                index <= 0 ||
+                                rows[index - 1].groupId != person.groupId
+                        if (isLeader) {
+                            Box(
+                                contentAlignment = Alignment.Center,
+                                modifier = Modifier.fillMaxSize().draggableHandle(),
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Reorder,
+                                    contentDescription = "Drag group",
+                                )
+                            }
+                        }
+                    }
+                }
+
+                column(PersonColumn.Name, valueOf = { it.name }) {
+                    header("Name")
+                    cell { person, _ -> Text(person.name) }
+                }
+            }
+        }
+
+    val state =
+        rememberTableState(
+            columns = PersonColumn.entries.toImmutableList(),
+            settings = TableSettings(rowReorderEnabled = true),
+        )
+
+    val rowGroups =
+        remember(people) {
+            TableRowGroups(
+                // "Team A" is rows 1..2 — Alice and Dave stay single-row units.
+                ranges = people.rowGroupsOf { it.groupId },
+                onMove = { from, to ->
+                    // Fires during the drag: apply it now, and keep both ranges intact.
+                    people = people.toMutableList().apply { moveRowGroup(from = from, to = to) }
+                },
+                header = { rows ->
+                    Text(
+                        text = people[rows.first].groupId.orEmpty(),
+                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    )
+                },
+            )
+        }
+
+    Table(
+        itemsCount = people.size,
+        itemAt = { index -> people.getOrNull(index) },
+        state = state,
+        columns = columns,
+        tableData = people,
+        rowKey = { item, index -> item?.id ?: index },
+        rowGroups = rowGroups,
+    )
+}
+```

--- a/docs/content/modules/table-core.md
+++ b/docs/content/modules/table-core.md
@@ -18,6 +18,7 @@ row selection, i18n, styling/customization, and dynamic or fixed row height.
 - Footer row with customizable content per column (totals, averages, summaries); supports pinned and scrollable modes.
 - Drag & drop to reorder columns in the header.
 - Row reordering powered by Reorderable with custom drag handles inside cell content.
+- Dragging a declared range of adjacent rows as a single unit, with an optional header above the block.
 - Column resize via drag with per‑column min width.
 - Filters: text, number (int/double, ranges), boolean, date, enum (single/multi; IN/NOT IN/EQUALS) with built‑in
   `FilterPanel`.

--- a/docs/content/reference/core-api.md
+++ b/docs/content/reference/core-api.md
@@ -3,7 +3,7 @@
 - **Composable `Table<T, C>`**: renders header and virtualized rows for read-only tables (tableData = Unit).
     - **Required**: `itemsCount`, `itemAt(index)`, `state: TableState<C>`, `columns: List<ColumnSpec<T, C, Unit>>`.
     - **Slots**: `placeholderRow()`.
-    - **UX**: `onRowClick`, `onRowLongClick`, `onRowMove`, `contextMenu(item, pos, dismiss)`.
+    - **UX**: `onRowClick`, `onRowLongClick`, `onRowMove`, `rowGroups`, `contextMenu(item, pos, dismiss)`.
     - **Look**: `customization`, `colors = TableDefaults.colors()`, `icons = TableHeaderDefaults.icons()`, `strings`,
       `shape`, `border` (outer border; `null` = theme default, `TableDefaults.NoBorder` = no border).
     - **Scroll**: optional `verticalState`, `horizontalState`.
@@ -14,7 +14,8 @@
       cells.
     - All other parameters same as read-only variant.
 - **Composable `EditableTable<T, C, E>`**: renders header and virtualized rows with editing support.
-    - **Additional parameters**: `tableData: E`, `onRowMove`, `onRowEditStart`, `onRowEditComplete`, `onEditCancelled`.
+    - **Additional parameters**: `tableData: E`, `onRowMove`, `rowGroups`, `onRowEditStart`, `onRowEditComplete`,
+      `onEditCancelled`.
     - Columns must use `ColumnSpec<T, C, E>` with `E` matching the tableData type.
 - **Columns DSL**:
     - `tableColumns<T, C, E> { ... }` produces `List<ColumnSpec<T, C, E>>` for read-only tables.
@@ -78,7 +79,15 @@ column(PersonField.Name, valueOf = { it.name }) {
     - Row reorder mode notes: while `rowReorderEnabled = true`, sorting and grouping UI is disabled.
       Filtering stays available; fast filters and active filters header continue to work.
     - `TableDimensions`: `defaultColumnWidth`, `defaultRowHeight`, `footerHeight`, `checkBoxColumnWidth`,
-      `verticalDividerThickness`, `verticalDividerPaddingHorizontal`.
+      `verticalDividerThickness`, `verticalDividerPaddingHorizontal`, `rowGroupSpacing`.
     - `TableColors`: via `TableDefaults.colors(...)`.
+- **Row groups**: `rowGroups = TableRowGroups(ranges, onMove, header)` makes a range of adjacent rows drag as one
+  unit — see [Row reordering](../guides/row-reordering.md#dragging-a-group-of-rows).
+    - `ranges`: sorted, non-overlapping `IntRange`s over row indices; derive them with
+      `List<T>.rowGroupsOf { it.groupId }` and hold the whole `TableRowGroups` in `remember`.
+    - `onMove(from: IntRange, to: IntRange)`: required when `rowReorderEnabled` and `ranges` is non-empty. Apply the
+      move to your list with `MutableList<T>.moveRowGroup(from, to)`; never collapse `to` to a single index.
+    - `header`: optional content drawn in the band above the block, pinned to the viewport.
+    - Ignored while `groupBy` is active; `TableColors.rowGroupContainerColor` tints the band.
 
 For the full generated API, see the [API Reference](../api/).

--- a/docs/superpowers/specs/2026-07-15-row-group-drag-design.md
+++ b/docs/superpowers/specs/2026-07-15-row-group-drag-design.md
@@ -1,0 +1,364 @@
+# Dragging a Row Group as a Single Unit — Design
+
+**Date:** 2026-07-15
+**Status:** Approved
+**Topic:** Let a consumer declare that a range of adjacent rows moves as one draggable unit.
+
+## Problem
+
+Row reordering in `table-core` is single-row only:
+
+```kotlin
+onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)? = null
+```
+
+`TableBody` emits one `LazyColumn` item per row and wraps each in `ReorderableItem`, so the drag
+handle exposed through `TableCellScope.draggableHandle()` always drags exactly one row.
+
+Consumers that let users merge arbitrary rows into groups need the opposite: a list where some
+adjacent rows form a group, the drag handle sits on the group's first row, and dragging it carries
+the whole group. Whether a group exists, what it is called, and how it is created or dissolved are
+domain concerns owned by the consumer; the only thing the table lacks is the ability to move N
+adjacent rows as one unit and report the move in terms of a range.
+
+This is a UX improvement rather than a capability gap: a consumer whose backend relocates the whole
+group when the leader row is dragged already gets the right result today — the group simply jumps
+into place after the drop instead of following the cursor.
+
+## Goals
+
+- Declare that rows `[i..j]` form one drag unit; dragging any handle inside it moves the block.
+- Report moves with row ranges, not single indices.
+- Visually separate a group from surrounding rows.
+- No behavior change for consumers that do not use groups.
+- No fork of, or patch to, `sh.calvin.reorderable`.
+
+## Non-Goals
+
+- Library-side grouping model (`groupBy`) — it groups by column value and draws a header at each
+  value change, whereas these groups are arbitrary, header-less, and interleaved with ungrouped
+  rows. Group creation / renaming / dissolution stay in consumer UI.
+- Row indentation — done with cell padding by the consumer.
+- Lifting the "reorder excludes sorting and grouping" rule (`isInteractionLockByRowReorderEnabled`).
+- "Drop between neighbours" insert semantics with a gap indicator (see Rejected alternatives).
+
+## Decisions (locked)
+
+| Decision | Choice |
+|---|---|
+| Drag model | A group is **one lazy item** containing its rows |
+| Group declaration | One config object, `TableRowGroups(ranges, onMove, header)` — index ranges, derived from data |
+| Move callback | `TableRowGroups.onMove(from: IntRange, to: IntRange)`; `onRowMove` kept unchanged |
+| Callback index space | Row indices only — unit indices never leave the table |
+| Visual separation | Tinted band around the block; rows keep their own dividers; no horizontal insets |
+| Gap value | `TableDimensions.rowGroupSpacing: Dp = 8.dp`, `TableColors.rowGroupContainerColor` |
+| Group label | Consumer's `header` slot in the band; the library adds no click handling |
+| `groupBy` conflict | `groupBy != null` wins; row units fall back to identity + log warning |
+| Embedded tables | Supported, with settle-time callback semantics documented |
+| Tests | Apply `ua.wwind.convention.test` to `table-core` (its first tests) |
+
+## Rejected alternatives
+
+**Drag the leader row; let the consumer move the block.** The cheapest-looking option does not work.
+`ReorderableLazyCollectionState.onDrag()` picks a target with `shouldItemMove`, invokes `onMove`
+mid-drag, then predicts the dragged item's new offset as
+`(target.offset + target.size) - dragging.size`. That formula holds only for a two-neighbour swap; if
+the consumer moves N rows per callback, the leader jumps to a wrong offset until `layoutInfo`
+catches up. Worse, the group's other rows remain separate reorderable items whose centres fall
+inside the leader's drag rect, so the library offers them as targets — the group would reorder
+against itself. Filtering them out requires `shouldItemMove`, which is a private constructor
+parameter not exposed by `rememberReorderableLazyListState`, i.e. a fork. And the non-leader rows
+still would not follow the cursor.
+
+**A custom drag engine in `table-core`.** Full control, including insert semantics with a drop
+indicator, at the price of reimplementing ~800 lines of edge autoscroll, dynamic heights, RTL, and
+pointer handling across four platforms. Not justified by one non-blocking UX task. If insert
+semantics are ever needed, they can be built on top of this design without undoing it.
+
+## Architecture
+
+### Row units
+
+A **unit** is either a single row or a `rowGroups` range. `RowUnitIndex` translates between row
+indices (the public index space) and unit indices (the `LazyColumn` index space):
+
+```kotlin
+@Immutable
+internal class RowUnitIndex private constructor(
+    private val starts: IntArray,           // group start rows, ascending
+    private val ends: IntArray,             // group end rows, inclusive
+    private val collapsedBefore: IntArray,  // sum of (len - 1) over groups to the left
+    val unitCount: Int,
+) {
+    fun unitOf(rowIndex: Int): Int          // 3 -> 1  (row 3 inside group 2..4)
+    fun rowsOf(unitIndex: Int): IntRange    // 1 -> 2..4
+    fun isGroup(unitIndex: Int): Boolean
+}
+```
+
+Memory is `O(number of groups)`, not `O(rows)` — a 100k-row table pays nothing for having two
+groups. Lookups are binary searches over `starts` (row -> unit) and over the derived unit-space
+starts (unit -> rows).
+
+With `rowGroups` null or empty the index is **identity**: `unitCount == itemsCount`,
+`unitOf(i) == i`, `rowsOf(i) == i..i`, arrays empty, no binary search. Existing consumers execute
+the same code path as before — the absence of regressions is structural, not a promise.
+
+The index lives in `TableState` as `state.rowUnits`, assigned from `Table.kt` during composition the
+same way `visibleColumns` is. This matters practically: `ViewportUtils` and `KeyboardNavigation`
+already receive `state`, so the mapping reaches them without signature churn.
+
+It is snapshot state, unlike the `visibleColumns` field it sits beside: the prefetcher reads the
+index inside a `snapshotFlow`, which re-evaluates only when a *tracked* read changes. A plain field
+would be untracked there and would ride on the `layoutInfo` read next to it — right only while
+something else keeps scrolling.
+
+`rowGroups` validation (ascending, non-overlapping, within `itemsCount`) is a `require` in the index
+builder, matching `IndexedListAdapter` in `TableBody.kt`. The index is built under
+`remember(itemsCount, rowGroups)`, so validation runs once per change, not per frame.
+
+### Public API
+
+```kotlin
+// Table / EditableTable — ONE parameter for the whole feature
+rowGroups: TableRowGroups? = null,
+
+@Stable
+public class TableRowGroups(
+    public val ranges: ImmutableList<IntRange>,
+    public val onMove: ((from: IntRange, to: IntRange) -> Unit)? = null,
+    public val header: (@Composable (rows: IntRange) -> Unit)? = null,
+)
+
+// TableDimensions / TableColors
+val rowGroupSpacing: Dp = 8.dp
+val rowGroupContainerColor: Color
+
+// RowGroups.kt
+public fun <T> List<T>.rowGroupsOf(groupIdOf: (T) -> Any?): ImmutableList<IntRange>
+public fun <T> MutableList<T>.moveRowGroup(from: IntRange, to: IntRange)
+```
+
+One config object rather than three parameters: `Table` already carries
+`@Suppress("LongParameterList")`, and the codebase already has this vocabulary — `TableSettings`,
+`TableColors`, `TableDimensions`, `TableCustomization`. `TableRowGroups` joins that row.
+
+`@Stable`, not `@Immutable`. `@Immutable` buys only static-expression promotion, which can never fire
+here because `ranges` is derived from rendered data inside a `remember`; and it would overclaim, since
+a class holding a `@Composable` slot is not a fixed value and its equality is by identity. The repo
+draws the same line already: `TableColors` / `TableSettings` are data-class values (`@Immutable`),
+`TableCustomization` carries composables (`@Stable`).
+
+Identity equality has a consequence worth stating: **hold the instance in `remember`**. A fresh
+`TableRowGroups` each recomposition stops `Table` from skipping. This is stricter than `TableSettings`,
+whose structural equality forgives a fresh instance.
+
+`onRowMove` is untouched; existing code compiles and behaves as before. The contract is explicit:
+when row reorder is enabled, `require(rowGroups?.onMove != null || rowGroups?.ranges.isNullOrEmpty())`
+— passing groups without a move callback fails loudly instead of silently breaking the drag. With
+reorder disabled, `rowGroups` is still honoured for its visual effect and no callback is required.
+
+Ranges rather than leader indices: the table already knows the block extent it just moved, so
+returning `IntRange` costs nothing and keeps the callback self-contained. `from.first` is the leader
+index for consumers that only need it. Returning `T` values instead of indices is not an option —
+`itemAt` may return `null` for not-yet-loaded rows.
+
+**Do not collapse `to` to a single index.** A downward move inserts the block after `to.last`; passing
+only the target's leader row drops the block *inside* the target group and splits it. Upward moves
+insert at `to.first`, where the leader happens to be correct — so the mistake looks direction-specific
+and survives casual testing. This is not hypothetical: the first version of the sample made exactly
+this error.
+
+There is deliberately no `onClick` for groups. A consumer that wants interaction puts its own
+`Modifier.clickable` inside `header`, which avoids defining how a library-level group click would
+compose with row clicks and drags.
+
+Consumer usage:
+
+```kotlin
+val rows: List<PlanRow> = uiState.rows
+
+Table(
+    itemsCount = rows.size,
+    itemAt = { rows.getOrNull(it) },
+    rowGroups = remember(rows) {
+        TableRowGroups(
+            ranges = rows.rowGroupsOf { it.groupId },   // [2..4, 7..8]
+            onMove = { from, to -> vm.moveBlock(from, to) },
+            header = { range -> GroupHeader(rows[range.first].groupId) },
+        )
+    },
+)
+```
+
+Grouping, renaming and dissolving a group never touch ranges: those operations change a row's
+`groupId` in the consumer's own data, a new list arrives, and `rowGroupsOf` recomputes. Ranges are
+derived state, not state to maintain.
+
+### Rendering
+
+```kotlin
+val rowUnits = state.rowUnits
+
+items(
+    count = rowUnits.unitCount,
+    key = { unit -> val lead = rowUnits.rowsOf(unit).first; rowKey(itemAt(lead), lead) },
+) { unit ->
+    val rows = rowUnits.rowsOf(unit)
+    ReorderableItem(state = reorderState, key = /* same key */) {
+        val rowScope = remember(this) { TableItemDragScope(this) }
+        context(rowScope) { RowUnit(rows, isGroup = rowUnits.isGroup(unit), ...) }
+    }
+}
+```
+
+The unit key is the **leader row's** `rowKey`. The block moves as a whole, so the leader stays the
+leader and the key is stable across a drag — reorderable never loses the dragged item.
+
+A group unit:
+
+```kotlin
+Column(
+    modifier = Modifier
+        .width(state.tableWidth)
+        .background(colors.rowGroupContainerColor)
+        .padding(
+            top = if (rowGroupHeader != null) 0.dp else dimensions.rowGroupSpacing,
+            bottom = if (nextIsGroup) 0.dp else dimensions.rowGroupSpacing,
+        ),
+) {
+    rows.forEach { TableBodyRow(index = it, ...) }
+}
+```
+
+Three details here were each settled by looking at the real thing on screen rather than at a mockup:
+
+**Every row keeps its own divider, including the group's last one.** A divider means "this row ended";
+suppressing it inside a group leaves the last row visually open. The block therefore draws no divider
+of its own, and the rule stays uniform: rows draw dividers, blocks draw margin.
+
+**The tint is what makes the group legible, and it can only live in the margin.** Each row paints its
+own opaque `Surface`, so a background *behind* the rows is invisible. Painting it on the `Column` that
+also carries the padding means the rows cover the middle while the gap bands show the tint — that band
+is the group's boundary. A bare gap with no tint disappears on a dark theme.
+
+**A block always opens with a top band and closes with a bottom gap only when the next unit is not a
+group.** Symmetric padding stacks between adjacent blocks — 8dp + 8dp of tinted band merged into one
+slab, erasing the boundary it exists to draw. The band that opens a block is the header when one is
+configured, so it is the *bottom* gap that gives way: suppressing the top instead would leave the
+second of two adjacent blocks nameless. `nextIsGroup` comes from `rowUnits.isGroup(unit + 1)`, so
+exactly one band separates any two units and a block at either end of the list keeps its outer band.
+
+A single-row unit takes the existing branch unchanged. The wrapper is pure vertical composition and
+adds **no horizontal insets** — this is load-bearing, not cosmetic: horizontal padding would shift
+group rows relative to the header. Column widths (`state.resolveColumnWidth`) and column order
+(`state.columnOrder`) live in `TableState` and are read per row per render, so column resizing and
+column reordering are unaffected. `ApplyAutoWidthEffect` only reads
+`visibleItemsInfo.isNotEmpty()` — no index arithmetic — so units are invisible to auto-width.
+
+A group of one row stays a group: gap and drag still apply.
+
+Callback translation:
+
+```kotlin
+rememberReorderableLazyListState(verticalState) { from, to ->
+    val fromRows = rowUnits.rowsOf(from.index)   // from.index is a unit index
+    val toRows = rowUnits.rowsOf(to.index)
+    onRowsMove?.invoke(fromRows, toRows) ?: onRowMove?.invoke(fromRows.first, toRows.first)
+}
+```
+
+**Constraint:** `rowGroups` must be derived from the same data snapshot as `itemAt`. In a
+`LazyColumn`, reorderable invokes `onMove` *during* the drag and waits for `layoutInfo` to change,
+so the consumer mutates its list synchronously and `rowGroups` must recompute in the same
+recomposition. Groups lagging the data by even one frame desynchronise unit boundaries from rows and
+break the drag. `remember(rows) { rows.rowGroupsOf { it.groupId } }` is the supported pattern;
+hand-maintained range state is not.
+
+### Embedded path
+
+`TableBodyEmbedded` renders every row eagerly through `ReorderableColumn`, which takes the backing
+list and reports `onSettle(fromIndex, toIndex)` **on drop**, not during the drag. The same
+`RowUnitIndex` applies: `IndexedListAdapter` is built over units instead of rows, each unit renders
+its rows in a `Column`, and `onSettle`'s unit indices translate through `rowsOf(...)` exactly as in
+the lazy path. `rowGroups` therefore means the same thing in both modes.
+
+The live-vs-settle difference is reorderable's, not ours, and it already applies to `onRowMove`
+today: in a `LazyColumn` the callback fires repeatedly mid-drag and the consumer must mutate
+synchronously; in an embedded table it fires once, after the drop. The design documents this
+asymmetry rather than hiding it, because for `TableRowGroups.onMove` it decides whether the consumer
+needs an optimistic in-drag move at all.
+
+### Index mapping
+
+Three places currently assume lazy-item index == row index. Each is fixed with one `state.rowUnits`
+call:
+
+- `ViewportUtils.ensureRowFullyVisible` — `visibleItemsInfo.firstOrNull { it.index == index }` and
+  `animateScrollToItem(index)` take `unitOf(index)`. Height estimates come from per-row
+  `rowHeightsPx` and under-count a group's gaps; the function already corrects the scroll from
+  actual `info.offset` afterwards, so this is a deliberate approximation, not a defect.
+- `KeyboardNavigation` PageUp/PageDown — `fullyVisible` counts visible lazy items (units) but is
+  added to a row index. Correct target: `rowsOf(unitOf(currentRow) ± fullyVisible).first`, clamped.
+- `TableViewportPrefetcher` — `lastVisible + 1` is the next *unit*; use
+  `rowsOf(lastVisibleUnit).last + 1`.
+
+`TableActiveFilters` needs no change: its `LazyRow` scrolls filter chips and clamps to
+`activeFilters.size`, an index space of its own that never touched rows.
+
+`rowGroups` and `state.groupBy` describe two different structures over one list. While reorder is
+on, the grouping menu is locked; with reorder off a user could group by column on top of
+`rowGroups`. Throwing from a menu click handler is unacceptable, so `groupBy != null` wins: row
+units fall back to identity, the gap disappears, rows render normally, and a warning is logged.
+
+## Testing and verification
+
+`table-core` has no tests today. Applying the existing `ua.wwind.convention.test` plugin is one line
+in `table-core/build.gradle.kts` and adds no new catalog entries.
+
+`commonTest` covers where the off-by-ones live:
+
+- `RowUnitIndexTest` — identity without groups; group at start / end / adjacent groups; single-row
+  group; round-trip `rowsOf(unitOf(row)).contains(row)` for every row; `require` failures on
+  overlap, wrong order, out-of-bounds.
+- `RowGroupsTest` — `rowGroupsOf` collapses only *adjacent* runs of an equal non-null `groupId`
+  (two disjoint runs of the same id yield two ranges — documented behavior, not a bug); `null` never
+  groups.
+- `MoveRowGroupTest` — block up, block down, to either edge, no-op, swapping two groups.
+
+Unit tests only prove the arithmetic. The feature is done when the real surface is driven: a
+`table-sample` demo with two groups among plain rows, run on the desktop target, dragging a group by
+its leader handle and observing that the block follows the cursor rather than jumping, lands between
+neighbours intact, shows the gap — and that a table *without* `rowGroups` behaves exactly as before.
+The same demo is driven a second time with `embedded = true` to exercise the settle-time path. The
+demo doubles as the API showcase for the docs.
+
+## Rollout
+
+- Minor version bump; `CHANGELOG.md` entry.
+- `docs/content/guides/row-reordering.md` gains a group section: `TableRowGroups` and its three
+  members, the `remember` requirement, the derived-state constraint, the "don't collapse `to`"
+  warning, the live-vs-settle callback difference, and the `groupBy` conflict rule.
+- KDoc on the new public API (Dokka publishes it).
+
+## Known limitations
+
+- Keyboard navigation to a row inside a group scrolls to the block, not the row.
+- A group's rows are not individually lazy: a very large group composes as one item.
+- No drop indicator between neighbours; drops remain swap-based (see Rejected alternatives).
+- **The embedded-table group path is verified by compilation only.** `TableBodyEmbedded` routes groups
+  through `ReorderableColumn`'s settle-time `onSettle`, and the index translation is the same
+  `RowUnitIndex` the scrolling path uses — but no test covers it and nobody has driven it on screen.
+  The scrolling path was verified by hand and produced four rendering defects that no test caught, so
+  this is a real gap, not a formality. It is also the less defended of the two paths:
+  `ReorderableColumn` captures `onSettle` once and keys its state on the list by structural equality,
+  where `rememberReorderableLazyListState` wraps the callback in `rememberUpdatedState`. Anything the
+  callback reads must therefore be routed through state rather than captured — review found exactly
+  this defect here, since a list of group leaders can compare equal across a change to `RowUnitIndex`.
+- `TableColors.rowGroupContainerColor` has no default value, so constructing `TableColors` directly is
+  source-breaking. Nothing in this repo does — only `TableDefaults.colors()` builds it, with named
+  arguments — but external code need not be so lucky, which is what the CHANGELOG note is for. The
+  factory takes the new colour as a *trailing* optional parameter: every parameter it has is a
+  `Color`, so inserting one in the middle would leave positional calls compiling while silently
+  rebinding the colours after it. `TableDimensions.rowGroupSpacing` defaults and is therefore
+  compatible.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 # --- Project metadata ---
-version-name = "1.10.0"
-version-date = "24.06.2026"
-android-version-code = "42"
+version-name = "1.11.0"
+version-date = "15.07.2026"
+android-version-code = "43"
 
 # --- Android SDK & AGP ---
 android-compileSdk = "37"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # --- Project metadata ---
 version-name = "1.11.0"
-version-date = "15.07.2026"
+version-date = "16.07.2026"
 android-version-code = "43"
 
 # --- Android SDK & AGP ---

--- a/table-core/build.gradle.kts
+++ b/table-core/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("ua.wwind.convention.compose")
     id("ua.wwind.convention.publishing")
     id("ua.wwind.convention.logging")
+    id("ua.wwind.convention.test")
 }
 
 kotlin {

--- a/table-core/build.gradle.kts
+++ b/table-core/build.gradle.kts
@@ -13,5 +13,11 @@ kotlin {
             implementation(libs.reorderable)
             implementation(libs.kotlinx.datetime)
         }
+        commonTest.dependencies {
+            implementation(libs.compose.ui.test)
+        }
+        jvmTest.dependencies {
+            implementation(compose.desktop.currentOs)
+        }
     }
 }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/RowGroups.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/RowGroups.kt
@@ -1,0 +1,58 @@
+package ua.wwind.table
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+/**
+ * Derives drag-unit ranges from a flat row list: every run of **adjacent** rows sharing the same
+ * non-null group id becomes one [IntRange]. Rows whose id is `null` are never grouped.
+ *
+ * Two disjoint runs of the same id produce two ranges — a group is defined by adjacency, because a
+ * drag unit must be contiguous on screen.
+ *
+ * The result must be recomputed from the same data snapshot the table renders, e.g.
+ * `remember(rows) { rows.rowGroupsOf { it.groupId } }`. Group ranges are derived state, not state to
+ * maintain by hand.
+ */
+public fun <T> List<T>.rowGroupsOf(groupIdOf: (T) -> Any?): ImmutableList<IntRange> {
+    val groups = mutableListOf<IntRange>()
+    var runStart = -1
+    var runId: Any? = null
+    for (index in indices) {
+        val id = groupIdOf(this[index])
+        if (id != null && id == runId) continue
+        if (runStart >= 0) groups += runStart..index - 1
+        if (id != null) {
+            runStart = index
+            runId = id
+        } else {
+            runStart = -1
+            runId = null
+        }
+    }
+    if (runStart >= 0) groups += runStart..lastIndex
+    return groups.toImmutableList()
+}
+
+/**
+ * Moves the rows in [from] so that they swap with [to], matching the semantics of the table's
+ * [TableRowGroups.onMove] callback: moving down lands the block after [to], moving up lands it
+ * before [to].
+ *
+ * Both ranges are interpreted against the list's current contents.
+ */
+public fun <T> MutableList<T>.moveRowGroup(
+    from: IntRange,
+    to: IntRange,
+) {
+    require(!from.isEmpty() && !to.isEmpty()) { "moveRowGroup ranges must not be empty" }
+    require(from.first >= 0 && from.last < size) { "from range $from is out of bounds for size $size" }
+    require(to.first >= 0 && to.last < size) { "to range $to is out of bounds for size $size" }
+    if (from.first == to.first) return
+
+    val blockSize = from.last - from.first + 1
+    val block = ArrayList<T>(blockSize)
+    repeat(blockSize) { block += removeAt(from.first) }
+    val insertAt = if (to.first > from.first) to.last - blockSize + 1 else to.first
+    addAll(insertAt.coerceIn(0, size), block)
+}

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/Table.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/Table.kt
@@ -53,6 +53,7 @@ import ua.wwind.table.config.TableColors
 import ua.wwind.table.config.TableCustomization
 import ua.wwind.table.config.TableDefaults
 import ua.wwind.table.config.isInteractionLockByRowReorderEnabled
+import ua.wwind.table.config.isRowReorderEnabled
 import ua.wwind.table.interaction.ApplyAutoWidthEffect
 import ua.wwind.table.interaction.ApplyAutoWidthEmbeddedEffect
 import ua.wwind.table.interaction.ContextMenuState
@@ -62,8 +63,10 @@ import ua.wwind.table.interaction.tableKeyboardNavigation
 import ua.wwind.table.platform.getPlatform
 import ua.wwind.table.platform.isMobile
 import ua.wwind.table.state.LocalTableState
+import ua.wwind.table.state.RowUnitIndex
 import ua.wwind.table.state.SortState
 import ua.wwind.table.state.TableState
+import ua.wwind.table.state.buildRowUnitIndex
 import ua.wwind.table.state.mapNotNullToImmutable
 import ua.wwind.table.strings.DefaultStrings
 import ua.wwind.table.strings.LocalStringProvider
@@ -120,6 +123,11 @@ public fun <T : Any, C, E> EditableTable(
     onRowClick: ((T) -> Unit)? = null,
     onRowLongClick: ((T) -> Unit)? = null,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)? = null,
+    /**
+     * Row grouping: the ranges of adjacent rows that drag as one unit, the move callback and an
+     * optional per-block header. Hold it in `remember` — see [TableRowGroups].
+     */
+    rowGroups: TableRowGroups? = null,
     contextMenu: (@Composable (item: T, pos: Offset, dismiss: () -> Unit) -> Unit)? = null,
     customization: TableCustomization<T, C> = DefaultTableCustomization(),
     colors: TableColors = TableDefaults.colors(),
@@ -151,6 +159,24 @@ public fun <T : Any, C, E> EditableTable(
     }
 
     state.visibleColumns = visibleColumns
+
+    require(
+        rowGroups?.onMove != null ||
+            rowGroups?.ranges.isNullOrEmpty() ||
+            !state.settings.isRowReorderEnabled,
+    ) {
+        "TableRowGroups.ranges requires TableRowGroups.onMove when row reorder is enabled"
+    }
+
+    // Library grouping and row groups describe two different structures over one list.
+    // groupBy wins: fall back to identity instead of throwing from a menu click.
+    val groupByActive = state.groupBy != null && !rowGroups?.ranges.isNullOrEmpty()
+    val effectiveGroups: ImmutableList<IntRange>? = if (groupByActive) null else rowGroups?.ranges
+    LaunchedEffect(groupByActive) {
+        if (groupByActive) Logger.w { "rowGroups ignored while groupBy is active" }
+    }
+    val rowUnits = remember(itemsCount, effectiveGroups) { buildRowUnitIndex(itemsCount, effectiveGroups) }
+    state.rowUnits = rowUnits
 
     var contextMenuState by remember { mutableStateOf(ContextMenuState<T>()) }
     val tableFocusRequester = remember { FocusRequester() }
@@ -267,7 +293,10 @@ public fun <T : Any, C, E> EditableTable(
                             onRowClick = onRowClick,
                             onRowLongClick = onRowLongClick,
                             onRowMove = onRowMove,
+                            onRowsMove = rowGroups?.onMove,
+                            rowGroupHeader = rowGroups?.header,
                             onContextMenu = onContextMenuHandler,
+                            rowUnits = rowUnits,
                             verticalState = verticalState,
                             horizontalState = horizontalState,
                             requestTableFocus = { tableFocusRequester.requestFocus() },
@@ -363,6 +392,11 @@ public fun <T : Any, C> Table(
     onRowClick: ((T) -> Unit)? = null,
     onRowLongClick: ((T) -> Unit)? = null,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)? = null,
+    /**
+     * Row grouping: the ranges of adjacent rows that drag as one unit, the move callback and an
+     * optional per-block header. Hold it in `remember` — see [TableRowGroups].
+     */
+    rowGroups: TableRowGroups? = null,
     contextMenu: (@Composable (item: T, pos: Offset, dismiss: () -> Unit) -> Unit)? = null,
     customization: TableCustomization<T, C> = DefaultTableCustomization(),
     colors: TableColors = TableDefaults.colors(),
@@ -387,6 +421,7 @@ public fun <T : Any, C> Table(
         onRowClick = onRowClick,
         onRowLongClick = onRowLongClick,
         onRowMove = onRowMove,
+        rowGroups = rowGroups,
         contextMenu = contextMenu,
         customization = customization,
         colors = colors,
@@ -457,6 +492,11 @@ public fun <T : Any, C, E> Table(
     onRowClick: ((T) -> Unit)? = null,
     onRowLongClick: ((T) -> Unit)? = null,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)? = null,
+    /**
+     * Row grouping: the ranges of adjacent rows that drag as one unit, the move callback and an
+     * optional per-block header. Hold it in `remember` — see [TableRowGroups].
+     */
+    rowGroups: TableRowGroups? = null,
     contextMenu: (@Composable (item: T, pos: Offset, dismiss: () -> Unit) -> Unit)? = null,
     customization: TableCustomization<T, C> = DefaultTableCustomization(),
     colors: TableColors = TableDefaults.colors(),
@@ -481,6 +521,7 @@ public fun <T : Any, C, E> Table(
         onRowClick = onRowClick,
         onRowLongClick = onRowLongClick,
         onRowMove = onRowMove,
+        rowGroups = rowGroups,
         contextMenu = contextMenu,
         customization = customization,
         colors = colors,
@@ -605,7 +646,10 @@ private fun <T : Any, C, E> TableBodySection(
     onRowClick: ((T) -> Unit)?,
     onRowLongClick: ((T) -> Unit)?,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)?,
+    onRowsMove: ((from: IntRange, to: IntRange) -> Unit)?,
+    rowGroupHeader: (@Composable (rows: IntRange) -> Unit)?,
     onContextMenu: ((item: T, pos: Offset) -> Unit)?,
+    rowUnits: RowUnitIndex,
     verticalState: LazyListState,
     horizontalState: ScrollState,
     requestTableFocus: () -> Unit,
@@ -630,7 +674,10 @@ private fun <T : Any, C, E> TableBodySection(
                 onRowClick = onRowClick,
                 onRowLongClick = onRowLongClick,
                 onRowMove = onRowMove,
+                onRowsMove = onRowsMove,
+                rowGroupHeader = rowGroupHeader,
                 onContextMenu = onContextMenu,
+                rowUnits = rowUnits,
                 horizontalState = horizontalState,
                 requestTableFocus = requestTableFocus,
             )
@@ -648,7 +695,10 @@ private fun <T : Any, C, E> TableBodySection(
                 onRowClick = onRowClick,
                 onRowLongClick = onRowLongClick,
                 onRowMove = onRowMove,
+                onRowsMove = onRowsMove,
+                rowGroupHeader = rowGroupHeader,
                 onContextMenu = onContextMenu,
+                rowUnits = rowUnits,
                 rowEmbedded = rowEmbedded,
                 verticalState = verticalState,
                 horizontalState = horizontalState,

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/TableRowGroups.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/TableRowGroups.kt
@@ -1,0 +1,44 @@
+package ua.wwind.table
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import kotlinx.collections.immutable.ImmutableList
+
+/**
+ * Row grouping for the table: which runs of adjacent rows drag as one unit, what happens when one is
+ * moved, and what is drawn in the band above each block.
+ *
+ * Hold the instance in `remember`, e.g.
+ * `remember(rows) { TableRowGroups(rows.rowGroupsOf { it.groupId }) }`. This type compares by
+ * identity — carrying a `@Composable` slot, it has no meaningful structural equality — so a fresh
+ * instance on each recomposition makes the `rowGroups` argument look changed and stops `Table` from
+ * skipping. Keying the `remember` on the rendered data also keeps [ranges] in step with it.
+ */
+@Stable
+public class TableRowGroups(
+    /**
+     * Ranges of adjacent rows that drag as one unit. Must be sorted, non-empty, non-overlapping and
+     * within the table's `itemsCount`. Derive them from the same data the table renders — see
+     * [rowGroupsOf].
+     */
+    public val ranges: ImmutableList<IntRange>,
+    /**
+     * Called when a unit is moved, with row ranges rather than single indices; `from.first` is the
+     * leader row. Required when [ranges] is non-empty and row reorder is enabled.
+     *
+     * In a scrolling table this fires **during** the drag and the consumer must apply the move to its
+     * list synchronously (see [moveRowGroup]); in an `embedded` table it fires once on drop.
+     *
+     * Do NOT collapse `to` to a single index: for a downward move the block is inserted after
+     * `to.last`, so passing only the target's leader row would drop the block inside the target
+     * group and split it.
+     */
+    public val onMove: ((from: IntRange, to: IntRange) -> Unit)? = null,
+    /**
+     * Optional content rendered in the band above each group block, pinned horizontally to the
+     * viewport so it stays visible while the table scrolls sideways. Use it for a group name, a
+     * rename affordance, a count — attach your own `Modifier.clickable` inside it; the library adds
+     * no click handling of its own.
+     */
+    public val header: (@Composable (rows: IntRange) -> Unit)? = null,
+)

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/RowUnit.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/RowUnit.kt
@@ -1,0 +1,154 @@
+package ua.wwind.table.component.body
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import ua.wwind.table.ColumnSpec
+import ua.wwind.table.TableItemScope
+import ua.wwind.table.config.TableColors
+import ua.wwind.table.config.TableCustomization
+import ua.wwind.table.state.TableState
+
+/**
+ * Renders one drag unit: either a single row (identical to the pre-groups layout) or a group block —
+ * its rows stacked and divided exactly like standalone rows, over a
+ * [TableColors.rowGroupContainerColor] background that also spans the vertical gap around them, so
+ * the block reads as one card.
+ *
+ * Every row keeps its own divider, the last one included, and the block adds none: each rule sits
+ * directly under the row it closes, inside the padded content, so the divider rhythm is the same
+ * inside a block as anywhere else in the table. The tinted band is therefore pure margin around the
+ * block, never crossed or trailed by a rule.
+ *
+ * A block **always opens with a top band**: the [rowGroupHeader] when there is one, otherwise a
+ * `rowGroupSpacing` gap. It **closes with a bottom gap only when [nextIsGroup] is false** — a
+ * following block opens with a band of its own, so drawing this one's bottom gap too would stack two
+ * tinted regions between them and merge the pair into a single fat slab, erasing the very boundary
+ * the band exists to draw. Suppressing the *bottom* gap rather than the next block's top band is
+ * what keeps that band a header when one is configured: suppressing the top instead would leave the
+ * second of two adjacent blocks nameless.
+ *
+ * The rule leaves exactly one band between any two units, and still gives a block at either end of
+ * the list its own outer band.
+ *
+ * The header wraps its own content rather than being pinned to `rowGroupSpacing`, but is floored at
+ * it: [nextIsGroup] drops a block's bottom gap on the promise that the next block opens with a band,
+ * and a header free to measure zero could quietly break that promise — a slot that renders nothing
+ * while its leader is still loading would butt two blocks together with no boundary at all. The
+ * floor makes a header that draws nothing collapse to exactly the gap it replaced. The header is
+ * also offset by the horizontal scroll so it stays in the viewport while the table scrolls sideways
+ * — the same technique the `groupBy` header cell uses.
+ *
+ * The wrapper adds **no horizontal insets**: any horizontal padding here would shift group rows
+ * relative to the header and break column alignment.
+ */
+@Composable
+@Suppress("LongParameterList")
+context(_: TableItemScope)
+internal fun <T : Any, C, E> RowUnit(
+    rows: IntRange,
+    isGroup: Boolean,
+    /** True when the following unit is a group, which opens with a band of its own. */
+    nextIsGroup: Boolean,
+    /** Optional content for the band above a group block; replaces the block's top gap. */
+    rowGroupHeader: (@Composable (rows: IntRange) -> Unit)?,
+    itemAt: (Int) -> T?,
+    visibleColumns: ImmutableList<ColumnSpec<T, C, E>>,
+    state: TableState<C>,
+    colors: TableColors,
+    customization: TableCustomization<T, C>,
+    tableData: E,
+    rowEmbedded: (@Composable (rowIndex: Int, item: T) -> Unit)?,
+    placeholderRow: (@Composable () -> Unit)?,
+    onRowClick: ((T) -> Unit)?,
+    onRowLongClick: ((T) -> Unit)?,
+    onContextMenu: ((T, Offset) -> Unit)?,
+    horizontalState: ScrollState,
+    requestTableFocus: () -> Unit,
+) {
+    if (!isGroup) {
+        TableBodyRow(
+            index = rows.first,
+            itemAt = itemAt,
+            visibleColumns = visibleColumns,
+            state = state,
+            colors = colors,
+            customization = customization,
+            tableData = tableData,
+            rowEmbedded = rowEmbedded,
+            placeholderRow = placeholderRow,
+            onRowClick = onRowClick,
+            onRowLongClick = onRowLongClick,
+            onContextMenu = onContextMenu,
+            horizontalState = horizontalState,
+            requestTableFocus = requestTableFocus,
+        )
+        return
+    }
+
+    Column(
+        modifier =
+            Modifier
+                .width(state.tableWidth)
+                .background(colors.rowGroupContainerColor)
+                .padding(
+                    top =
+                        if (rowGroupHeader != null) {
+                            0.dp
+                        } else {
+                            state.dimensions.rowGroupSpacing
+                        },
+                    bottom =
+                        if (nextIsGroup) {
+                            0.dp
+                        } else {
+                            state.dimensions.rowGroupSpacing
+                        },
+                ),
+    ) {
+        if (rowGroupHeader != null) {
+            val viewportWidth = with(LocalDensity.current) { horizontalState.viewportSize.toDp() }
+            Box(
+                modifier =
+                    Modifier
+                        .heightIn(min = state.dimensions.rowGroupSpacing)
+                        .graphicsLayer {
+                            translationX = horizontalState.value.toFloat()
+                        },
+            ) {
+                Box(modifier = Modifier.width(viewportWidth)) {
+                    rowGroupHeader(rows)
+                }
+            }
+        }
+        rows.forEach { row ->
+            TableBodyRow(
+                index = row,
+                itemAt = itemAt,
+                visibleColumns = visibleColumns,
+                state = state,
+                colors = colors,
+                customization = customization,
+                tableData = tableData,
+                rowEmbedded = rowEmbedded,
+                placeholderRow = placeholderRow,
+                onRowClick = onRowClick,
+                onRowLongClick = onRowLongClick,
+                onContextMenu = onContextMenu,
+                horizontalState = horizontalState,
+                requestTableFocus = requestTableFocus,
+            )
+        }
+    }
+}

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableBody.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableBody.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
@@ -27,6 +28,7 @@ import ua.wwind.table.component.footer.TableFooter
 import ua.wwind.table.config.TableColors
 import ua.wwind.table.config.TableCustomization
 import ua.wwind.table.config.isRowReorderEnabled
+import ua.wwind.table.state.RowUnitIndex
 import ua.wwind.table.state.TableState
 
 @Composable
@@ -45,7 +47,10 @@ internal fun <T : Any, C, E> TableBody(
     onRowClick: ((T) -> Unit)?,
     onRowLongClick: ((T) -> Unit)?,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)?,
+    onRowsMove: ((from: IntRange, to: IntRange) -> Unit)?,
+    rowGroupHeader: (@Composable (rows: IntRange) -> Unit)?,
     onContextMenu: ((T, Offset) -> Unit)?,
+    rowUnits: RowUnitIndex,
     verticalState: LazyListState,
     horizontalState: ScrollState,
     requestTableFocus: () -> Unit,
@@ -53,11 +58,17 @@ internal fun <T : Any, C, E> TableBody(
     modifier: Modifier = Modifier,
 ) {
     val showFooter = state.settings.showFooter && !state.settings.footerPinned
-    val rowReorderEnabled = state.settings.isRowReorderEnabled && onRowMove != null
+    val rowReorderEnabled = state.settings.isRowReorderEnabled && (onRowsMove != null || onRowMove != null)
     val reorderState =
         if (rowReorderEnabled) {
             rememberReorderableLazyListState(verticalState) { from, to ->
-                onRowMove.invoke(from.index, to.index)
+                val fromRows = rowUnits.rowsOf(from.index)
+                val toRows = rowUnits.rowsOf(to.index)
+                if (onRowsMove != null) {
+                    onRowsMove.invoke(fromRows, toRows)
+                } else {
+                    onRowMove?.invoke(fromRows.first, toRows.first)
+                }
             }
         } else {
             null
@@ -68,8 +79,19 @@ internal fun <T : Any, C, E> TableBody(
         state = verticalState,
         userScrollEnabled = enableScrolling,
     ) {
-        items(count = itemsCount, key = { index -> rowKey(itemAt(index), index) }) { index ->
-            val key = rowKey(itemAt(index), index)
+        items(
+            count = rowUnits.unitCount,
+            key = { unit ->
+                val leader = rowUnits.rowsOf(unit).first
+                rowKey(itemAt(leader), leader)
+            },
+        ) { unit ->
+            val rows = rowUnits.rowsOf(unit)
+            val isGroup = rowUnits.isGroup(unit)
+            // Units only; the footer is a separate lazy item and never a group, so the bound keeps
+            // the lookup in range and a trailing block still draws its closing gap above the footer.
+            val nextIsGroup = unit < rowUnits.unitCount - 1 && rowUnits.isGroup(unit + 1)
+            val key = rowKey(itemAt(rows.first), rows.first)
             val currentReorderState = reorderState
             if (currentReorderState != null) {
                 ReorderableItem(state = currentReorderState, key = key) {
@@ -78,8 +100,11 @@ internal fun <T : Any, C, E> TableBody(
                             TableItemDragScope(this)
                         }
                     context(rowScope) {
-                        TableBodyRow(
-                            index = index,
+                        RowUnit(
+                            rows = rows,
+                            isGroup = isGroup,
+                            nextIsGroup = nextIsGroup,
+                            rowGroupHeader = rowGroupHeader,
                             itemAt = itemAt,
                             visibleColumns = visibleColumns,
                             state = state,
@@ -98,8 +123,11 @@ internal fun <T : Any, C, E> TableBody(
                 }
             } else {
                 context(DefaultTableItemScope) {
-                    TableBodyRow(
-                        index = index,
+                    RowUnit(
+                        rows = rows,
+                        isGroup = isGroup,
+                        nextIsGroup = nextIsGroup,
+                        rowGroupHeader = rowGroupHeader,
                         itemAt = itemAt,
                         visibleColumns = visibleColumns,
                         state = state,
@@ -176,33 +204,65 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
     onRowClick: ((T) -> Unit)?,
     onRowLongClick: ((T) -> Unit)?,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)?,
+    onRowsMove: ((from: IntRange, to: IntRange) -> Unit)?,
+    rowGroupHeader: (@Composable (rows: IntRange) -> Unit)?,
     onContextMenu: ((T, Offset) -> Unit)?,
+    rowUnits: RowUnitIndex,
     horizontalState: ScrollState,
     requestTableFocus: () -> Unit,
 ) {
     if (itemsCount <= 0 && !state.settings.showFooter) return
 
-    val rowMoveCallback = onRowMove
-    val rowReorderEnabled = state.settings.isRowReorderEnabled && rowMoveCallback != null
-    val itemList = remember(itemsCount, itemAt) { IndexedListAdapter(itemsCount, itemAt) }
+    val rowReorderEnabled =
+        state.settings.isRowReorderEnabled && (onRowsMove != null || onRowMove != null)
+
+    // One element per drag unit, holding that unit's leading item. `ReorderableColumn` keys its
+    // internal drag state on this list *by equality*, and only rebuilds it — clearing the drag
+    // offsets left over from a drop — when the contents change. Elements must therefore track the
+    // items, not the unit indices: `0..unitCount-1` never changes and would strand those offsets.
+    val unitList =
+        remember(rowUnits, itemAt) {
+            IndexedListAdapter(rowUnits.unitCount) { unit -> itemAt(rowUnits.rowsOf(unit).first) }
+        }
+
+    // `ReorderableColumn` captures `onSettle` once, when it builds that state, and never refreshes it
+    // — unlike the lazy path, whose `rememberReorderableLazyListState` wraps the callback in
+    // `rememberUpdatedState`. Leaders do not distinguish every layout this callback reads: inserting a
+    // row *into* a group changes `rowUnits` while leaving the leaders — and so the list — equal, so a
+    // captured callback would keep translating units against a stale index and report rows that no
+    // longer match the data. Route through the state, so the callback that runs is the current one.
+    val settleUnits: (Int, Int) -> Unit = { fromUnit, toUnit ->
+        val fromRows = rowUnits.rowsOf(fromUnit)
+        val toRows = rowUnits.rowsOf(toUnit)
+        if (onRowsMove != null) {
+            onRowsMove.invoke(fromRows, toRows)
+        } else {
+            onRowMove?.invoke(fromRows.first, toRows.first)
+        }
+    }
+    val currentSettleUnits = rememberUpdatedState(settleUnits)
 
     Column {
         if (rowReorderEnabled) {
             ReorderableColumn(
-                list = itemList,
-                onSettle = { fromIndex, toIndex ->
-                    rowMoveCallback.invoke(fromIndex, toIndex)
-                },
-            ) { index, item, _ ->
-                key(rowKey(item, index)) {
+                list = unitList,
+                onSettle = { fromUnit, toUnit -> currentSettleUnits.value(fromUnit, toUnit) },
+            ) { unitIndex, leadingItem, _ ->
+                val rows = rowUnits.rowsOf(unitIndex)
+                key(rowKey(leadingItem, rows.first)) {
                     ReorderableItem {
                         val rowScope: TableItemScope =
                             remember(this) {
                                 TableItemListDragScope(this)
                             }
                         context(rowScope) {
-                            TableBodyRow(
-                                index = index,
+                            RowUnit(
+                                rows = rows,
+                                isGroup = rowUnits.isGroup(unitIndex),
+                                nextIsGroup =
+                                    unitIndex < rowUnits.unitCount - 1 &&
+                                        rowUnits.isGroup(unitIndex + 1),
+                                rowGroupHeader = rowGroupHeader,
                                 itemAt = itemAt,
                                 visibleColumns = visibleColumns,
                                 state = state,
@@ -222,10 +282,15 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
                 }
             }
         } else {
-            for (index in 0 until itemsCount) {
+            for (unitIndex in 0 until rowUnits.unitCount) {
                 context(DefaultTableItemScope) {
-                    TableBodyRow(
-                        index = index,
+                    RowUnit(
+                        rows = rowUnits.rowsOf(unitIndex),
+                        isGroup = rowUnits.isGroup(unitIndex),
+                        nextIsGroup =
+                            unitIndex < rowUnits.unitCount - 1 &&
+                                rowUnits.isGroup(unitIndex + 1),
+                        rowGroupHeader = rowGroupHeader,
                         itemAt = itemAt,
                         visibleColumns = visibleColumns,
                         state = state,
@@ -288,7 +353,7 @@ private class IndexedListAdapter<T>(
 @Composable
 @Suppress("LongParameterList")
 context(_: TableItemScope)
-private fun <T : Any, C, E> TableBodyRow(
+internal fun <T : Any, C, E> TableBodyRow(
     index: Int,
     itemAt: (Int) -> T?,
     visibleColumns: ImmutableList<ColumnSpec<T, C, E>>,

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableViewportPrefetcher.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableViewportPrefetcher.kt
@@ -58,8 +58,17 @@ internal fun <T : Any, C, E> TableViewportPrefetcher(
         snapshotFlow<Pair<Int, Int>> {
             val li = verticalState.layoutInfo
             val viewport = (li.viewportEndOffset - li.viewportStartOffset).coerceAtLeast(0)
-            val lastVisible = li.visibleItemsInfo.maxByOrNull { it.index }?.index ?: -1
-            Pair(viewport, (lastVisible + 1).coerceAtMost(itemsCount))
+            // Lazy items are units; the prefetch loop below walks rows, so translate back to rows.
+            val lastVisibleUnit = li.visibleItemsInfo.maxByOrNull { it.index }?.index ?: -1
+            val units = state.rowUnits
+            val nextRow =
+                when {
+                    lastVisibleUnit < 0 -> 0
+                    // The footer is an extra lazy item at index == unitCount; it has no rows.
+                    lastVisibleUnit >= units.unitCount -> itemsCount
+                    else -> units.rowsOf(lastVisibleUnit).last + 1
+                }
+            Pair(viewport, nextRow.coerceAtMost(itemsCount))
         }.distinctUntilChanged()
             .collect { pair ->
                 val (vp, start) = pair

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/config/TableColors.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/config/TableColors.kt
@@ -12,6 +12,8 @@ public data class TableColors(
     val rowSelectedContainerColor: Color,
     val stripedRowContainerColor: Color,
     val groupContainerColor: Color,
+    /** Container color painted behind a row group block declared via `rowGroups`. */
+    val rowGroupContainerColor: Color,
     val footerContainerColor: Color,
     val footerContentColor: Color,
 )

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/config/TableDefaults.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/config/TableDefaults.kt
@@ -14,7 +14,12 @@ public object TableDefaults {
      */
     public val NoBorder: BorderStroke = BorderStroke(0.dp, Color.Transparent)
 
-    /** Convenience factory for default [TableColors] derived from [androidx.compose.material3.MaterialTheme]. */
+    /**
+     * Convenience factory for default [TableColors] derived from [androidx.compose.material3.MaterialTheme].
+     *
+     * New parameters are appended, never inserted: every parameter here is a [Color], so inserting one
+     * would leave positional calls compiling while silently binding to the wrong colors.
+     */
     @Composable
     public fun colors(
         headerContainerColor: Color = MaterialTheme.colorScheme.surfaceContainer,
@@ -27,6 +32,7 @@ public object TableDefaults {
         footerContainerColor: Color = MaterialTheme.colorScheme.surfaceContainer,
         footerContentColor: Color =
             MaterialTheme.colorScheme.contentColorFor(footerContainerColor),
+        rowGroupContainerColor: Color = MaterialTheme.colorScheme.surfaceContainerHighest,
     ): TableColors =
         TableColors(
             headerContainerColor = headerContainerColor,
@@ -35,6 +41,7 @@ public object TableDefaults {
             rowSelectedContainerColor = rowSelectedContainerColor,
             stripedRowContainerColor = stripedRowContainerColor,
             groupContainerColor = groupContainerColor,
+            rowGroupContainerColor = rowGroupContainerColor,
             footerContainerColor = footerContainerColor,
             footerContentColor = footerContentColor,
         )

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/config/TableDimensions.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/config/TableDimensions.kt
@@ -21,9 +21,12 @@ public data class TableDimensions(
         level = DeprecationLevel.WARNING,
     )
     val fixedColumnDividerThickness: Dp = pinnedColumnDividerThickness,
+    /** Vertical gap rendered above and below a row group declared via `rowGroups`. */
+    val rowGroupSpacing: Dp = 8.dp,
 ) {
     init {
         require(dividerThickness >= 1.dp) { "dividerThickness must be at least 1.dp" }
         require(pinnedColumnDividerThickness >= 1.dp) { "pinnedColumnDividerThickness must be at least 1.dp" }
+        require(rowGroupSpacing >= 0.dp) { "rowGroupSpacing must not be negative" }
     }
 }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/interaction/KeyboardNavigation.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/interaction/KeyboardNavigation.kt
@@ -112,7 +112,18 @@ internal fun <T : Any, C> Modifier.tableKeyboardNavigation(
                                     val bottom = item.offset + item.size
                                     top >= 0 && bottom <= viewportHeight
                                 }.coerceAtLeast(1)
-                        val target = currentRow + fullyVisible
+                        // `fullyVisible` counts lazy items (units), so page by units and land on the
+                        // target unit's first row. Without groups this reduces to currentRow + fullyVisible.
+                        val units = state.rowUnits
+                        val target =
+                            if (units.unitCount <= 0) {
+                                currentRow
+                            } else {
+                                val targetUnit =
+                                    (units.unitOf(currentRow) + fullyVisible)
+                                        .coerceAtMost(units.unitCount - 1)
+                                units.rowsOf(targetUnit).first
+                            }
                         ensureFocus(target, currentColIndex)
                         true
                     }
@@ -128,7 +139,15 @@ internal fun <T : Any, C> Modifier.tableKeyboardNavigation(
                                     val bottom = item.offset + item.size
                                     top >= 0 && bottom <= viewportHeight
                                 }.coerceAtLeast(1)
-                        val target = currentRow - fullyVisible
+                        // See PageDown: page by units, then land on the target unit's first row.
+                        val units = state.rowUnits
+                        val target =
+                            if (units.unitCount <= 0) {
+                                currentRow
+                            } else {
+                                val targetUnit = (units.unitOf(currentRow) - fullyVisible).coerceAtLeast(0)
+                                units.rowsOf(targetUnit).first
+                            }
                         ensureFocus(target, currentColIndex)
                         true
                     }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/interaction/ViewportUtils.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/interaction/ViewportUtils.kt
@@ -8,7 +8,15 @@ import androidx.compose.ui.unit.dp
 import ua.wwind.table.ColumnSpec
 import ua.wwind.table.state.TableState
 
-/** Ensure that the given [index] row becomes fully visible in the viewport (supports dynamic row heights). */
+/**
+ * Ensure that the given [index] row becomes fully visible in the viewport (supports dynamic row heights).
+ *
+ * [index] is a row index; the backing `LazyColumn` is indexed by *units* (a unit is a single row or a
+ * declared group of adjacent rows), so it is translated once via [TableState.rowUnits] and the unit
+ * index is used for every `layoutInfo` lookup and scroll call. Height estimates stay keyed by row
+ * (`state.rowHeightsPx`): they under-count a group's internal gap, which is acceptable because every
+ * branch fine-tunes the final scroll from the measured `info.offset` once the target unit is visible.
+ */
 public suspend fun <C> ensureRowFullyVisible(
     index: Int,
     verticalState: LazyListState,
@@ -16,16 +24,17 @@ public suspend fun <C> ensureRowFullyVisible(
     density: Density,
     movement: Int = 0,
 ) {
+    val unitIndex = state.rowUnits.unitOf(index)
     val layout = verticalState.layoutInfo
     val visible = layout.visibleItemsInfo
     if (visible.isEmpty()) {
-        verticalState.animateScrollToItem(index)
+        verticalState.animateScrollToItem(unitIndex)
         return
     }
 
     val firstVisibleIndex = visible.first().index
     val lastVisibleIndex = visible.last().index
-    val targetInfo = visible.firstOrNull { it.index == index }
+    val targetInfo = visible.firstOrNull { it.index == unitIndex }
     val viewportHeight = (layout.viewportEndOffset - layout.viewportStartOffset).coerceAtLeast(0)
 
     if (targetInfo != null) {
@@ -39,29 +48,29 @@ public suspend fun <C> ensureRowFullyVisible(
         return
     }
 
-    if (index < firstVisibleIndex) {
+    if (unitIndex < firstVisibleIndex) {
         // If moving upward and the target is immediately above, scroll just enough to reveal it at the top.
         val prevIndex = firstVisibleIndex - 1
-        if (movement < 0 && index == prevIndex) {
+        if (movement < 0 && unitIndex == prevIndex) {
             val estimatedHeight =
                 state.rowHeightsPx[index] ?: with(density) { state.dimensions.rowHeight.toPx() }.toInt()
             val firstTop = visible.first().offset
             val delta = (firstTop - estimatedHeight)
             if (delta != 0) verticalState.animateScrollBy(delta.toFloat())
             // Fine-tune once it becomes visible
-            val info = verticalState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == index }
+            val info = verticalState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == unitIndex }
             if (info != null && info.offset < 0) verticalState.animateScrollBy(info.offset.toFloat())
         } else {
             // Fallback: align to top
-            verticalState.animateScrollToItem(index)
+            verticalState.animateScrollToItem(unitIndex)
         }
         return
     }
 
-    if (index > lastVisibleIndex) {
-        // If moving downward and the target is the next row after the last visible, reveal just one row.
+    if (unitIndex > lastVisibleIndex) {
+        // If moving downward and the target is the next unit after the last visible, reveal just one unit.
         val nextIndex = lastVisibleIndex + 1
-        if (movement > 0 && index == nextIndex) {
+        if (movement > 0 && unitIndex == nextIndex) {
             val estimatedHeight =
                 state.rowHeightsPx[index] ?: with(density) { state.dimensions.rowHeight.toPx() }.toInt()
             val last = visible.last()
@@ -70,7 +79,7 @@ public suspend fun <C> ensureRowFullyVisible(
             val delta = (lastBottom - desiredTop).coerceAtLeast(0)
             if (delta != 0) verticalState.animateScrollBy(delta.toFloat())
             // Fine-tune now that it's visible
-            val info = verticalState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == index }
+            val info = verticalState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == unitIndex }
             if (info != null) {
                 val bottom = info.offset + info.size
                 val overflow = bottom - viewportHeight
@@ -83,9 +92,11 @@ public suspend fun <C> ensureRowFullyVisible(
 
             fun heightOf(i: Int): Int = state.rowHeightsPx[i] ?: defaultHeight
 
-            // Sum heights between the last visible row and the target (excluding the target)
+            // Sum heights between the last visible row and the target (excluding the target).
+            // `lastVisibleIndex` is a unit index, so translate it back to the last row it renders
+            // before walking rows; with no groups this is exactly `lastVisibleIndex + 1`.
             var betweenSum = 0
-            var i = lastVisibleIndex + 1
+            var i = state.rowUnits.rowsOf(lastVisibleIndex).last + 1
             while (i < index) {
                 betweenSum += heightOf(i)
                 i++
@@ -99,7 +110,7 @@ public suspend fun <C> ensureRowFullyVisible(
             if (delta != 0) verticalState.animateScrollBy(delta.toFloat())
 
             // Fine-tune once it becomes visible (avoid off-by-one and dynamic height adjustments)
-            val info = verticalState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == index }
+            val info = verticalState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == unitIndex }
             if (info != null) {
                 val bottom = info.offset + info.size
                 val overflow = bottom - viewportHeight

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/state/RowUnitIndex.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/state/RowUnitIndex.kt
@@ -1,0 +1,140 @@
+package ua.wwind.table.state
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Maps row indices (the public index space of the table) to unit indices (the index space of the
+ * backing `LazyColumn`), where a unit is either a single row or a declared group of adjacent rows.
+ *
+ * Memory is O(number of groups): only group bounds and prefix sums are stored, never a per-row
+ * array. With no groups the index is identity and no binary search is performed.
+ */
+@Immutable
+internal class RowUnitIndex private constructor(
+    private val starts: IntArray,
+    private val ends: IntArray,
+    /** `collapsedBefore[i]` = number of rows absorbed by groups left of group `i`; size is groups+1. */
+    private val collapsedBefore: IntArray,
+    val unitCount: Int,
+) {
+    val isIdentity: Boolean get() = starts.isEmpty()
+
+    /** Unit index that renders [rowIndex]. */
+    fun unitOf(rowIndex: Int): Int {
+        if (isIdentity) return rowIndex
+        val group = groupContaining(rowIndex)
+        if (group >= 0) return starts[group] - collapsedBefore[group]
+        return rowIndex - collapsedBefore[groupsFullyBefore(rowIndex)]
+    }
+
+    /** Rows rendered by [unitIndex]; a single-row unit returns `i..i`. */
+    fun rowsOf(unitIndex: Int): IntRange {
+        if (isIdentity) return unitIndex..unitIndex
+        val group = groupAtUnit(unitIndex)
+        if (group >= 0) return starts[group]..ends[group]
+        val row = unitIndex + collapsedBefore[groupsBeforeUnit(unitIndex)]
+        return row..row
+    }
+
+    fun isGroup(unitIndex: Int): Boolean = !isIdentity && groupAtUnit(unitIndex) >= 0
+
+    /** Index of the group containing [row], or -1. */
+    private fun groupContaining(row: Int): Int {
+        val insertion = upperBoundByStart(row)
+        val candidate = insertion - 1
+        return if (candidate >= 0 && row <= ends[candidate]) candidate else -1
+    }
+
+    /** Number of groups that end strictly before [row]. */
+    private fun groupsFullyBefore(row: Int): Int = upperBoundByStart(row)
+
+    /** Number of groups whose `starts` are <= [row]. */
+    private fun upperBoundByStart(row: Int): Int {
+        var low = 0
+        var high = starts.size
+        while (low < high) {
+            val mid = (low + high) ushr 1
+            if (starts[mid] <= row) low = mid + 1 else high = mid
+        }
+        return low
+    }
+
+    /** Unit index at which group [i] starts. */
+    private fun unitStartOf(i: Int): Int = starts[i] - collapsedBefore[i]
+
+    /** Index of the group whose unit index is exactly [unit], or -1. */
+    private fun groupAtUnit(unit: Int): Int {
+        var low = 0
+        var high = starts.size - 1
+        while (low <= high) {
+            val mid = (low + high) ushr 1
+            val midUnit = unitStartOf(mid)
+            when {
+                midUnit == unit -> return mid
+                midUnit < unit -> low = mid + 1
+                else -> high = mid - 1
+            }
+        }
+        return -1
+    }
+
+    /** Number of groups whose unit index is < [unit]. */
+    private fun groupsBeforeUnit(unit: Int): Int {
+        var low = 0
+        var high = starts.size
+        while (low < high) {
+            val mid = (low + high) ushr 1
+            if (unitStartOf(mid) < unit) low = mid + 1 else high = mid
+        }
+        return low
+    }
+
+    internal companion object {
+        fun identity(itemsCount: Int): RowUnitIndex =
+            RowUnitIndex(
+                starts = IntArray(0),
+                ends = IntArray(0),
+                collapsedBefore = IntArray(1),
+                unitCount = itemsCount.coerceAtLeast(0),
+            )
+
+        fun of(itemsCount: Int, groups: List<IntRange>): RowUnitIndex {
+            val size = groups.size
+            val starts = IntArray(size)
+            val ends = IntArray(size)
+            val collapsedBefore = IntArray(size + 1)
+            var previousEnd = -1
+            var collapsed = 0
+            groups.forEachIndexed { i, range ->
+                require(!range.isEmpty()) { "rowGroups must not contain empty ranges, got $range" }
+                require(range.first > previousEnd) {
+                    "rowGroups must be sorted and non-overlapping, got $range after row $previousEnd"
+                }
+                require(range.first >= 0 && range.last < itemsCount) {
+                    "rowGroups range $range is out of bounds for $itemsCount rows"
+                }
+                starts[i] = range.first
+                ends[i] = range.last
+                collapsedBefore[i] = collapsed
+                collapsed += range.last - range.first
+                previousEnd = range.last
+            }
+            collapsedBefore[size] = collapsed
+            return RowUnitIndex(starts, ends, collapsedBefore, itemsCount - collapsed)
+        }
+    }
+}
+
+/**
+ * Builds a [RowUnitIndex] for [itemsCount] rows. Returns the identity index when [groups] is null or
+ * empty, so tables without groups keep their existing behavior with no extra work.
+ */
+internal fun buildRowUnitIndex(
+    itemsCount: Int,
+    groups: List<IntRange>?,
+): RowUnitIndex =
+    if (groups.isNullOrEmpty() || itemsCount <= 0) {
+        RowUnitIndex.identity(itemsCount)
+    } else {
+        RowUnitIndex.of(itemsCount, groups)
+    }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/state/TableState.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/state/TableState.kt
@@ -69,8 +69,12 @@ public class TableState<C>
 
         /**
          * Current visible columns list. Must be set externally before tableWidth is accessed.
+         *
+         * Snapshot state, because [tableWidth] derives from it: a plain field would be an untracked
+         * read, leaving the derived width frozen at whatever the first composition computed until
+         * some *other* tracked read — a [columnWidths] write — happened to invalidate it.
          */
-        internal var visibleColumns: List<ColumnSpec<*, C, *>> = emptyList()
+        internal var visibleColumns: List<ColumnSpec<*, C, *>> by mutableStateOf(emptyList())
 
         /**
          * Row-to-unit mapping for the current data set. Identity unless the consumer passed

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/state/TableState.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/state/TableState.kt
@@ -73,6 +73,20 @@ public class TableState<C>
         internal var visibleColumns: List<ColumnSpec<*, C, *>> = emptyList()
 
         /**
+         * Row-to-unit mapping for the current data set. Identity unless the consumer passed
+         * `rowGroups`. Assigned by `Table` during composition, read by scroll/keyboard effects.
+         *
+         * Snapshot state, because the prefetcher reads it inside a `snapshotFlow`, which re-evaluates
+         * only on a tracked read. As a plain field it would be carried along by the `layoutInfo` read
+         * next to it — correct only for as long as something else keeps scrolling.
+         *
+         * `Table` holds the index in `remember`, and [RowUnitIndex] compares by identity, so
+         * re-assigning the same instance each recomposition is a no-op and only a genuine rebuild
+         * notifies.
+         */
+        internal var rowUnits: RowUnitIndex by mutableStateOf(RowUnitIndex.identity(0))
+
+        /**
          * Current table width computed from visible columns and their widths.
          * Automatically recalculates when columnOrder, columnWidths, or visibleColumns change.
          */

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/ColumnVisibilityTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/ColumnVisibilityTest.kt
@@ -1,0 +1,148 @@
+package ua.wwind.table
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isLessThan
+import kotlinx.collections.immutable.persistentListOf
+import ua.wwind.table.state.TableState
+import ua.wwind.table.state.rememberTableState
+import kotlin.test.Test
+
+/**
+ * Composition-level cover for `ColumnSpec.visible` changing after the first render — the path that
+ * `TableState.tableWidth` derives from, and the one the unit tests can only reach by assigning
+ * `visibleColumns` by hand.
+ *
+ * These also stand in for a recomposition-loop check: `Table` assigns `state.visibleColumns` *during*
+ * composition, and a write that kept invalidating its own readers would never let `waitForIdle`
+ * return, failing here by timeout rather than by assertion.
+ */
+@OptIn(ExperimentalTestApi::class, ExperimentalTableApi::class)
+class ColumnVisibilityTest {
+    private fun columnsWith(showSecond: Boolean) =
+        tableColumns<String, String, Unit> {
+            column("a", valueOf = { it }) {
+                header("A")
+                width(100.dp, 100.dp)
+                resizable(false)
+                cell { item, _ -> Text(item) }
+            }
+            column("b", valueOf = { it }) {
+                header("B")
+                width(100.dp, 100.dp)
+                resizable(false)
+                visible(showSecond)
+                cell { _, _ -> Text("cell-b") }
+            }
+        }
+
+    @Test
+    fun `table width grows when a column becomes visible after the first render`() =
+        runComposeUiTest {
+            // Starts hidden on purpose: the width freezes at whatever the first composition
+            // computed, so a table that opens narrow is the case that breaks. Opening wide and
+            // hiding freezes at the *wider* value, which still fits every cell and hides nothing.
+            var showSecond by mutableStateOf(false)
+            lateinit var state: TableState<String>
+
+            setContent {
+                val columns = remember(showSecond) { columnsWith(showSecond) }
+                state = rememberTableState(columns = persistentListOf("a", "b"))
+                Box(Modifier.size(400.dp)) {
+                    Table(
+                        itemsCount = 1,
+                        itemAt = { "row" },
+                        state = state,
+                        columns = columns,
+                    )
+                }
+            }
+
+            waitForIdle()
+            val divider = state.dimensions.dividerThickness
+            assertThat(state.tableWidth).isEqualTo(100.dp + divider)
+
+            showSecond = true
+            waitForIdle()
+            assertThat(state.tableWidth).isEqualTo(200.dp + divider * 2)
+
+            showSecond = false
+            waitForIdle()
+            assertThat(state.tableWidth).isEqualTo(100.dp + divider)
+        }
+
+    @Test
+    fun `a cell of a column revealed after the first render is on screen`() =
+        runComposeUiTest {
+            var showSecond by mutableStateOf(false)
+
+            setContent {
+                val columns = remember(showSecond) { columnsWith(showSecond) }
+                val state = rememberTableState(columns = persistentListOf("a", "b"))
+                Box(Modifier.size(400.dp)) {
+                    Table(
+                        itemsCount = 1,
+                        itemAt = { "row" },
+                        state = state,
+                        columns = columns,
+                    )
+                }
+            }
+
+            waitForIdle()
+            onNodeWithText("cell-b").assertDoesNotExist()
+
+            // Asserts the *cell*, not the header: the header measures from its own width map and
+            // rendered fine even while the bug was live. It was the row — measured with
+            // `state.tableWidth` — that kept the revealed column outside its bounds and out of
+            // horizontal scroll range.
+            showSecond = true
+            waitForIdle()
+            onNodeWithText("cell-b").assertIsDisplayed()
+        }
+
+    @Test
+    fun `a visibility flip settles instead of recomposing forever`() =
+        runComposeUiTest {
+            var showSecond by mutableStateOf(true)
+            var rootCompositions = 0
+
+            setContent {
+                SideEffect { rootCompositions++ }
+                val columns = remember(showSecond) { columnsWith(showSecond) }
+                val state = rememberTableState(columns = persistentListOf("a", "b"))
+                Box(Modifier.size(400.dp)) {
+                    Table(
+                        itemsCount = 1,
+                        itemAt = { "row" },
+                        state = state,
+                        columns = columns,
+                    )
+                }
+            }
+
+            waitForIdle()
+            val settled = rootCompositions
+
+            showSecond = false
+            waitForIdle()
+
+            // Writing state during composition costs at most one extra pass; anything more means the
+            // write is feeding its own readers.
+            assertThat(rootCompositions - settled).isLessThan(3)
+        }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/RowGroupsTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/RowGroupsTest.kt
@@ -1,0 +1,94 @@
+package ua.wwind.table
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+private data class Row(val id: Int, val groupId: String?)
+
+class RowGroupsTest {
+    @Test
+    fun `no group ids yields no groups`() {
+        val rows = listOf(Row(0, null), Row(1, null))
+        assertThat(rows.rowGroupsOf { it.groupId }).isEqualTo(emptyList<IntRange>())
+    }
+
+    @Test
+    fun `adjacent equal ids collapse into one range`() {
+        val rows = listOf(Row(0, null), Row(1, "a"), Row(2, "a"), Row(3, null), Row(4, "b"))
+        assertThat(rows.rowGroupsOf { it.groupId }).isEqualTo(listOf(1..2, 4..4))
+    }
+
+    @Test
+    fun `disjoint runs of the same id yield separate ranges`() {
+        val rows = listOf(Row(0, "a"), Row(1, null), Row(2, "a"))
+        assertThat(rows.rowGroupsOf { it.groupId }).isEqualTo(listOf(0..0, 2..2))
+    }
+
+    @Test
+    fun `different adjacent ids do not merge`() {
+        val rows = listOf(Row(0, "a"), Row(1, "b"))
+        assertThat(rows.rowGroupsOf { it.groupId }).isEqualTo(listOf(0..0, 1..1))
+    }
+
+    @Test
+    fun `group at the end is closed`() {
+        val rows = listOf(Row(0, null), Row(1, "a"), Row(2, "a"))
+        assertThat(rows.rowGroupsOf { it.groupId }).isEqualTo(listOf(1..2))
+    }
+
+    @Test
+    fun `move block down lands after the target`() {
+        val list = (0..9).toMutableList()
+        list.moveRowGroup(from = 2..4, to = 7..8)
+        assertThat(list).isEqualTo(listOf(0, 1, 5, 6, 7, 8, 2, 3, 4, 9))
+    }
+
+    @Test
+    fun `move block down past a single row`() {
+        val list = (0..6).toMutableList()
+        list.moveRowGroup(from = 2..4, to = 5..5)
+        assertThat(list).isEqualTo(listOf(0, 1, 5, 2, 3, 4, 6))
+    }
+
+    @Test
+    fun `move block up lands before the target`() {
+        val list = (0..9).toMutableList()
+        list.moveRowGroup(from = 5..6, to = 2..2)
+        assertThat(list).isEqualTo(listOf(0, 1, 5, 6, 2, 3, 4, 7, 8, 9))
+    }
+
+    @Test
+    fun `move single row behaves like remove and insert`() {
+        val list = (0..4).toMutableList()
+        list.moveRowGroup(from = 0..0, to = 3..3)
+        assertThat(list).isEqualTo(listOf(1, 2, 3, 0, 4))
+    }
+
+    @Test
+    fun `move to the same position is a no-op`() {
+        val list = (0..4).toMutableList()
+        list.moveRowGroup(from = 1..2, to = 1..2)
+        assertThat(list).isEqualTo(listOf(0, 1, 2, 3, 4))
+    }
+
+    @Test
+    fun `out of bounds move is rejected`() {
+        val list = (0..4).toMutableList()
+        assertFailsWith<IllegalArgumentException> { list.moveRowGroup(from = 3..7, to = 0..0) }
+    }
+
+    @Test
+    fun `out of bounds target is rejected`() {
+        val list = (0..4).toMutableList()
+        assertFailsWith<IllegalArgumentException> { list.moveRowGroup(from = 0..0, to = 3..7) }
+    }
+
+    @Test
+    fun `empty range is rejected`() {
+        val list = (0..4).toMutableList()
+        assertFailsWith<IllegalArgumentException> { list.moveRowGroup(from = 3..2, to = 0..0) }
+        assertFailsWith<IllegalArgumentException> { list.moveRowGroup(from = 0..0, to = 3..2) }
+    }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/state/RowUnitIndexTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/state/RowUnitIndexTest.kt
@@ -1,0 +1,152 @@
+package ua.wwind.table.state
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class RowUnitIndexTest {
+    @Test
+    fun `no groups is identity`() {
+        val index = buildRowUnitIndex(itemsCount = 10, groups = null)
+        assertThat(index.unitCount).isEqualTo(10)
+        repeat(10) { row ->
+            assertThat(index.unitOf(row)).isEqualTo(row)
+            assertThat(index.rowsOf(row)).isEqualTo(row..row)
+            assertThat(index.isGroup(row)).isFalse()
+        }
+    }
+
+    @Test
+    fun `empty group list is identity`() {
+        val index = buildRowUnitIndex(itemsCount = 3, groups = emptyList())
+        assertThat(index.unitCount).isEqualTo(3)
+        assertThat(index.unitOf(2)).isEqualTo(2)
+    }
+
+    @Test
+    fun `single group in the middle collapses its rows`() {
+        // rows: 0 1 [2 3 4] 5 6 7 8 9  ->  units: 0 1 2 3 4 5 6 7
+        val index = buildRowUnitIndex(itemsCount = 10, groups = listOf(2..4))
+        assertThat(index.unitCount).isEqualTo(8)
+        assertThat(index.unitOf(0)).isEqualTo(0)
+        assertThat(index.unitOf(1)).isEqualTo(1)
+        assertThat(index.unitOf(2)).isEqualTo(2)
+        assertThat(index.unitOf(3)).isEqualTo(2)
+        assertThat(index.unitOf(4)).isEqualTo(2)
+        assertThat(index.unitOf(5)).isEqualTo(3)
+        assertThat(index.unitOf(9)).isEqualTo(7)
+        assertThat(index.rowsOf(2)).isEqualTo(2..4)
+        assertThat(index.rowsOf(3)).isEqualTo(5..5)
+        assertThat(index.rowsOf(7)).isEqualTo(9..9)
+        assertThat(index.isGroup(2)).isTrue()
+        assertThat(index.isGroup(3)).isFalse()
+    }
+
+    @Test
+    fun `group at the start`() {
+        val index = buildRowUnitIndex(itemsCount = 5, groups = listOf(0..1))
+        assertThat(index.unitCount).isEqualTo(4)
+        assertThat(index.unitOf(0)).isEqualTo(0)
+        assertThat(index.unitOf(1)).isEqualTo(0)
+        assertThat(index.unitOf(2)).isEqualTo(1)
+        assertThat(index.rowsOf(0)).isEqualTo(0..1)
+    }
+
+    @Test
+    fun `group at the end`() {
+        val index = buildRowUnitIndex(itemsCount = 5, groups = listOf(3..4))
+        assertThat(index.unitCount).isEqualTo(4)
+        assertThat(index.unitOf(4)).isEqualTo(3)
+        assertThat(index.rowsOf(3)).isEqualTo(3..4)
+    }
+
+    @Test
+    fun `adjacent groups stay separate units`() {
+        // rows: [0 1] [2 3] 4  ->  units: 0 1 2
+        val index = buildRowUnitIndex(itemsCount = 5, groups = listOf(0..1, 2..3))
+        assertThat(index.unitCount).isEqualTo(3)
+        assertThat(index.unitOf(1)).isEqualTo(0)
+        assertThat(index.unitOf(2)).isEqualTo(1)
+        assertThat(index.unitOf(4)).isEqualTo(2)
+        assertThat(index.rowsOf(0)).isEqualTo(0..1)
+        assertThat(index.rowsOf(1)).isEqualTo(2..3)
+        assertThat(index.rowsOf(2)).isEqualTo(4..4)
+    }
+
+    @Test
+    fun `single row group is still a group`() {
+        val index = buildRowUnitIndex(itemsCount = 3, groups = listOf(1..1))
+        assertThat(index.unitCount).isEqualTo(3)
+        assertThat(index.isGroup(1)).isTrue()
+        assertThat(index.rowsOf(1)).isEqualTo(1..1)
+    }
+
+    @Test
+    fun `round trip holds for every row`() {
+        val index = buildRowUnitIndex(itemsCount = 20, groups = listOf(2..4, 7..7, 15..18))
+        repeat(20) { row ->
+            val unit = index.unitOf(row)
+            assertThat(index.rowsOf(unit).contains(row)).isTrue()
+        }
+    }
+
+    @Test
+    fun `every unit maps back to a distinct row range covering all rows`() {
+        val index = buildRowUnitIndex(itemsCount = 12, groups = listOf(1..3, 8..9))
+        val covered = (0 until index.unitCount).flatMap { index.rowsOf(it) }
+        assertThat(covered).isEqualTo((0 until 12).toList())
+    }
+
+    // The footer is an extra lazy item at `unitCount`, past every unit the index describes. Callers
+    // that read `layoutInfo` can hand that index straight back, so both accessors must answer for it
+    // rather than throw or claim a group.
+    @Test
+    fun `footer unit index reports no group and the row past the end`() {
+        val identity = buildRowUnitIndex(itemsCount = 10, groups = null)
+        assertThat(identity.isGroup(identity.unitCount)).isFalse()
+        assertThat(identity.rowsOf(identity.unitCount)).isEqualTo(10..10)
+
+        val grouped = buildRowUnitIndex(itemsCount = 10, groups = listOf(2..4))
+        assertThat(grouped.unitCount).isEqualTo(8)
+        assertThat(grouped.isGroup(grouped.unitCount)).isFalse()
+        assertThat(grouped.rowsOf(grouped.unitCount)).isEqualTo(10..10)
+    }
+
+    @Test
+    fun `no items is identity with no units`() {
+        val index = buildRowUnitIndex(itemsCount = 0, groups = listOf(0..0))
+        assertThat(index.unitCount).isEqualTo(0)
+        assertThat(index.isGroup(0)).isFalse()
+    }
+
+    @Test
+    fun `overlapping groups are rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            buildRowUnitIndex(itemsCount = 10, groups = listOf(2..4, 4..6))
+        }
+    }
+
+    @Test
+    fun `unsorted groups are rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            buildRowUnitIndex(itemsCount = 10, groups = listOf(5..6, 1..2))
+        }
+    }
+
+    @Test
+    fun `out of bounds group is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            buildRowUnitIndex(itemsCount = 5, groups = listOf(3..7))
+        }
+    }
+
+    @Test
+    fun `empty range is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            buildRowUnitIndex(itemsCount = 5, groups = listOf(3..2))
+        }
+    }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/state/TableWidthTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/state/TableWidthTest.kt
@@ -1,0 +1,76 @@
+package ua.wwind.table.state
+
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import ua.wwind.table.ColumnSpec
+import ua.wwind.table.config.TableDefaults
+import ua.wwind.table.config.TableSettings
+import kotlin.test.Test
+
+private fun spec(key: String): ColumnSpec<Any, String, Unit> =
+    ColumnSpec(
+        key = key,
+        header = {},
+        cell = { _, _ -> },
+        valueOf = { null },
+    )
+
+/**
+ * [TableState.tableWidth] is a `derivedStateOf` over [TableState.visibleColumns]. Snapshot state
+ * only invalidates a derived value when a *tracked* read changes, so `visibleColumns` has to be
+ * snapshot state itself: as a plain field its writes are invisible and the width freezes at
+ * whatever the first composition computed.
+ *
+ * That freeze is not cosmetic. Rows are measured with `Modifier.width(state.tableWidth)` and the
+ * horizontal scroll range follows it, so a stale width leaves newly shown columns off screen and
+ * unreachable — while the header, which measures from its own width map, lays them out. The result
+ * is a header that no longer lines up with the rows beneath it.
+ */
+class TableWidthTest {
+    private fun newState(): TableState<String> =
+        TableState(
+            initialColumns = listOf("a", "b"),
+            initialSort = null,
+            initialOrder = listOf("a", "b"),
+            initialWidths = mapOf("a" to 100.dp, "b" to 100.dp),
+            settings = TableSettings(),
+            dimensions = TableDefaults.standardDimensions(),
+        )
+
+    @Test
+    fun `tableWidth follows a column being hidden`() {
+        val state = newState()
+        val divider = state.dimensions.dividerThickness
+
+        state.visibleColumns = listOf(spec("a"), spec("b"))
+        assertThat(state.tableWidth).isEqualTo(200.dp + divider * 2)
+
+        state.visibleColumns = listOf(spec("a"))
+        assertThat(state.tableWidth).isEqualTo(100.dp + divider)
+    }
+
+    @Test
+    fun `tableWidth follows a column being shown again`() {
+        val state = newState()
+        val divider = state.dimensions.dividerThickness
+
+        state.visibleColumns = listOf(spec("a"))
+        assertThat(state.tableWidth).isEqualTo(100.dp + divider)
+
+        state.visibleColumns = listOf(spec("a"), spec("b"))
+        assertThat(state.tableWidth).isEqualTo(200.dp + divider * 2)
+    }
+
+    @Test
+    fun `tableWidth follows a column width change`() {
+        val state = newState()
+        val divider = state.dimensions.dividerThickness
+
+        state.visibleColumns = listOf(spec("a"))
+        assertThat(state.tableWidth).isEqualTo(100.dp + divider)
+
+        state.columnWidths["a"] = 150.dp
+        assertThat(state.tableWidth).isEqualTo(150.dp + divider)
+    }
+}

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/SampleApp.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/SampleApp.kt
@@ -1,19 +1,27 @@
 package ua.wwind.table.sample.app
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -35,14 +43,17 @@ import io.github.fletchmckee.liquid.rememberLiquidState
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import ua.wwind.table.ExperimentalTableApi
+import ua.wwind.table.TableRowGroups
 import ua.wwind.table.config.RowHeightMode
 import ua.wwind.table.config.SelectionMode
 import ua.wwind.table.config.TableDefaults
 import ua.wwind.table.config.TableSettings
 import ua.wwind.table.filter.data.TableFilterState
 import ua.wwind.table.format.rememberCustomization
+import ua.wwind.table.rowGroupsOf
 import ua.wwind.table.sample.app.components.AppToolbar
 import ua.wwind.table.sample.app.components.ConditionalFormattingDialog
+import ua.wwind.table.sample.app.components.GroupRenameDialog
 import ua.wwind.table.sample.app.components.MainTable
 import ua.wwind.table.sample.app.components.SampleTableConfig
 import ua.wwind.table.sample.app.components.SelectionActionBar
@@ -92,12 +103,17 @@ fun SampleApp(modifier: Modifier = Modifier) {
 
     // Create columns with callbacks
     val columns =
-        remember(tableConfig.useCompactMode, tableConfig.enableRowReorder) {
+        remember(
+            tableConfig.useCompactMode,
+            tableConfig.enableRowReorder,
+            tableConfig.enableRowGroups,
+        ) {
             createTableColumns(
                 onToggleMovementExpanded = viewModel::toggleMovementExpanded,
                 onEvent = viewModel::onEvent,
                 useCompactMode = tableConfig.useCompactMode,
                 enableRowReorder = tableConfig.enableRowReorder,
+                enableRowGroups = tableConfig.enableRowGroups,
             )
         }
 
@@ -132,9 +148,11 @@ fun SampleApp(modifier: Modifier = Modifier) {
     // Liquid glass effect state for SelectionActionBar
     val liquidState = rememberLiquidState()
 
-    // Toggle visibility of SELECTION column by adjusting width based on selection mode
+    // The SELECTION column carries the checkbox in selection mode and the drag handle outside it,
+    // so it must stay open for either one; collapsing it on selection mode alone took the handle
+    // with it. Width is the only visibility control the column has.
     val selectionColumnWidth =
-        if (tableData.selectionModeEnabled) {
+        if (tableData.selectionModeEnabled || tableConfig.enableRowReorder) {
             if (tableConfig.useCompactMode) 36.dp else 48.dp
         } else {
             0.dp
@@ -223,6 +241,88 @@ fun SampleApp(modifier: Modifier = Modifier) {
                                             )
                                         }
                                     },
+                                    // Built only while groups are on: a non-null onMove takes
+                                    // precedence over onRowMove inside the table, which would turn
+                                    // the plain single-row swap demo into a remove-and-insert move.
+                                    rowGroups =
+                                        remember(
+                                            tableData.displayedPeople,
+                                            tableConfig.enableRowGroups,
+                                        ) {
+                                            if (!tableConfig.enableRowGroups) {
+                                                null
+                                            } else {
+                                                TableRowGroups(
+                                                    ranges =
+                                                        tableData.displayedPeople.rowGroupsOf {
+                                                            it.groupId
+                                                        },
+                                                    onMove = { from, to ->
+                                                        val people = tableData.displayedPeople
+                                                        val movedIds =
+                                                            from.mapNotNull { people.getOrNull(it)?.id }
+                                                        val targetIds =
+                                                            to.mapNotNull { people.getOrNull(it)?.id }
+                                                        if (movedIds.isNotEmpty() && targetIds.isNotEmpty()) {
+                                                            viewModel.onEvent(
+                                                                SampleUiEvent.RowsMove(
+                                                                    fromPersonIds = movedIds,
+                                                                    toPersonIds = targetIds,
+                                                                ),
+                                                            )
+                                                        }
+                                                    },
+                                                    // Names the block in the band above it — where the
+                                                    // group chip used to sit inside the Name cell.
+                                                    // The id IS the name, so tapping it edits the id.
+                                                    header = { rows ->
+                                                        val groupId =
+                                                            tableData.displayedPeople
+                                                                .getOrNull(rows.first)
+                                                                ?.groupId
+                                                        if (groupId != null) {
+                                                            Row(
+                                                                verticalAlignment =
+                                                                    Alignment.CenterVertically,
+                                                                horizontalArrangement =
+                                                                    Arrangement.spacedBy(6.dp),
+                                                                // clickable before padding: the
+                                                                // padding is inside the touch target,
+                                                                // not dead space around it.
+                                                                modifier =
+                                                                    Modifier
+                                                                        .clickable {
+                                                                            viewModel
+                                                                                .setRenamingGroup(groupId)
+                                                                        }.padding(
+                                                                            horizontal = 12.dp,
+                                                                            vertical = 6.dp,
+                                                                        ),
+                                                            ) {
+                                                                Text(
+                                                                    text = groupId,
+                                                                    style =
+                                                                        MaterialTheme.typography
+                                                                            .labelLarge,
+                                                                    color =
+                                                                        MaterialTheme.colorScheme
+                                                                            .onSurface,
+                                                                )
+                                                                Icon(
+                                                                    imageVector = Icons.Default.Edit,
+                                                                    contentDescription =
+                                                                        "Rename group $groupId",
+                                                                    tint =
+                                                                        MaterialTheme.colorScheme
+                                                                            .onSurfaceVariant,
+                                                                    modifier = Modifier.size(16.dp),
+                                                                )
+                                                            }
+                                                        }
+                                                    },
+                                                )
+                                            }
+                                        },
                                     onMovementRowMove = { person, from, to ->
                                         viewModel.onEvent(
                                             SampleUiEvent.MovementRowMove(
@@ -267,6 +367,22 @@ fun SampleApp(modifier: Modifier = Modifier) {
                                     viewModel.onEvent(SampleUiEvent.ClearSelection)
                                 },
                                 liquidState = liquidState,
+                                // Gated on the groups toggle: with groups off `rowGroups` is null,
+                                // so grouping would change nothing visible and look broken.
+                                canGroup =
+                                    tableConfig.enableRowGroups &&
+                                        tableData.selectedIds.size >= 2,
+                                onGroupClick = {
+                                    viewModel.onEvent(SampleUiEvent.GroupSelected)
+                                },
+                                canUngroup =
+                                    tableConfig.enableRowGroups &&
+                                        tableData.displayedPeople.any {
+                                            it.id in tableData.selectedIds && it.groupId != null
+                                        },
+                                onUngroupClick = {
+                                    viewModel.onEvent(SampleUiEvent.UngroupSelected)
+                                },
                                 modifier =
                                     Modifier
                                         .align(Alignment.BottomCenter)
@@ -284,6 +400,27 @@ fun SampleApp(modifier: Modifier = Modifier) {
             onRulesChanged = viewModel::updateRules,
             buildFormatFilterData = viewModel::buildFormatFilterData,
             onDismissRequest = { viewModel.toggleFormatDialog(false) },
+        )
+
+        // The master list, NOT `tableData.displayedPeople`: that one is filtered, so a name held by
+        // a hidden row would look free and the rename would silently bail out in the ViewModel.
+        // Group identity lives in the unfiltered list, which is exactly what RenameGroup rewrites.
+        val allPeople by viewModel.people.collectAsState()
+        val renamingGroupId = viewModel.renamingGroupId
+        GroupRenameDialog(
+            groupId = renamingGroupId,
+            // Its own name is excluded, or the dialog would call the group's current id taken.
+            takenGroupIds =
+                remember(allPeople, renamingGroupId) {
+                    allPeople.mapNotNull { it.groupId }.toSet() - setOfNotNull(renamingGroupId)
+                },
+            onRename = { newGroupId ->
+                val groupId = renamingGroupId ?: return@GroupRenameDialog
+                viewModel.onEvent(
+                    SampleUiEvent.RenameGroup(groupId = groupId, newGroupId = newGroupId),
+                )
+            },
+            onDismissRequest = { viewModel.setRenamingGroup(null) },
         )
     }
 }

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/GroupRenameDialog.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/GroupRenameDialog.kt
@@ -1,0 +1,80 @@
+package ua.wwind.table.sample.app.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+/**
+ * Renames a row group. The group id doubles as its name in this sample, so the dialog edits the id
+ * itself and every row carrying it is rewritten.
+ *
+ * Because the id IS the identity, names must stay unique: two groups sharing one id are one logical
+ * group that renames together yet only merges visually when adjacent. The dialog is the gate that
+ * keeps them apart.
+ *
+ * @param groupId Id of the group being renamed; null keeps the dialog closed.
+ * @param takenGroupIds Ids already in use by OTHER groups - [groupId] itself must be excluded by the
+ *   caller, or the dialog would reject the name the group already has as taken.
+ * @param onRename Callback with the new id, invoked only for a non-blank, unused change.
+ * @param onDismissRequest Callback to close the dialog.
+ */
+@Composable
+fun GroupRenameDialog(
+    groupId: String?,
+    takenGroupIds: Set<String>,
+    onRename: (String) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    if (groupId == null) return
+
+    // Keyed on the group so reopening the dialog - or switching to another group without closing -
+    // refills the field instead of showing the previous target's id.
+    var newGroupId by remember(groupId) { mutableStateOf(groupId) }
+    // Trimmed is what gets saved, so it is also what gets validated: a name is judged exactly as it
+    // would be stored. Comparison is case-sensitive to match `rowGroupsOf`, which decides identity
+    // with `==` - "alice" really is a free name next to "Alice".
+    val trimmed = newGroupId.trim()
+    val errorMessage =
+        when {
+            trimmed.isEmpty() -> "Name cannot be empty"
+            trimmed in takenGroupIds -> "Name is already in use"
+            else -> null
+        }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text("Rename group") },
+        text = {
+            OutlinedTextField(
+                value = newGroupId,
+                onValueChange = { newGroupId = it },
+                label = { Text("Group name") },
+                singleLine = true,
+                isError = errorMessage != null,
+                supportingText = errorMessage?.let { message -> { Text(message) } },
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onRename(trimmed)
+                    onDismissRequest()
+                },
+                enabled = errorMessage == null && trimmed != groupId,
+            ) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text("Cancel")
+            }
+        },
+    )
+}

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/MainTable.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/MainTable.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.delay
 import ua.wwind.table.ColumnSpec
 import ua.wwind.table.EditableTable
 import ua.wwind.table.ExperimentalTableApi
+import ua.wwind.table.TableRowGroups
 import ua.wwind.table.config.TableCustomization
 import ua.wwind.table.filter.data.TableFilterState
 import ua.wwind.table.sample.column.PersonColumn
@@ -54,6 +55,7 @@ fun MainTable(
     onRowEditStart: (Person, Int) -> Unit,
     onRowEditComplete: (Int) -> Boolean,
     onEditCancelled: (Int) -> Unit,
+    rowGroups: TableRowGroups? = null,
     useCompactMode: Boolean = false,
     enableRowReorder: Boolean = false,
     modifier: Modifier = Modifier,
@@ -126,6 +128,7 @@ fun MainTable(
                     )
                 }
             },
+            rowGroups = rowGroups,
             onRowMove = onRowMove,
             onRowEditStart = onRowEditStart,
             onRowEditComplete = onRowEditComplete,

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/SampleTableConfig.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/SampleTableConfig.kt
@@ -15,6 +15,7 @@ data class SampleTableConfig(
     val showFastFilters: Boolean = true,
     val enableDragToScroll: Boolean = getPlatform().isMobile(),
     val enableRowReorder: Boolean = false,
+    val enableRowGroups: Boolean = false,
     val pinnedColumnsCount: Int = 0,
     val pinnedColumnsSide: PinnedSide = PinnedSide.Left,
     val enableEditing: Boolean = false,

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/SelectionActionBar.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/SelectionActionBar.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -37,6 +39,10 @@ import io.github.fletchmckee.liquid.liquid
  * @param onClearSelection Callback when clear selection button is clicked
  * @param liquidState State for the Liquid Glass effect (must be shared with liquefiable content)
  * @param modifier Modifier for the composable
+ * @param canGroup Whether the selection can be pulled together into a group
+ * @param onGroupClick Callback when the group button is clicked
+ * @param canUngroup Whether the selection contains at least one grouped row
+ * @param onUngroupClick Callback when the ungroup button is clicked
  */
 @Composable
 fun SelectionActionBar(
@@ -45,6 +51,10 @@ fun SelectionActionBar(
     onClearSelection: () -> Unit,
     liquidState: LiquidState,
     modifier: Modifier = Modifier,
+    canGroup: Boolean = false,
+    onGroupClick: () -> Unit = {},
+    canUngroup: Boolean = false,
+    onUngroupClick: () -> Unit = {},
 ) {
     AnimatedVisibility(
         visible = selectedCount > 0,
@@ -81,6 +91,44 @@ fun SelectionActionBar(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(modifier = Modifier.width(8.dp))
+                if (canGroup) {
+                    Button(
+                        onClick = onGroupClick,
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor =
+                                    MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.9f),
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                            ),
+                        shape = RoundedCornerShape(16.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Link,
+                            contentDescription = null,
+                            modifier = Modifier.padding(end = 8.dp),
+                        )
+                        Text("Group")
+                    }
+                }
+                if (canUngroup) {
+                    Button(
+                        onClick = onUngroupClick,
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor =
+                                    MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.9f),
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                            ),
+                        shape = RoundedCornerShape(16.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.LinkOff,
+                            contentDescription = null,
+                            modifier = Modifier.padding(end = 8.dp),
+                        )
+                        Text("Ungroup")
+                    }
+                }
                 Button(
                     onClick = onDeleteClick,
                     colors =

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/SettingsSidebar.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/SettingsSidebar.kt
@@ -153,6 +153,12 @@ fun SettingsSidebar(
                     )
                     Spacer(modifier = Modifier.height(12.dp))
                     SettingSwitch(
+                        label = "Row groups",
+                        checked = config.enableRowGroups,
+                        onCheckedChange = { onConfigChange(config.copy(enableRowGroups = it)) },
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    SettingSwitch(
                         label = "Cell editing",
                         checked = config.enableEditing,
                         onCheckedChange = { onConfigChange(config.copy(enableEditing = it)) },

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/column/TableColumns.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/column/TableColumns.kt
@@ -61,6 +61,7 @@ fun createTableColumns(
     onEvent: (SampleUiEvent) -> Unit,
     useCompactMode: Boolean = false,
     enableRowReorder: Boolean = false,
+    enableRowGroups: Boolean = false,
 ): ImmutableList<ColumnSpec<Person, PersonColumn, PersonTableData>> =
     editableTableColumns {
         val cellPadding = if (useCompactMode) CellPadding.compact else CellPadding.standard
@@ -85,15 +86,28 @@ fun createTableColumns(
                         )
                     }
                 } else if (enableRowReorder) {
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier = Modifier.fillMaxSize().draggableHandle(),
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Reorder,
-                            contentDescription = "Drag to reorder",
-                            modifier = Modifier.size(24.dp),
-                        )
+                    val people = tableData.displayedPeople
+                    val rowIndex = people.indexOfFirst { it.id == item.id }
+                    // Leader = ungrouped row, or the first row of an adjacent same-group run.
+                    // Mirrors rowGroupsOf's adjacency rule, so it stays correct when a filter
+                    // splits one group into two runs. With groups off every row is its own
+                    // drag unit, so every row keeps its handle.
+                    val isLeader =
+                        !enableRowGroups ||
+                            item.groupId == null ||
+                            rowIndex <= 0 ||
+                            people[rowIndex - 1].groupId != item.groupId
+                    if (isLeader) {
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier.fillMaxSize().draggableHandle(),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Reorder,
+                                contentDescription = "Drag to reorder",
+                                modifier = Modifier.size(24.dp),
+                            )
+                        }
                     }
                 }
             }
@@ -152,7 +166,11 @@ fun createTableColumns(
             autoWidth(500.dp)
             sortable()
             filterTypes[PersonColumn.NAME]?.let { filter(it) }
-            cell { item, _ -> Text(item.name, modifier = Modifier.padding(cellPadding)) }
+            cell { item, _ ->
+                // Group metadata belongs in the row group's header band, not in a row cell — see
+                // the `header` slot of the `TableRowGroups` built in SampleApp.
+                Text(item.name, modifier = Modifier.padding(cellPadding))
+            }
 
             // Editing configuration - table will manage when to show this
             editCell { person, tableData, onComplete ->

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/data/DemoData.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/data/DemoData.kt
@@ -33,6 +33,7 @@ fun createDemoData(): List<Person> =
             salary = 68000,
             rating = 4,
             hireDate = LocalDate(2018, 7, 20),
+            groupId = "team-alpha",
         ),
         Person(
             name = "Carol",
@@ -47,6 +48,7 @@ fun createDemoData(): List<Person> =
             salary = 82000,
             rating = 5,
             hireDate = LocalDate(2020, 1, 10),
+            groupId = "team-alpha",
         ),
         Person(
             name = "Dave",
@@ -61,6 +63,7 @@ fun createDemoData(): List<Person> =
             salary = 95000,
             rating = 4,
             hireDate = LocalDate(2015, 9, 5),
+            groupId = "team-alpha",
         ),
         Person(
             name = "Eve",
@@ -103,6 +106,7 @@ fun createDemoData(): List<Person> =
             salary = 72000,
             rating = 4,
             hireDate = LocalDate(2021, 2, 14),
+            groupId = "team-beta",
         ),
         Person(
             name = "Henry",
@@ -117,6 +121,7 @@ fun createDemoData(): List<Person> =
             salary = 79000,
             rating = 3,
             hireDate = LocalDate(2019, 11, 8),
+            groupId = "team-beta",
         ),
         Person(
             name = "Ivy",

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/model/Person.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/model/Person.kt
@@ -20,6 +20,8 @@ data class Person(
     val salary: Int,
     val rating: Int,
     val hireDate: LocalDate,
+    /** Demo grouping: adjacent people sharing a non-null id drag as one unit. */
+    val groupId: String? = null,
     /** Multiline notes to demonstrate dynamic row height in table. */
     val notes: String =
         when {

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/viewmodel/SampleUiEvent.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/viewmodel/SampleUiEvent.kt
@@ -53,6 +53,18 @@ sealed class SampleUiEvent {
     /** Delete all selected persons */
     data object DeleteSelected : SampleUiEvent()
 
+    /** Pull the selected rows together and give them a shared group id. */
+    data object GroupSelected : SampleUiEvent()
+
+    /** Move the selected rows out of their groups, dropping them just below the block they left. */
+    data object UngroupSelected : SampleUiEvent()
+
+    /** Rename a group: every row carrying [groupId] gets [newGroupId] instead. */
+    data class RenameGroup(
+        val groupId: String,
+        val newGroupId: String,
+    ) : SampleUiEvent()
+
     /** Clear all selections */
     data object ClearSelection : SampleUiEvent()
 
@@ -60,6 +72,12 @@ sealed class SampleUiEvent {
     data class RowMove(
         val fromPersonId: Int,
         val toPersonId: Int,
+    ) : SampleUiEvent()
+
+    /** Move a block of people (a group) so that it swaps with the block of [toPersonIds]. */
+    data class RowsMove(
+        val fromPersonIds: List<Int>,
+        val toPersonIds: List<Int>,
     ) : SampleUiEvent()
 
     /** Reorder embedded movement rows for a specific person by movement indices. */

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/viewmodel/SampleViewModel.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/viewmodel/SampleViewModel.kt
@@ -17,6 +17,7 @@ import ua.wwind.table.ExperimentalTableApi
 import ua.wwind.table.filter.data.TableFilterState
 import ua.wwind.table.format.FormatFilterData
 import ua.wwind.table.format.data.TableFormatRule
+import ua.wwind.table.moveRowGroup
 import ua.wwind.table.sample.column.PersonColumn
 import ua.wwind.table.sample.data.createDemoData
 import ua.wwind.table.sample.filter.filterTypes
@@ -87,6 +88,11 @@ class SampleViewModel : ViewModel() {
     var showFormatDialog by mutableStateOf(false)
         private set
 
+    // Group whose name is being edited; null while the rename dialog is closed. The id doubles as
+    // the dialog's payload, so there is no "open but no target" state to get wrong.
+    var renamingGroupId by mutableStateOf<String?>(null)
+        private set
+
     // Editing state as StateFlow for reactive composition
     private val editingRowState = MutableStateFlow(PersonEditState())
 
@@ -115,6 +121,11 @@ class SampleViewModel : ViewModel() {
     /** Toggle dialog visibility */
     fun toggleFormatDialog(show: Boolean) {
         showFormatDialog = show
+    }
+
+    /** Open the rename dialog for [groupId], or close it when null. */
+    fun setRenamingGroup(groupId: String?) {
+        renamingGroupId = groupId
     }
 
     /** Update formatting rules */
@@ -316,6 +327,128 @@ class SampleViewModel : ViewModel() {
                 selectedIds.value = emptySet()
             }
 
+            is SampleUiEvent.GroupSelected -> {
+                val ids = selectedIds.value
+                if (ids.size < 2) return
+                var grouped = false
+                _people.update { currentPeople ->
+                    val anchor = currentPeople.indexOfFirst { it.id in ids }
+                    if (anchor < 0) return@update currentPeople
+
+                    // The id IS the name, so the block is named after its leader - the topmost
+                    // selected row - and group ids are kept unique: a duplicate would make two
+                    // blocks one identity, renamed together yet still separate drag units unless
+                    // adjacent. A leader's name can collide, so it is suffixed until free.
+                    // Only rows staying OUTSIDE the new block can hold a name against it; the
+                    // selected ones are all about to take the new id, which is what lets two whole
+                    // groups merge back under the leader's plain name.
+                    // Derived from `currentPeople` alone, so a retried CAS attempt is harmless.
+                    val takenGroupIds =
+                        currentPeople.filterNot { it.id in ids }.mapNotNull { it.groupId }.toSet()
+                    val groupId = uniqueGroupId(currentPeople[anchor].name, takenGroupIds)
+
+                    // A drag unit must be contiguous: rowGroupsOf only collapses adjacent rows,
+                    // so the rows are pulled together first and only then share an id.
+                    val block =
+                        currentPeople.filter { it.id in ids }.map { it.copy(groupId = groupId) }
+                    val rest = currentPeople.filterNot { it.id in ids }
+
+                    // The anchor is the FIRST selected index, so every row before it is unselected
+                    // and survives in `rest` - the insertion point is still the anchor after the
+                    // removal. Do not "fix" this by shifting it. Removing the selected rows is safe
+                    // on its own: it can only bring same-id rows closer, never split a run.
+                    // Never cut another group in half: if the insertion point lands between two rows
+                    // of the same group, push it past that group's last row. Splitting a run would
+                    // leave two blocks sharing one id - one logical group torn in two, which renames
+                    // together but drags apart.
+                    var insertAt = anchor.coerceAtMost(rest.size)
+                    while (
+                        insertAt > 0 && insertAt < rest.size &&
+                        rest[insertAt - 1].groupId != null &&
+                        rest[insertAt - 1].groupId == rest[insertAt].groupId
+                    ) {
+                        insertAt++
+                    }
+
+                    grouped = true
+                    rest.toMutableList().apply { addAll(insertAt, block) }
+                }
+                if (grouped) {
+                    // Grouping reorders rows, so a stale sort would fight the new order.
+                    currentSort.value = null
+                }
+            }
+
+            is SampleUiEvent.UngroupSelected -> {
+                val ids = selectedIds.value
+                if (ids.isEmpty()) return
+                var ungrouped = false
+                _people.update { currentPeople ->
+                    // Only a row that is IN a group can leave one: a selected row without a group
+                    // keeps both its null id and its place.
+                    val touchedGroupIds =
+                        currentPeople.filter { it.id in ids }.mapNotNull { it.groupId }.toSet()
+                    if (touchedGroupIds.isEmpty()) return@update currentPeople
+
+                    // A row leaving a group must leave the block as well. rowGroupsOf only collapses
+                    // ADJACENT rows, so merely clearing the id of a row in the middle of the run
+                    // tears the block into two halves that BOTH keep the group's id - one name, two
+                    // drag units, exactly the duplicate the uniqueness invariant forbids. Dropping
+                    // the leavers just past the group's last row keeps the rows that stay
+                    // contiguous, so the group survives whole under its own id.
+                    val lastIndexOfGroup =
+                        touchedGroupIds.associateWith { groupId ->
+                            currentPeople.indexOfLast { it.groupId == groupId }
+                        }
+                    val leavers = mutableMapOf<String, MutableList<Person>>()
+
+                    ungrouped = true
+                    buildList {
+                        currentPeople.forEachIndexed { index, person ->
+                            val groupId = person.groupId
+                            if (groupId != null && person.id in ids) {
+                                leavers.getOrPut(groupId) { mutableListOf() } +=
+                                    person.copy(groupId = null)
+                            } else {
+                                add(person)
+                            }
+                            // Flushed once the run is over, so the leavers land right under what is
+                            // left of the block - and back in their own place when the whole group
+                            // left and there is no block any more. Relative order is preserved
+                            // because they were collected in list order.
+                            if (groupId != null && lastIndexOfGroup[groupId] == index) {
+                                leavers.remove(groupId)?.let { addAll(it) }
+                            }
+                        }
+                    }
+                }
+                if (ungrouped) {
+                    // Ungrouping reorders rows, so a stale sort would fight the new order.
+                    currentSort.value = null
+                }
+            }
+
+            is SampleUiEvent.RenameGroup -> {
+                val newGroupId = event.newGroupId
+                // A blank id still groups - rowGroupsOf only skips nulls - so it would not ungroup
+                // the block, just leave it with a nameless band. Checked ahead of the uniqueness
+                // guard below, which would only catch the SECOND blank name, not the first.
+                // A no-op rename would rewrite every row for nothing.
+                if (newGroupId.isBlank() || newGroupId == event.groupId) return
+                // Rows keep their position: renaming must never reorder, so no sort reset either.
+                _people.update { currentPeople ->
+                    // The id IS the name, so a taken name would fuse two groups into one identity:
+                    // both would rename together yet stay separate drag units unless adjacent.
+                    // The dialog already refuses taken names; this is the last line of defence, and
+                    // it bails out rather than half-applying. Any row already carrying `newGroupId`
+                    // is outside the renamed group - the equal-id case returned above.
+                    if (currentPeople.any { it.groupId == newGroupId }) return@update currentPeople
+                    currentPeople.map {
+                        if (it.groupId == event.groupId) it.copy(groupId = newGroupId) else it
+                    }
+                }
+            }
+
             is SampleUiEvent.ClearSelection -> {
                 selectedIds.value = emptySet()
             }
@@ -336,6 +469,42 @@ class SampleViewModel : ViewModel() {
                         val sourcePerson = this[sourceIndex]
                         this[sourceIndex] = this[targetIndex]
                         this[targetIndex] = sourcePerson
+                    }
+                }
+                if (moved) {
+                    currentSort.value = null
+                }
+            }
+
+            is SampleUiEvent.RowsMove -> {
+                var moved = false
+                _people.update { currentPeople ->
+                    fun indicesOf(ids: List<Int>): List<Int> =
+                        ids
+                            .mapNotNull { id ->
+                                currentPeople.indexOfFirst { it.id == id }.takeIf { it >= 0 }
+                            }.sorted()
+
+                    fun contiguousRangeOrNull(indices: List<Int>): IntRange? =
+                        when {
+                            indices.isEmpty() -> null
+                            indices.last() - indices.first() + 1 != indices.size -> null
+                            else -> indices.first()..indices.last()
+                        }
+
+                    // Blocks are contiguous on screen but may not be in the unfiltered master list;
+                    // moving a split block would scramble it, so skip instead.
+                    val from =
+                        contiguousRangeOrNull(indicesOf(event.fromPersonIds))
+                            ?: return@update currentPeople
+                    val to =
+                        contiguousRangeOrNull(indicesOf(event.toPersonIds))
+                            ?: return@update currentPeople
+                    if (to.first in from) return@update currentPeople
+
+                    moved = true
+                    currentPeople.toMutableList().apply {
+                        moveRowGroup(from = from, to = to)
                     }
                 }
                 if (moved) {
@@ -370,5 +539,20 @@ class SampleViewModel : ViewModel() {
                 }
             }
         }
+    }
+
+    /**
+     * First free name in the sequence [base], "[base] 2", "[base] 3"... Deterministic on purpose:
+     * the id doubles as the label, so a random or timestamped suffix would be unique but unreadable.
+     * Comparison is exact, matching `rowGroupsOf`'s `==` identity rule.
+     */
+    private fun uniqueGroupId(
+        base: String,
+        takenGroupIds: Set<String>,
+    ): String {
+        if (base !in takenGroupIds) return base
+        var suffix = 2
+        while ("$base $suffix" in takenGroupIds) suffix++
+        return "$base $suffix"
     }
 }


### PR DESCRIPTION
Two changes in `table-core`. Version `1.10.0` → `1.11.0`.

## Row groups

Declare ranges of **adjacent** rows that drag as one unit:

```kotlin
val groups = remember(rows) { rows.rowGroupsOf { it.groupId } }
val rowGroups = remember(groups) {
    TableRowGroups(
        ranges = groups,
        onMove = { from, to -> rows.moveRowGroup(from, to) },
        header = { rows -> Text(labelFor(rows)) },
    )
}

Table(itemsCount = rows.size, itemAt = rows::get, state = state, columns = columns, rowGroups = rowGroups)
```

A group renders as **one lazy item**, so the reorder library keeps dragging exactly one item and its
geometry stays correct with no patches. Row indices remain the only public index space; an internal
row-to-unit index maps them for scroll, keyboard and prefetch, and is the identity when no groups are
passed — so tables without `rowGroups` execute the previous code path.

`onMove` reports **row ranges**, never unit indices: collapsing the target to a single index splits the
group it lands on. `rowGroupsOf` / `moveRowGroup` derive ranges from a flat list and apply a range
move. Ignored while `groupBy` is active — the two describe different structures over one list.

The library draws no drag handle: put `Modifier.draggableHandle()` in whichever cells you want.

See [Row reordering](docs/content/guides/row-reordering.md#dragging-a-group-of-rows).

## Fix: table width ignored column visibility

`TableState.tableWidth` derives from the visible column list, but that list was a plain field. A
derived value only recomputes when a **tracked** read changes, so writing the field was invisible to
Compose and the width kept serving a cached value.

Rows measure with `Modifier.width(state.tableWidth)` and the horizontal scroll range follows it, so a
column made visible after the first render was laid out beyond that width and could not be scrolled
to — while the header, which measures from its own width map, laid it out. Header and rows drifted
apart.

It hid well: any unrelated write to `columnWidths` flushed the stale value, so resizing a column made
the missing columns appear. Tables using `autoWidth` never showed it at all.

Fields assigned during composition are now snapshot state.

## Breaking change

`TableColors` gained a **required** `rowGroupContainerColor` constructor parameter — direct constructor
calls must supply it.

`TableDefaults.colors()` takes it as a **trailing optional** parameter, so existing calls keep compiling
and binding as before, positional ones included. `TableDimensions.rowGroupSpacing` defaults to `8.dp`.

## Tests

The module's first tests — 34, covering the row-to-unit index, the group helpers, the table width
across hide/show/resize, and a composition-level cover that flips `ColumnSpec.visible` on a live
`Table`. The width tests were confirmed to fail without the fix before being kept.