### PR TITLE
Row blocks: drag adjacent rows as a single unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file.
 
+### 1.11.0 — 2026-07-16
+
+- Added: `rowGroups` parameter on `Table`/`EditableTable`, taking `TableRowGroups(ranges, onMove, header)`.
+    - A range of adjacent rows can be dragged as a single unit, with the drag handle typically placed on the group's
+      first row and an optional header rendered above the block.
+    - `onMove` reports moves as row ranges (`from: IntRange`, `to: IntRange`) rather than single indices; it is
+      required when row reorder is enabled and `ranges` is non-empty.
+    - When `onMove` is set it supersedes `onRowMove`, which is then no longer invoked.
+    - `TableRowGroups` is `@Stable` and compares by identity — hold it in `remember` to keep `Table` skippable.
+    - Ignored while `state.groupBy` is active: the two describe different structures over one list, so `groupBy` wins
+      and a warning is logged.
+    - Works for both regular lazy tables and embedded table bodies; in a lazy table `onMove` fires during the drag,
+      in an embedded table once on drop.
+- Added: `List.rowGroupsOf` and `MutableList.moveRowGroup` helpers.
+    - `rowGroupsOf` derives drag-unit ranges from a flat row list, collapsing runs of adjacent rows that share a
+      non-null group id.
+    - `moveRowGroup` applies a range move to a `MutableList` with the same semantics as the `onMove` callback.
+- Added: `TableDimensions.rowGroupSpacing` and `TableColors.rowGroupContainerColor` for row group visuals.
+    - `rowGroupSpacing` (default `8.dp`) is the vertical band around a group block; `rowGroupContainerColor` tints it.
+- Changed: `TableColors` gained a required `rowGroupContainerColor` constructor parameter.
+    - Direct constructor calls must supply the new parameter.
+    - `TableDefaults.colors()` takes it as a trailing optional parameter, so existing calls keep compiling and binding
+      as before, positional ones included.
+    - `TableDimensions.rowGroupSpacing` defaults to `8.dp`, so existing `TableDimensions` construction is unaffected.
+- Fixed: table width no longer freezes when `ColumnSpec.visible` changes after the first render.
+    - `TableState.tableWidth` derives from the visible column list, but that list was a plain field, so
+      Compose never saw it change and served a cached width instead. Columns shown again stayed off
+      screen and out of horizontal scroll range, while the header — which measures independently —
+      laid them out, leaving header and rows misaligned.
+    - The stale width was only flushed by an unrelated write to `columnWidths`, so the symptom
+      disappeared as soon as a column was resized, and never appeared at all where `autoWidth` writes
+      those widths on every column change.
+- Added: the module's first tests, covering row groups, the row-to-unit index, the table width across
+  column hide, show and resize, and a composition-level cover that flips `ColumnSpec.visible` on a
+  live `Table` and asserts the revealed column's cell reaches the screen.
+
+Compare: [v1.10.0...v1.11.0](https://github.com/White-Wind-LLC/table/compare/v1.10.0...v1.11.0)
+
 ### 1.10.0 — 2026-06-24
 
 - Updated: Kotlin to 2.4.0 (from 2.3.21).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,29 @@ All notable changes to this project will be documented in this file.
 ### 1.11.0 — 2026-07-17
 
 - Added: row blocks — a `rowBlocks` parameter on `Table`, `EditableTable` and the `table-paging` adapter, taking
-  `RowBlocks(blockOf, onCommit, blockHeader)`.
+  `RowBlocks(blockOf, onCommit, blockHeader, onRowReorderWithinBlock)`.
     - Blocks are declared by identity: adjacent rows whose `blockOf` returns the same non-null id render and drag
       as one unit, with an optional header band above the block. The table derives block extents itself from the
       same snapshot it renders — there are no index ranges to compute or keep in sync with an asynchronous
       pipeline.
+    - Two drag levels: the whole block is dragged from a `draggableHandle()` in its `blockHeader`, while every
+      row carries a cell handle that reorders it **within** its block only — a row can never leave its block.
+      A standalone row's cell handle reorders it among units.
     - The drag is managed: during a gesture the table permutes its own internal view and the consumer's data does
-      not change; on drop `onCommit` receives exactly one `RowBlockMove(blockId, movedKeys, afterKey, beforeKey)`
-      expressed in stable row keys — identical semantics in lazy and embedded tables. `rowBlocks` supersedes
-      `onRowMove`, which is then no longer invoked: standalone rows report through `onCommit` too, with a null
-      `blockId`. Without `onCommit` blocks are display-only and row drag is disabled entirely. If the rendered
-      list changes mid-gesture, the gesture is cancelled.
+      not change; on drop a whole-block drag delivers exactly one `RowBlockMove(blockId, movedKeys, afterKey,
+      beforeKey)` via `onCommit`, and a within-block reorder delivers one `RowWithinBlockMove(blockId, movedKey,
+      afterKey, beforeKey)` via `onRowReorderWithinBlock` — all in stable row keys, identical in lazy and embedded
+      tables. `rowBlocks` supersedes `onRowMove`, which is then no longer invoked: standalone rows report through
+      `onCommit` too, with a null `blockId`. `onCommit == null` disables whole-block drag; `onRowReorderWithinBlock
+      == null` disables within-block reorder; a block with neither is display-only. A block with no `blockHeader`
+      cannot be dragged as a whole (a warning is logged when `onCommit` is set without one). If the rendered list
+      changes mid-gesture, the gesture is cancelled.
     - Positional runtime state — selection, checked rows, the row being edited, cached row heights — is remapped
       through the move at commit, so it keeps pointing at the same rows.
     - Blocks require a stable `rowKey`: move anchors are row keys, and passing `rowBlocks` with the default
       positional key logs a warning.
-    - `TableCellScope.isRowBlockLeader` (also exposed as a context accessor inside `cell { ... }`) marks the rows
-      that may carry a drag handle: the first visible row of each block and every standalone row.
+    - The `blockHeader` slot runs in a `RowBlockHeaderScope`; a `Modifier.draggableHandle()` there is the
+      whole-block drag handle. A cell `Modifier.draggableHandle()` is the within-block (or standalone unit) handle.
     - Filtering composes: blocks derive from the rendered list, a partially hidden block drags as its visible
       rows, and the commit still describes the whole block.
     - Mutually exclusive with `state.groupBy`: while grouping is active, blocks are suppressed with a warning and
@@ -29,10 +35,13 @@ All notable changes to this project will be documented in this file.
       taking over. The read-only `TableState.rowBlocksSuppressedByGroupBy` flag surfaces the
       conflict, and the column menu's group-by item is disabled while blocks are present.
 - Added: block-preserving data helpers.
-    - `MutableList.applyRowBlockMove(move, keyOf, blockOf)` applies a commit to the source list: it relocates
-      every member of the moved block — including rows hidden by the current filter — preserving relative order,
-      and expands the insertion point to whole-block boundaries so no other block is ever split. When neither
-      anchor resolves, the list is left untouched.
+    - `MutableList.applyRowBlockMove(move, keyOf, blockOf)` applies a whole-block commit to the source list: it
+      relocates every member of the moved block — including rows hidden by the current filter — preserving relative
+      order, and expands the insertion point to whole-block boundaries so no other block is ever split. When
+      neither anchor resolves, the list is left untouched.
+    - `MutableList.applyRowReorderWithinBlock(move, keyOf, blockOf)` applies a within-block commit: it relocates
+      the single moved row among its block-mates using the move's anchors; hidden block members keep their
+      relative order, and the list is left untouched when neither anchor resolves.
     - `List.sortedWithinRowBlocks(blockOf, comparator)` sorts rows within each block; units order by their
       minimal member, so blocks never fragment. The sort is stable.
     - `List.filteredWholeRowBlocks(blockOf, predicate)` filters at block granularity: a block survives whole when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,30 +2,60 @@
 
 All notable changes to this project will be documented in this file.
 
-### 1.11.0 — 2026-07-16
+### 1.11.0 — 2026-07-17
 
-- Added: `rowGroups` parameter on `Table`/`EditableTable`, taking `TableRowGroups(ranges, onMove, header)`.
-    - A range of adjacent rows can be dragged as a single unit, with the drag handle typically placed on the group's
-      first row and an optional header rendered above the block.
-    - `onMove` reports moves as row ranges (`from: IntRange`, `to: IntRange`) rather than single indices; it is
-      required when row reorder is enabled and `ranges` is non-empty.
-    - When `onMove` is set it supersedes `onRowMove`, which is then no longer invoked.
-    - `TableRowGroups` is `@Stable` and compares by identity — hold it in `remember` to keep `Table` skippable.
-    - Ignored while `state.groupBy` is active: the two describe different structures over one list, so `groupBy` wins
-      and a warning is logged.
-    - Works for both regular lazy tables and embedded table bodies; in a lazy table `onMove` fires during the drag,
-      in an embedded table once on drop.
-- Added: `List.rowGroupsOf` and `MutableList.moveRowGroup` helpers.
-    - `rowGroupsOf` derives drag-unit ranges from a flat row list, collapsing runs of adjacent rows that share a
-      non-null group id.
-    - `moveRowGroup` applies a range move to a `MutableList` with the same semantics as the `onMove` callback.
-- Added: `TableDimensions.rowGroupSpacing` and `TableColors.rowGroupContainerColor` for row group visuals.
-    - `rowGroupSpacing` (default `8.dp`) is the vertical band around a group block; `rowGroupContainerColor` tints it.
-- Changed: `TableColors` gained a required `rowGroupContainerColor` constructor parameter.
-    - Direct constructor calls must supply the new parameter.
-    - `TableDefaults.colors()` takes it as a trailing optional parameter, so existing calls keep compiling and binding
-      as before, positional ones included.
-    - `TableDimensions.rowGroupSpacing` defaults to `8.dp`, so existing `TableDimensions` construction is unaffected.
+- Added: row blocks — a `rowBlocks` parameter on `Table`, `EditableTable` and the `table-paging` adapter, taking
+  `RowBlocks(blockOf, onCommit, blockHeader)`.
+    - Blocks are declared by identity: adjacent rows whose `blockOf` returns the same non-null id render and drag
+      as one unit, with an optional header band above the block. The table derives block extents itself from the
+      same snapshot it renders — there are no index ranges to compute or keep in sync with an asynchronous
+      pipeline.
+    - The drag is managed: during a gesture the table permutes its own internal view and the consumer's data does
+      not change; on drop `onCommit` receives exactly one `RowBlockMove(blockId, movedKeys, afterKey, beforeKey)`
+      expressed in stable row keys — identical semantics in lazy and embedded tables. `rowBlocks` supersedes
+      `onRowMove`, which is then no longer invoked: standalone rows report through `onCommit` too, with a null
+      `blockId`. Without `onCommit` blocks are display-only and row drag is disabled entirely. If the rendered
+      list changes mid-gesture, the gesture is cancelled.
+    - Positional runtime state — selection, checked rows, the row being edited, cached row heights — is remapped
+      through the move at commit, so it keeps pointing at the same rows.
+    - Blocks require a stable `rowKey`: move anchors are row keys, and passing `rowBlocks` with the default
+      positional key logs a warning.
+    - `TableCellScope.isRowBlockLeader` (also exposed as a context accessor inside `cell { ... }`) marks the rows
+      that may carry a drag handle: the first visible row of each block and every standalone row.
+    - Filtering composes: blocks derive from the rendered list, a partially hidden block drags as its visible
+      rows, and the commit still describes the whole block.
+    - Mutually exclusive with `state.groupBy`: while grouping is active, blocks are suppressed with a warning and
+      row drag is disabled entirely — `onCommit` is not invoked and `onRowMove` stays superseded rather than
+      taking over. The read-only `TableState.rowBlocksSuppressedByGroupBy` flag surfaces the
+      conflict, and the column menu's group-by item is disabled while blocks are present.
+- Added: block-preserving data helpers.
+    - `MutableList.applyRowBlockMove(move, keyOf, blockOf)` applies a commit to the source list: it relocates
+      every member of the moved block — including rows hidden by the current filter — preserving relative order,
+      and expands the insertion point to whole-block boundaries so no other block is ever split. When neither
+      anchor resolves, the list is left untouched.
+    - `List.sortedWithinRowBlocks(blockOf, comparator)` sorts rows within each block; units order by their
+      minimal member, so blocks never fragment. The sort is stable.
+    - `List.filteredWholeRowBlocks(blockOf, predicate)` filters at block granularity: a block survives whole when
+      any member matches.
+- Added: row blocks in `table-paging`.
+    - Bands derive over loaded adjacent runs; an unloaded placeholder breaks a run, and a partially loaded block
+      extends as its pages arrive.
+    - Paged drop policy: a drop commits only when its landing neighbours are loaded; against a placeholder the
+      gesture snaps back and nothing is emitted. Pages loading under the held pointer do not cancel the gesture.
+    - A paged consumer applies commits in its data layer by `RowBlockMove.blockId` — it holds no materialized
+      list for `applyRowBlockMove`, and the data layer knows full block membership, including rows the client
+      never loaded.
+- Added: row block theming — `TableDimensions.rowBlockSpacing` (default `8.dp`) and
+  `TableColors.rowBlockContainerColor` (default `Color.Unspecified`, resolved to `surfaceContainerHighest` at
+  draw time). Both are trailing optional parameters, so existing construction keeps compiling, positional calls
+  included.
+- Changed: `state.setSort()` is now a warning no-op while row reorder is enabled, matching the existing
+  `initialSort` normalization — under an active sort the rendered order is a function of row values, so a reorder
+  would be unobservable; the two features cannot both apply.
+- Deprecated: `TableRowContext.isGroup`, renamed to `isInRowBlock` — "group" is the column-value grouping
+  (`groupBy`) vocabulary, which never set this flag. A read-only forwarder keeps existing customizations
+  compiling, and the flag is now actually set: it is true for rows rendered inside a row block, so
+  `TableCustomization` can style block members (previously it was always `false`).
 - Fixed: table width no longer freezes when `ColumnSpec.visible` changes after the first render.
     - `TableState.tableWidth` derives from the visible column list, but that list was a plain field, so
       Compose never saw it change and served a cached width instead. Columns shown again stayed off
@@ -34,9 +64,11 @@ All notable changes to this project will be documented in this file.
     - The stale width was only flushed by an unrelated write to `columnWidths`, so the symptom
       disappeared as soon as a column was resized, and never appeared at all where `autoWidth` writes
       those widths on every column change.
-- Added: the module's first tests, covering row groups, the row-to-unit index, the table width across
-  column hide, show and resize, and a composition-level cover that flips `ColumnSpec.visible` on a
-  live `Table` and asserts the revealed column's cell reaches the screen.
+- Added: the module's first tests, covering row blocks end to end (block derivation, the managed drag and its
+  commit event, the data helpers under seeded property harnesses, paged sources, groupBy suppression, selection
+  and editing remap), the row-to-unit index, the table width across column hide, show and resize, and a
+  composition-level cover that flips `ColumnSpec.visible` on a live `Table` and asserts the revealed column's
+  cell reaches the screen.
 
 Compare: [v1.10.0...v1.11.0](https://github.com/White-Wind-LLC/table/compare/v1.10.0...v1.11.0)
 

--- a/docs/content/guides/row-reordering.md
+++ b/docs/content/guides/row-reordering.md
@@ -104,10 +104,15 @@ the table which rows belong together, never where they are — with a `RowBlocks
 public class RowBlocks<T : Any>(
     /** Block identity; null = standalone row. Adjacent equal ids form one block. */
     public val blockOf: (T) -> Any?,
-    /** Exactly one event per completed drag gesture; null = display-only blocks (no drag). */
+    /** One event per completed whole-block drag; null = a block cannot be dragged as a unit. */
     public val onCommit: ((RowBlockMove) -> Unit)? = null,
-    /** Band content above a block. */
-    public val blockHeader: (@Composable (blockId: Any, rows: IntRange) -> Unit)? = null,
+    /** Band above a block. Its `RowBlockHeaderScope` receiver carries the whole-block drag handle:
+     *  a `draggableHandle()` here drags the entire block. A block with no header is not draggable whole. */
+    public val blockHeader: (
+        @Composable context(RowBlockHeaderScope) (blockId: Any, rows: IntRange) -> Unit
+    )? = null,
+    /** One event per within-block row reorder; null = within-block reorder disabled. */
+    public val onRowReorderWithinBlock: ((RowWithinBlockMove) -> Unit)? = null,
 )
 ```
 
@@ -135,8 +140,10 @@ in the source. The contract between them has three parts:
    your code. At the drop the table also remaps its positional runtime state — selection, checked
    rows, the row being edited, cached row heights — so they keep pointing at the rows they pointed
    at.
-3. **You get one event per gesture.** On drop, `onCommit` receives a single `RowBlockMove`
-   describing the result in **stable row keys** — identical semantics in lazy and embedded tables:
+3. **You get one event per gesture.** On drop, a whole-block drag reports a single `RowBlockMove`
+   via `onCommit`; a within-block row reorder reports a single `RowWithinBlockMove` via
+   `onRowReorderWithinBlock`. Both describe the result in **stable row keys** — identical semantics
+   in lazy and embedded tables:
 
 ```kotlin
 public class RowBlockMove(
@@ -149,9 +156,21 @@ public class RowBlockMove(
     /** Key of the row the unit now sits before; null = end. Redundant anchor for edge cases. */
     public val beforeKey: Any?,
 )
+
+public class RowWithinBlockMove(
+    /** Block the row belongs to (unchanged by the move). */
+    public val blockId: Any,
+    /** Key of the moved row. */
+    public val movedKey: Any,
+    /** Key of the visible block-mate it now sits after; null = block start. */
+    public val afterKey: Any?,
+    /** Key of the visible block-mate it now sits before; null = block end. Redundant anchor. */
+    public val beforeKey: Any?,
+)
 ```
 
-Applying that event to the source list is one call to `applyRowBlockMove` — see below.
+Applying either event to the source list is one call — `applyRowBlockMove` /
+`applyRowReorderWithinBlock` — see below.
 
 ### Declaring blocks
 
@@ -167,30 +186,48 @@ Applying that event to the source list is one call to `applyRowBlockMove` — se
 - **`rowBlocks` supersedes `onRowMove`.** Drag units are blocks, so per-row move semantics cannot
   apply: while `rowBlocks` is passed, every gesture — standalone rows included — reports through
   `onCommit` (a standalone move carries `blockId == null`), and `onRowMove` is never invoked.
-- **`onCommit == null` means display-only blocks**: bands render and row drag is disabled
-  entirely — standalone rows do not drag either, even when `onRowMove` is set.
+- **`onCommit == null` disables whole-block drag**: a block cannot be dragged as a unit (standalone
+  rows do not drag either, even when `onRowMove` is set). Within-block row reorder is independent —
+  enable it via `onRowReorderWithinBlock`; a block with neither is display-only.
 
-### Putting the handle on the leader row
+### Drag handles: the whole block from its header, rows within a block
 
-The table already knows its unit boundaries, so cell content reads
-`TableCellScope.isRowBlockLeader` — true on the first visible row of a block and on every
-standalone row, exactly the rows that may carry a drag handle:
+Dragging is split across two levels:
+
+- **The whole block** is dragged from a handle in its **header**. The `blockHeader` slot runs in a
+  `RowBlockHeaderScope`, so a `draggableHandle()` there moves the entire block:
 
 ```kotlin
-cell { _, _ ->
-    if (isRowBlockLeader) {
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier.fillMaxSize().draggableHandle(),
-        ) {
-            Icon(Icons.Default.Reorder, contentDescription = "Drag block")
-        }
+blockHeader = { blockId, _ ->
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            Icons.Default.DragIndicator,
+            contentDescription = "Drag block",
+            modifier = Modifier.draggableHandle(),
+        )
+        Text(blockId.toString())
     }
 }
 ```
 
-Any handle inside the block drags the whole block; the leader is just the conventional place for
-it.
+- **A row within a block** is dragged from a handle in its own cell. Every row carries one; the
+  drag is constrained to its block — a row can never leave it, and the move reports through
+  `onRowReorderWithinBlock`. The same cell handle drives a standalone row's move among units:
+
+```kotlin
+cell { _, _ ->
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.fillMaxSize().draggableHandle(),
+    ) {
+        Icon(Icons.Default.Reorder, contentDescription = "Drag row")
+    }
+}
+```
+
+The table wires each `draggableHandle()` to the right engine automatically — the header to the
+whole-block drag, a block row's cell to the within-block drag, a standalone row's cell to the
+unit drag. A block needs a header handle to be movable as a whole.
 
 ### Applying the commit: `applyRowBlockMove`
 
@@ -222,6 +259,24 @@ Its semantics are deliberately stronger than "move the visible rows":
 Consumers with exotic placement needs can implement their own lift from the `RowBlockMove` keys —
 the event carries everything the library knows.
 
+For a within-block reorder, the matching lift is `applyRowReorderWithinBlock`:
+
+```kotlin
+onRowReorderWithinBlock = { move ->
+    people = people.toMutableList().apply {
+        applyRowReorderWithinBlock(
+            move = move,
+            keyOf = { it.id },        // must mirror the table's rowKey
+            blockOf = { it.groupId }, // must mirror RowBlocks.blockOf
+        )
+    }
+}
+```
+
+It relocates the single moved row among its block-mates using `afterKey` (primary) / `beforeKey`
+(fallback); hidden block members keep their relative order, and the list is left untouched when
+neither anchor resolves.
+
 ### Example
 
 ```kotlin
@@ -250,16 +305,16 @@ fun BlockedPeopleTable() {
                     width(48.dp, 48.dp)
                     resizable(false)
                     cell { _, _ ->
-                        if (isRowBlockLeader) {
-                            Box(
-                                contentAlignment = Alignment.Center,
-                                modifier = Modifier.fillMaxSize().draggableHandle(),
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Reorder,
-                                    contentDescription = "Drag to reorder",
-                                )
-                            }
+                        // Every row carries a handle: a block row reorders within its block, a
+                        // standalone row reorders among units.
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier.fillMaxSize().draggableHandle(),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Reorder,
+                                contentDescription = "Drag to reorder",
+                            )
                         }
                     }
                 }
@@ -292,12 +347,29 @@ fun BlockedPeopleTable() {
                         )
                     }
                 },
+                onRowReorderWithinBlock = { move ->
+                    people = people.toMutableList().apply {
+                        applyRowReorderWithinBlock(
+                            move = move,
+                            keyOf = { it.id },
+                            blockOf = { it.groupId },
+                        )
+                    }
+                },
+                // The header carries the whole-block drag handle.
                 blockHeader = { blockId, _ ->
-                    Text(
-                        text = blockId.toString(),
-                        style = MaterialTheme.typography.labelLarge,
-                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                    )
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.DragIndicator,
+                            contentDescription = "Drag block",
+                            modifier = Modifier.draggableHandle(),
+                        )
+                        Text(
+                            text = blockId.toString(),
+                            style = MaterialTheme.typography.labelLarge,
+                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                        )
+                    }
                 },
             )
         }
@@ -417,8 +489,9 @@ fun PagedBlockedPeopleTable(
 
 `blockHeader` renders in the band above each block. It receives the block id and the block's
 current row range, and is offset by the horizontal scroll so it stays in the viewport while the
-table scrolls sideways. The library adds **no click handling** of its own — attach your own
-`Modifier.clickable` inside the slot for renaming, dissolving, or anything else:
+table scrolls sideways. The slot runs in a `RowBlockHeaderScope`, so a `Modifier.draggableHandle()`
+inside it is the whole block's drag handle. The library adds **no click handling** of its own —
+attach your own `Modifier.clickable` inside the slot for renaming, dissolving, or anything else:
 
 ```kotlin
 blockHeader = { blockId, _ ->
@@ -472,14 +545,16 @@ list is meaningless over the new one. After a drop, the table keeps the moved or
 
 ### Checklist
 
-- `TableSettings(rowReorderEnabled = true)`; the handle rendered on `isRowBlockLeader` rows.
+- `TableSettings(rowReorderEnabled = true)`; a cell `draggableHandle()` on every row (within-block /
+  unit drag) and a `draggableHandle()` in `blockHeader` for whole-block drag.
 - A **stable `rowKey`** — move anchors are row keys; the default positional key triggers a
   warning and cannot survive a move.
 - `RowBlocks` held in `remember` — it compares by identity.
 - Block members contiguous in the source list; the library warns on fragmented ids but cannot
   repair them.
-- `onCommit` applies the move to the source with `applyRowBlockMove` — with `keyOf`/`blockOf`
-  mirroring the table's `rowKey`/`RowBlocks.blockOf` — or, for paged tables, forwards the event to
-  the data layer to apply by `blockId`.
+- `onCommit` applies the whole-block move to the source with `applyRowBlockMove`, and
+  `onRowReorderWithinBlock` applies the within-block move with `applyRowReorderWithinBlock` — both
+  with `keyOf`/`blockOf` mirroring the table's `rowKey`/`RowBlocks.blockOf`, or, for paged tables,
+  forwarded to the data layer to apply by `blockId`.
 - No free sort over blocked data: `sortedWithinRowBlocks` one-shot on the source when needed.
 - `groupBy` off — blocks are suppressed while it is active.

--- a/docs/content/guides/row-reordering.md
+++ b/docs/content/guides/row-reordering.md
@@ -1,18 +1,21 @@
 # Row reordering with Reorderable
 
-The library now provides a dedicated row reordering flow powered
+The library provides a dedicated row reordering flow powered
 by [Reorderable](https://github.com/Calvin-LL/Reorderable).
 
 ![Row reordering example](../images/row-reordering.gif)
 
 - **Enable it**: set `TableSettings(rowReorderEnabled = true)`.
 - **Handle moves**: pass `onRowMove = { fromIndex, toIndex -> ... }` to `Table` or `EditableTable`.
+  With `rowBlocks` declared, gestures report through `RowBlocks.onCommit` instead and `onRowMove` is
+  never invoked — see [Row blocks](#row-blocks-dragging-adjacent-rows-as-one-unit).
 - **Enable compiler support**: add `-Xcontext-parameters` in the consuming module, because row drag handles are exposed
   through Kotlin context parameters.
 - **How context is passed**: the `cell { ... }` DSL is backed by `context(TableCellScope)`, so inside a cell you can
   call `Modifier.draggableHandle()` or `Modifier.longPressDraggableHandle()` directly.
-- **Interaction rules**: while row reorder mode is active, sorting and grouping interactions are disabled and
-  `initialSort` is ignored.
+- **Interaction rules**: while row reorder mode is active, sorting and grouping interactions are disabled:
+  `initialSort` is ignored and `state.setSort()` is a warning no-op. Under an active sort the rendered order is a
+  function of row values, so a reorder would change nothing on screen — the two features cannot both apply.
 - **Embedded support**: the same API works for embedded table bodies too.
 
 Example:
@@ -22,6 +25,7 @@ data class Person(val id: Int, val name: String)
 
 enum class PersonColumn { Handle, Name }
 
+@OptIn(ExperimentalTableApi::class)
 @Composable
 fun ReorderablePeopleTable() {
     val people = remember {
@@ -87,3 +91,395 @@ fun ReorderablePeopleTable() {
     )
 }
 ```
+
+## Row blocks: dragging adjacent rows as one unit
+
+Adjacent rows sharing an id can render and drag as one **block**: a single drag carries all of
+them, and an optional header band names the block. Blocks are declared **by identity** — you tell
+the table which rows belong together, never where they are — with a `RowBlocks` passed as
+`rowBlocks` to `Table`, `EditableTable`, or the [table-paging](../modules/table-paging.md) adapter:
+
+```kotlin
+@Stable
+public class RowBlocks<T : Any>(
+    /** Block identity; null = standalone row. Adjacent equal ids form one block. */
+    public val blockOf: (T) -> Any?,
+    /** Exactly one event per completed drag gesture; null = display-only blocks (no drag). */
+    public val onCommit: ((RowBlockMove) -> Unit)? = null,
+    /** Band content above a block. */
+    public val blockHeader: (@Composable (blockId: Any, rows: IntRange) -> Unit)? = null,
+)
+```
+
+Whether a block exists, what it is called, and how it is created or dissolved stay in your own data
+and UI. The table derives block extents, moves the block, and draws the band.
+
+### The mental model: two lists, one contract
+
+There are two lists in play:
+
+- **the source** — your single source of truth;
+- **the rendered list** — what you pass through `itemsCount`/`itemAt`, usually a filtered
+  projection of the source.
+
+Everything the table tells you is expressed in terms of the rendered list; everything you own stays
+in the source. The contract between them has three parts:
+
+1. **Blocks derive from what you render.** The table applies `blockOf` to the same snapshot it
+   renders: a maximal run of *adjacent* rows sharing a non-null id is one block, a row with a
+   `null` id is a standalone unit. There are no index ranges to compute, keep in sync, or get
+   stale — an asynchronously filtered pipeline cannot desynchronize what is derived from its own
+   output.
+2. **The drag is managed.** While a gesture is in progress the library permutes its own internal
+   view; your data does not change mid-drag, and nothing is required to happen synchronously in
+   your code. At the drop the table also remaps its positional runtime state — selection, checked
+   rows, the row being edited, cached row heights — so they keep pointing at the rows they pointed
+   at.
+3. **You get one event per gesture.** On drop, `onCommit` receives a single `RowBlockMove`
+   describing the result in **stable row keys** — identical semantics in lazy and embedded tables:
+
+```kotlin
+public class RowBlockMove(
+    /** Block id of the dragged unit; null when a standalone row moved. */
+    public val blockId: Any?,
+    /** Keys of the VISIBLE moved rows, in order. */
+    public val movedKeys: List<Any>,
+    /** Key of the row the unit now sits after, in the rendered order; null = start. */
+    public val afterKey: Any?,
+    /** Key of the row the unit now sits before; null = end. Redundant anchor for edge cases. */
+    public val beforeKey: Any?,
+)
+```
+
+Applying that event to the source list is one call to `applyRowBlockMove` — see below.
+
+### Declaring blocks
+
+- **Hold the `RowBlocks` in `remember`.** It is `@Stable` and compares **by identity** — a fresh
+  instance on every recomposition makes the `rowBlocks` argument look changed and stops `Table`
+  from skipping. Nothing in the declaration depends on the current list, so no keys are needed.
+- **A stable `rowKey` is a hard requirement.** `movedKeys`, `afterKey` and `beforeKey` are built
+  from it, and the default positional key cannot survive the move it describes. The table logs a
+  warning when `rowBlocks` is passed with the default key.
+- **Keep block members adjacent in the source.** Blocks form over adjacent rows only; the library
+  derives, warns about fragmented ids (the same id in non-adjacent runs — evidence of a foreign
+  sort or a member-splitting mutation), but cannot repair your source order.
+- **`rowBlocks` supersedes `onRowMove`.** Drag units are blocks, so per-row move semantics cannot
+  apply: while `rowBlocks` is passed, every gesture — standalone rows included — reports through
+  `onCommit` (a standalone move carries `blockId == null`), and `onRowMove` is never invoked.
+- **`onCommit == null` means display-only blocks**: bands render and row drag is disabled
+  entirely — standalone rows do not drag either, even when `onRowMove` is set.
+
+### Putting the handle on the leader row
+
+The table already knows its unit boundaries, so cell content reads
+`TableCellScope.isRowBlockLeader` — true on the first visible row of a block and on every
+standalone row, exactly the rows that may carry a drag handle:
+
+```kotlin
+cell { _, _ ->
+    if (isRowBlockLeader) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.fillMaxSize().draggableHandle(),
+        ) {
+            Icon(Icons.Default.Reorder, contentDescription = "Drag block")
+        }
+    }
+}
+```
+
+Any handle inside the block drags the whole block; the leader is just the conventional place for
+it.
+
+### Applying the commit: `applyRowBlockMove`
+
+`applyRowBlockMove` is the lift from the rendered view back to the source list:
+
+```kotlin
+onCommit = { move ->
+    people = people.toMutableList().apply {
+        applyRowBlockMove(
+            move = move,
+            keyOf = { it.id },        // must mirror the table's rowKey
+            blockOf = { it.groupId }, // must mirror RowBlocks.blockOf
+        )
+    }
+}
+```
+
+Its semantics are deliberately stronger than "move the visible rows":
+
+- it relocates **every** row whose `blockOf` equals `move.blockId` — including rows hidden by the
+  current filter, which `movedKeys` cannot name — preserving their relative order;
+- the insertion point expands to the nearest whole-block boundary in the source, so no other block
+  is ever split;
+- `afterKey` is the primary anchor; when its row is gone from the list by apply time, `beforeKey`
+  pins the destination instead; when neither anchor resolves, the list is left untouched — guessing
+  a position would reorder data the user never dragged;
+- standalone moves (`blockId == null`) relocate just the moved keys.
+
+Consumers with exotic placement needs can implement their own lift from the `RowBlockMove` keys —
+the event carries everything the library knows.
+
+### Example
+
+```kotlin
+data class Person(val id: Int, val name: String, val groupId: String? = null)
+
+enum class PersonColumn { Handle, Name }
+
+@OptIn(ExperimentalTableApi::class)
+@Composable
+fun BlockedPeopleTable() {
+    var people by remember {
+        mutableStateOf(
+            listOf(
+                Person(1, "Alice"),
+                Person(2, "Bob", groupId = "Team A"),
+                Person(3, "Carol", groupId = "Team A"),
+                Person(4, "Dave"),
+            ),
+        )
+    }
+
+    val columns =
+        remember {
+            tableColumns<Person, PersonColumn, Unit> {
+                column(PersonColumn.Handle, valueOf = { it.id }) {
+                    width(48.dp, 48.dp)
+                    resizable(false)
+                    cell { _, _ ->
+                        if (isRowBlockLeader) {
+                            Box(
+                                contentAlignment = Alignment.Center,
+                                modifier = Modifier.fillMaxSize().draggableHandle(),
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Reorder,
+                                    contentDescription = "Drag to reorder",
+                                )
+                            }
+                        }
+                    }
+                }
+
+                column(PersonColumn.Name, valueOf = { it.name }) {
+                    header("Name")
+                    cell { person, _ -> Text(person.name) }
+                }
+            }
+        }
+
+    val state =
+        rememberTableState(
+            columns = PersonColumn.entries.toImmutableList(),
+            settings = TableSettings(rowReorderEnabled = true),
+        )
+
+    // Declared once, held by identity. "Team A" renders as one block; Alice and Dave stay
+    // standalone drag units.
+    val rowBlocks =
+        remember {
+            RowBlocks<Person>(
+                blockOf = { it.groupId },
+                onCommit = { move ->
+                    people = people.toMutableList().apply {
+                        applyRowBlockMove(
+                            move = move,
+                            keyOf = { it.id },
+                            blockOf = { it.groupId },
+                        )
+                    }
+                },
+                blockHeader = { blockId, _ ->
+                    Text(
+                        text = blockId.toString(),
+                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    )
+                },
+            )
+        }
+
+    Table(
+        itemsCount = people.size,
+        itemAt = { index -> people.getOrNull(index) },
+        state = state,
+        columns = columns,
+        rowKey = { person, index -> person?.id ?: index },
+        rowBlocks = rowBlocks,
+    )
+}
+```
+
+### Sorting: within blocks only
+
+A free sort cannot compose with drag reordering. Under an active sort the rendered order is a
+function of row *values*, not of row *positions* — the view is invariant to any permutation of the
+source, so a committed move would change nothing on screen. This is a property of sorting, not a
+policy the library chose, and it is why the sort UI is locked while reorder is enabled (see the
+interaction rules above). A sort your own pipeline applies over blocked data additionally fragments
+blocks: a plain `sortedBy` interleaves rows of different blocks, tearing one logical block into
+several bands with duplicated headers; the library logs a warning naming the block id when it
+detects this.
+
+What does compose is sorting **within** blocks:
+
+```kotlin
+// Rows sort inside their block; each unit — a block or a standalone row — takes its position
+// from its minimal member, so blocks never fragment. The sort is stable.
+val sorted = people.sortedWithinRowBlocks({ it.groupId }, compareBy { it.name })
+```
+
+Apply it **one-shot to the source list** — rewrite the list, then drop the sort — rather than
+keeping it as a persistent render-time projection. A live projection re-pins unit order on every
+emission, so the next committed drag is immediately "sorted back" and looks like it did nothing.
+A pipeline that must keep the projection while a sort toggle is active has to clear the sort as
+soon as a move commits — that clear is what makes the move visible.
+
+### Filtering: hidden members travel with the block
+
+Filtering stays fully available with blocks and drag. Blocks derive from the list you render, so a
+filtered list simply produces blocks over its visible rows — hiding a middle member does not split
+a block, because the remaining members are adjacent in the rendered list. When a filter hides part
+of a block:
+
+- the block renders — and drags — as its visible rows;
+- `RowBlockMove.movedKeys` names the **visible** members only;
+- `applyRowBlockMove` still relocates the **whole** block in the source: hidden members travel with
+  it, and clearing the filter shows them at the destination.
+
+To filter at block granularity instead — a block survives in full when *any* member matches — use:
+
+```kotlin
+val displayed = people.filteredWholeRowBlocks({ it.groupId }, { it.name.contains(query) })
+```
+
+### Paged tables
+
+The `table-paging` adapter takes the same `rowBlocks` parameter with the same declaration and the
+same commit event. Bands derive over loaded adjacent runs — an unloaded placeholder breaks a band,
+and a partially loaded block extends as its pages arrive. With `onCommit` set, a drop commits only
+when its landing neighbours are loaded; against a placeholder the gesture snaps back and nothing is
+emitted. A paged consumer holds no materialized source list, so `applyRowBlockMove` does not apply:
+forward the `RowBlockMove` to your data layer and apply it there by `blockId` — the data layer
+knows full block membership, including rows the client never loaded. See
+[table-paging](../modules/table-paging.md).
+
+```kotlin
+// Person and the column definitions are the ones from the example above;
+// the Table here is the ua.wwind.table.paging adapter.
+@Composable
+fun PagedBlockedPeopleTable(
+    paging: PagingData<Person>?,
+    columns: ImmutableList<ColumnSpec<Person, PersonColumn, Unit>>,
+    viewModel: PeopleViewModel,
+) {
+    val state =
+        rememberTableState(
+            columns = PersonColumn.entries.toImmutableList(),
+            settings = TableSettings(rowReorderEnabled = true),
+        )
+
+    // The declaration is identical to the in-memory table — only what onCommit does differs.
+    val rowBlocks =
+        remember {
+            RowBlocks<Person>(
+                blockOf = { it.groupId },
+                // No materialized source list here, so applyRowBlockMove cannot run: forward the
+                // event instead. The data layer relocates the whole block by move.blockId — it
+                // knows full membership, including rows this client never loaded — and the new
+                // order flows back as refreshed pages.
+                onCommit = { move -> viewModel.moveBlock(move) },
+                blockHeader = { blockId, _ ->
+                    Text(
+                        text = blockId.toString(),
+                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    )
+                },
+            )
+        }
+
+    Table(
+        items = paging,
+        state = state,
+        columns = columns,
+        // Placeholder keys must not collide with loaded ids, so namespace the fallback.
+        rowKey = { person, index -> person?.id?.toString() ?: "_$index" },
+        rowBlocks = rowBlocks,
+    )
+}
+```
+
+### The header band
+
+`blockHeader` renders in the band above each block. It receives the block id and the block's
+current row range, and is offset by the horizontal scroll so it stays in the viewport while the
+table scrolls sideways. The library adds **no click handling** of its own — attach your own
+`Modifier.clickable` inside the slot for renaming, dissolving, or anything else:
+
+```kotlin
+blockHeader = { blockId, _ ->
+    Text(
+        text = blockId.toString(),
+        modifier = Modifier
+            .clickable { renameGroup(blockId.toString()) }
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+    )
+}
+```
+
+### Visuals
+
+- `TableDimensions.rowBlockSpacing` (default `8.dp`) — the vertical gap around a block.
+- `TableColors.rowBlockContainerColor` — the tint painted behind it. Defaults to
+  `Color.Unspecified`, which resolves to `surfaceContainerHighest` at draw time, so a `TableColors`
+  built without the parameter still gets a themed band.
+
+Rows keep their own dividers, the block's last row included; the block adds none. The tinted band
+is purely the block's **margin**, which is what makes it legible — each row paints its own opaque
+surface, so only the gap shows the tint.
+
+A block always **opens** with a band — the header when configured, otherwise a `rowBlockSpacing`
+gap — and **closes** with a gap only when the next unit is not a block. Two adjacent blocks
+therefore get exactly one band between them instead of two stacked into a single fat slab, and a
+block at either end of the list still keeps its outer band.
+
+To style the rows *inside* a block, use `TableRowContext.isInRowBlock` from your
+`TableCustomization` — it is true exactly for block member rows.
+
+### Interaction with `groupBy`
+
+`rowBlocks` and `state.groupBy` describe two different structures over one list, so they do not
+compose: while `groupBy` is active, `rowBlocks` is **suppressed** — rows render with no block
+structure or band, a warning is logged, and row drag is disabled entirely: `onCommit` is not
+invoked, and `onRowMove` stays superseded rather than taking over. `groupBy` wins because refusing
+a grouping menu click with an exception would be worse. The conflict is surfaced on both sides:
+
+- `TableState.rowBlocksSuppressedByGroupBy` is true while the suppression is active, so your UI can
+  explain why blocks disappeared instead of leaving them to vanish silently;
+- the column menu's group-by item is disabled while the table derives at least one block, so the
+  suppression cannot be triggered by a stray menu click.
+
+### External changes during a drag
+
+If the rendered list changes mid-gesture — an external update arriving through your pipeline — the
+gesture is cancelled and the view resets to the new list: swap geometry computed against the old
+list is meaningless over the new one. After a drop, the table keeps the moved order optimistically
+(no snap-back) until your applied move flows back through the data you render.
+
+### Checklist
+
+- `TableSettings(rowReorderEnabled = true)`; the handle rendered on `isRowBlockLeader` rows.
+- A **stable `rowKey`** — move anchors are row keys; the default positional key triggers a
+  warning and cannot survive a move.
+- `RowBlocks` held in `remember` — it compares by identity.
+- Block members contiguous in the source list; the library warns on fragmented ids but cannot
+  repair them.
+- `onCommit` applies the move to the source with `applyRowBlockMove` — with `keyOf`/`blockOf`
+  mirroring the table's `rowKey`/`RowBlocks.blockOf` — or, for paged tables, forwards the event to
+  the data layer to apply by `blockId`.
+- No free sort over blocked data: `sortedWithinRowBlocks` one-shot on the source when needed.
+- `groupBy` off — blocks are suppressed while it is active.

--- a/docs/content/modules/table-core.md
+++ b/docs/content/modules/table-core.md
@@ -18,6 +18,8 @@ row selection, i18n, styling/customization, and dynamic or fixed row height.
 - Footer row with customizable content per column (totals, averages, summaries); supports pinned and scrollable modes.
 - Drag & drop to reorder columns in the header.
 - Row reordering powered by Reorderable with custom drag handles inside cell content.
+- Row blocks: adjacent rows sharing a block id render and drag as one unit, with an optional header band above the
+  block and a single key-based commit event per drag.
 - Column resize via drag with per‑column min width.
 - Filters: text, number (int/double, ranges), boolean, date, enum (single/multi; IN/NOT IN/EQUALS) with built‑in
   `FilterPanel`.

--- a/docs/content/modules/table-paging.md
+++ b/docs/content/modules/table-paging.md
@@ -14,3 +14,55 @@ fun PeoplePagingTable(paging: PagingData<Person>) {
 ```
 
 There is also `LazyListScope.handleLoadState(...)` to render loading/empty states.
+
+## Row blocks
+
+The adapter forwards the same `rowBlocks: RowBlocks<T>?` parameter as the core table, with the same
+declaration and the same commit event — see the
+[row blocks guide](../guides/row-reordering.md#row-blocks-dragging-adjacent-rows-as-one-unit).
+What differs is what paging can and cannot know:
+
+- **Bands derive over loaded runs.** Block extents are derived from loaded adjacent rows on each
+  snapshot; an unloaded placeholder breaks a run, so a partially loaded block renders a partial
+  band that extends as its pages arrive.
+- **Display-only without `onCommit`.** Blocks render their bands; nothing drags as a block.
+- **Paged drop policy.** With `onCommit` set, a drop commits only when the landing neighbours are
+  loaded — their keys anchor the move. Against a placeholder the gesture cancels and the block
+  snaps back to its origin; no event is emitted. Holding the drag over the landing spot is the
+  natural retry: rendering the placeholders there is what makes their page load. Pages loading
+  under the held pointer do not cancel the gesture.
+- **A partially loaded block drags as its loaded fragment.** `RowBlockMove.movedKeys` carries
+  loaded members only.
+- **No client-side list apply.** `applyRowBlockMove` needs the materialized source list, which a
+  paged consumer does not hold. The commit event is semantic — `blockId` plus key anchors — so
+  forward it to your data layer and apply the move there by `blockId`: the data layer knows full
+  block membership, including rows the client never loaded.
+
+The adapter call has the same shape as the core table; only `onCommit` differs — it forwards to the
+data layer instead of applying to a local list:
+
+```kotlin
+val rowBlocks =
+    remember {
+        RowBlocks<Person>(
+            blockOf = { it.teamId },
+            // No materialized list for applyRowBlockMove: the data layer relocates the whole
+            // block by move.blockId — it knows full membership, including rows never loaded
+            // here — and the new order arrives back as refreshed pages.
+            onCommit = { move -> viewModel.moveBlock(move) },
+            blockHeader = { blockId, _ -> Text(blockId.toString()) },
+        )
+    }
+
+Table(
+    items = paging,
+    state = state,
+    columns = columns,
+    // Placeholder keys must not collide with loaded ids, so namespace the fallback.
+    rowKey = { person, index -> person?.id?.toString() ?: "_$index" },
+    rowBlocks = rowBlocks,
+)
+```
+
+As in the core table, blocks require a stable `rowKey` (the default positional key triggers a
+warning), and `RowBlocks` should be held in `remember`.

--- a/docs/content/reference/core-api.md
+++ b/docs/content/reference/core-api.md
@@ -86,20 +86,25 @@ column(PersonField.Name, valueOf = { it.name }) {
     - `TableDimensions`: `defaultColumnWidth`, `defaultRowHeight`, `footerHeight`, `checkBoxColumnWidth`,
       `verticalDividerThickness`, `verticalDividerPaddingHorizontal`, `rowBlockSpacing`.
     - `TableColors`: via `TableDefaults.colors(...)`.
-- **Row blocks**: `rowBlocks = RowBlocks(blockOf, onCommit, blockHeader)` makes adjacent rows sharing a non-null
-  `blockOf` id render and drag as one unit — see
+- **Row blocks**: `rowBlocks = RowBlocks(blockOf, onCommit, blockHeader, onRowReorderWithinBlock)` makes adjacent
+  rows sharing a non-null `blockOf` id render and drag as one unit — see
   [Row reordering](../guides/row-reordering.md#row-blocks-dragging-adjacent-rows-as-one-unit).
     - Declared by identity: the table derives block extents itself from the snapshot it renders; there are no
       index ranges to maintain. Hold the `RowBlocks` in `remember` (identity equality); a stable `rowKey` is
       required (the default positional key triggers a warning).
-    - `onCommit(move: RowBlockMove)`: exactly one event per completed drag gesture, expressed in stable row keys
-      (`blockId`, `movedKeys`, `afterKey`, `beforeKey`); `null` makes blocks display-only — bands render and row
-      drag is disabled entirely, standalone rows included. Apply the event to an in-memory list with
-      `MutableList<T>.applyRowBlockMove(move, keyOf, blockOf)` — it relocates the whole block, hidden members
-      included, and never splits another block.
-    - Supersedes `onRowMove`: while `rowBlocks` is passed, every gesture — standalone rows included — reports
-      through `onCommit` (a standalone move carries `blockId == null`), and `onRowMove` is never invoked.
-    - `blockHeader(blockId, rows)`: optional content drawn in the band above the block, pinned to the viewport.
+    - `onCommit(move: RowBlockMove)`: one event per completed **whole-block** drag, expressed in stable row keys
+      (`blockId`, `movedKeys`, `afterKey`, `beforeKey`); `null` disables whole-block drag (standalone rows do not
+      drag either). Apply the event to an in-memory list with `MutableList<T>.applyRowBlockMove(move, keyOf,
+      blockOf)` — it relocates the whole block, hidden members included, and never splits another block.
+    - `onRowReorderWithinBlock(move: RowWithinBlockMove)`: one event per **within-block** row reorder
+      (`blockId`, `movedKey`, `afterKey`, `beforeKey`); every row carries a handle and reorders only within its
+      block. `null` disables within-block reorder. Apply with `MutableList<T>.applyRowReorderWithinBlock(move,
+      keyOf, blockOf)`.
+    - Supersedes `onRowMove`: while `rowBlocks` is passed, every whole-block/unit gesture reports through
+      `onCommit` (a standalone move carries `blockId == null`), and `onRowMove` is never invoked.
+    - `blockHeader(blockId, rows)`: optional band content above the block, pinned to the viewport. It runs in a
+      `RowBlockHeaderScope`, so a `Modifier.draggableHandle()` there is the **whole-block** drag handle — a block
+      needs one to be draggable as a whole.
     - Ordering helpers over consumer data: `List<T>.sortedWithinRowBlocks(blockOf, comparator)` (blocks never
       fragment) and `List<T>.filteredWholeRowBlocks(blockOf, predicate)` (a block survives whole when any member
       matches).
@@ -107,7 +112,7 @@ column(PersonField.Name, valueOf = { it.name }) {
       invoked and `onRowMove` stays superseded); the read-only flag
       `TableState.rowBlocksSuppressedByGroupBy` surfaces the conflict, and the column menu's group-by item is
       disabled while blocks are present.
-    - `TableCellScope.isRowBlockLeader` marks the rows that may carry a drag handle;
+    - A cell `Modifier.draggableHandle()` reorders a block row within its block (or a standalone row among units);
       `TableRowContext.isInRowBlock` lets `TableCustomization` style block members;
       `TableColors.rowBlockContainerColor` tints the band.
 

--- a/docs/content/reference/core-api.md
+++ b/docs/content/reference/core-api.md
@@ -3,7 +3,8 @@
 - **Composable `Table<T, C>`**: renders header and virtualized rows for read-only tables (tableData = Unit).
     - **Required**: `itemsCount`, `itemAt(index)`, `state: TableState<C>`, `columns: List<ColumnSpec<T, C, Unit>>`.
     - **Slots**: `placeholderRow()`.
-    - **UX**: `onRowClick`, `onRowLongClick`, `onRowMove`, `contextMenu(item, pos, dismiss)`.
+    - **UX**: `onRowClick`, `onRowLongClick`, `onRowMove`, `rowBlocks` (supersedes `onRowMove` — see Row blocks
+      below), `contextMenu(item, pos, dismiss)`.
     - **Look**: `customization`, `colors = TableDefaults.colors()`, `icons = TableHeaderDefaults.icons()`, `strings`,
       `shape`, `border` (outer border; `null` = theme default, `TableDefaults.NoBorder` = no border).
     - **Scroll**: optional `verticalState`, `horizontalState`.
@@ -14,7 +15,8 @@
       cells.
     - All other parameters same as read-only variant.
 - **Composable `EditableTable<T, C, E>`**: renders header and virtualized rows with editing support.
-    - **Additional parameters**: `tableData: E`, `onRowMove`, `onRowEditStart`, `onRowEditComplete`, `onEditCancelled`.
+    - **Additional parameters**: `tableData: E`, `onRowMove`, `rowBlocks`, `onRowEditStart`, `onRowEditComplete`,
+      `onEditCancelled`.
     - Columns must use `ColumnSpec<T, C, E>` with `E` matching the tableData type.
 - **Columns DSL**:
     - `tableColumns<T, C, E> { ... }` produces `List<ColumnSpec<T, C, E>>` for read-only tables.
@@ -52,7 +54,8 @@ column(PersonField.Name, valueOf = { it.name }) {
 
 - **State**: `rememberTableState(columns, initialSort?, initialOrder?, initialWidths?, settings?, dimensions?)`.
     - Compatibility normalization: when `settings.rowReorderEnabled = true`,
-      `initialSort` is ignored (warning is logged).
+      `initialSort` is ignored and `state.setSort()` is a warning no-op — under an active sort a
+      reorder would be unobservable, so the two features cannot both apply.
     - Sorting: `state.setSort(column, order?)`; current `state.sort`.
     - Grouping: `state.groupBy(column)` to enable grouping; `state.groupBy(null)` to disable.
     - Column order/size: `state.setColumnOrder(order)`, `state.resizeColumn(column, Set/Reset)`,
@@ -76,9 +79,36 @@ column(PersonField.Name, valueOf = { it.name }) {
       `showHeaderDivider` (show/hide horizontal divider below header; defaults to `true`),
       `showFastFiltersDivider` (show/hide horizontal divider below fast filters row; defaults to `true`).
     - Row reorder mode notes: while `rowReorderEnabled = true`, sorting and grouping UI is disabled.
-      Filtering stays available; fast filters and active filters header continue to work.
+      Filtering stays available; fast filters and active filters header continue to work. With `rowBlocks`, note
+      that dragging a partially hidden block still relocates the whole block in the source list — hidden members
+      travel with it when the move is applied via `applyRowBlockMove` — see
+      [Row reordering](../guides/row-reordering.md#filtering-hidden-members-travel-with-the-block).
     - `TableDimensions`: `defaultColumnWidth`, `defaultRowHeight`, `footerHeight`, `checkBoxColumnWidth`,
-      `verticalDividerThickness`, `verticalDividerPaddingHorizontal`.
+      `verticalDividerThickness`, `verticalDividerPaddingHorizontal`, `rowBlockSpacing`.
     - `TableColors`: via `TableDefaults.colors(...)`.
+- **Row blocks**: `rowBlocks = RowBlocks(blockOf, onCommit, blockHeader)` makes adjacent rows sharing a non-null
+  `blockOf` id render and drag as one unit — see
+  [Row reordering](../guides/row-reordering.md#row-blocks-dragging-adjacent-rows-as-one-unit).
+    - Declared by identity: the table derives block extents itself from the snapshot it renders; there are no
+      index ranges to maintain. Hold the `RowBlocks` in `remember` (identity equality); a stable `rowKey` is
+      required (the default positional key triggers a warning).
+    - `onCommit(move: RowBlockMove)`: exactly one event per completed drag gesture, expressed in stable row keys
+      (`blockId`, `movedKeys`, `afterKey`, `beforeKey`); `null` makes blocks display-only — bands render and row
+      drag is disabled entirely, standalone rows included. Apply the event to an in-memory list with
+      `MutableList<T>.applyRowBlockMove(move, keyOf, blockOf)` — it relocates the whole block, hidden members
+      included, and never splits another block.
+    - Supersedes `onRowMove`: while `rowBlocks` is passed, every gesture — standalone rows included — reports
+      through `onCommit` (a standalone move carries `blockId == null`), and `onRowMove` is never invoked.
+    - `blockHeader(blockId, rows)`: optional content drawn in the band above the block, pinned to the viewport.
+    - Ordering helpers over consumer data: `List<T>.sortedWithinRowBlocks(blockOf, comparator)` (blocks never
+      fragment) and `List<T>.filteredWholeRowBlocks(blockOf, predicate)` (a block survives whole when any member
+      matches).
+    - Suppressed while `groupBy` is active (warning logged; row drag is disabled entirely — `onCommit` is not
+      invoked and `onRowMove` stays superseded); the read-only flag
+      `TableState.rowBlocksSuppressedByGroupBy` surfaces the conflict, and the column menu's group-by item is
+      disabled while blocks are present.
+    - `TableCellScope.isRowBlockLeader` marks the rows that may carry a drag handle;
+      `TableRowContext.isInRowBlock` lets `TableCustomization` style block members;
+      `TableColors.rowBlockContainerColor` tints the band.
 
 For the full generated API, see the [API Reference](../api/).

--- a/docs/superpowers/specs/2026-07-15-row-group-drag-design.md
+++ b/docs/superpowers/specs/2026-07-15-row-group-drag-design.md
@@ -1,0 +1,364 @@
+# Dragging a Row Group as a Single Unit — Design
+
+**Date:** 2026-07-15
+**Status:** Approved
+**Topic:** Let a consumer declare that a range of adjacent rows moves as one draggable unit.
+
+## Problem
+
+Row reordering in `table-core` is single-row only:
+
+```kotlin
+onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)? = null
+```
+
+`TableBody` emits one `LazyColumn` item per row and wraps each in `ReorderableItem`, so the drag
+handle exposed through `TableCellScope.draggableHandle()` always drags exactly one row.
+
+Consumers that let users merge arbitrary rows into groups need the opposite: a list where some
+adjacent rows form a group, the drag handle sits on the group's first row, and dragging it carries
+the whole group. Whether a group exists, what it is called, and how it is created or dissolved are
+domain concerns owned by the consumer; the only thing the table lacks is the ability to move N
+adjacent rows as one unit and report the move in terms of a range.
+
+This is a UX improvement rather than a capability gap: a consumer whose backend relocates the whole
+group when the leader row is dragged already gets the right result today — the group simply jumps
+into place after the drop instead of following the cursor.
+
+## Goals
+
+- Declare that rows `[i..j]` form one drag unit; dragging any handle inside it moves the block.
+- Report moves with row ranges, not single indices.
+- Visually separate a group from surrounding rows.
+- No behavior change for consumers that do not use groups.
+- No fork of, or patch to, `sh.calvin.reorderable`.
+
+## Non-Goals
+
+- Library-side grouping model (`groupBy`) — it groups by column value and draws a header at each
+  value change, whereas these groups are arbitrary, header-less, and interleaved with ungrouped
+  rows. Group creation / renaming / dissolution stay in consumer UI.
+- Row indentation — done with cell padding by the consumer.
+- Lifting the "reorder excludes sorting and grouping" rule (`isInteractionLockByRowReorderEnabled`).
+- "Drop between neighbours" insert semantics with a gap indicator (see Rejected alternatives).
+
+## Decisions (locked)
+
+| Decision | Choice |
+|---|---|
+| Drag model | A group is **one lazy item** containing its rows |
+| Group declaration | One config object, `TableRowGroups(ranges, onMove, header)` — index ranges, derived from data |
+| Move callback | `TableRowGroups.onMove(from: IntRange, to: IntRange)`; `onRowMove` kept unchanged |
+| Callback index space | Row indices only — unit indices never leave the table |
+| Visual separation | Tinted band around the block; rows keep their own dividers; no horizontal insets |
+| Gap value | `TableDimensions.rowGroupSpacing: Dp = 8.dp`, `TableColors.rowGroupContainerColor` |
+| Group label | Consumer's `header` slot in the band; the library adds no click handling |
+| `groupBy` conflict | `groupBy != null` wins; row units fall back to identity + log warning |
+| Embedded tables | Supported, with settle-time callback semantics documented |
+| Tests | Apply `ua.wwind.convention.test` to `table-core` (its first tests) |
+
+## Rejected alternatives
+
+**Drag the leader row; let the consumer move the block.** The cheapest-looking option does not work.
+`ReorderableLazyCollectionState.onDrag()` picks a target with `shouldItemMove`, invokes `onMove`
+mid-drag, then predicts the dragged item's new offset as
+`(target.offset + target.size) - dragging.size`. That formula holds only for a two-neighbour swap; if
+the consumer moves N rows per callback, the leader jumps to a wrong offset until `layoutInfo`
+catches up. Worse, the group's other rows remain separate reorderable items whose centres fall
+inside the leader's drag rect, so the library offers them as targets — the group would reorder
+against itself. Filtering them out requires `shouldItemMove`, which is a private constructor
+parameter not exposed by `rememberReorderableLazyListState`, i.e. a fork. And the non-leader rows
+still would not follow the cursor.
+
+**A custom drag engine in `table-core`.** Full control, including insert semantics with a drop
+indicator, at the price of reimplementing ~800 lines of edge autoscroll, dynamic heights, RTL, and
+pointer handling across four platforms. Not justified by one non-blocking UX task. If insert
+semantics are ever needed, they can be built on top of this design without undoing it.
+
+## Architecture
+
+### Row units
+
+A **unit** is either a single row or a `rowGroups` range. `RowUnitIndex` translates between row
+indices (the public index space) and unit indices (the `LazyColumn` index space):
+
+```kotlin
+@Immutable
+internal class RowUnitIndex private constructor(
+    private val starts: IntArray,           // group start rows, ascending
+    private val ends: IntArray,             // group end rows, inclusive
+    private val collapsedBefore: IntArray,  // sum of (len - 1) over groups to the left
+    val unitCount: Int,
+) {
+    fun unitOf(rowIndex: Int): Int          // 3 -> 1  (row 3 inside group 2..4)
+    fun rowsOf(unitIndex: Int): IntRange    // 1 -> 2..4
+    fun isGroup(unitIndex: Int): Boolean
+}
+```
+
+Memory is `O(number of groups)`, not `O(rows)` — a 100k-row table pays nothing for having two
+groups. Lookups are binary searches over `starts` (row -> unit) and over the derived unit-space
+starts (unit -> rows).
+
+With `rowGroups` null or empty the index is **identity**: `unitCount == itemsCount`,
+`unitOf(i) == i`, `rowsOf(i) == i..i`, arrays empty, no binary search. Existing consumers execute
+the same code path as before — the absence of regressions is structural, not a promise.
+
+The index lives in `TableState` as `state.rowUnits`, assigned from `Table.kt` during composition the
+same way `visibleColumns` is. This matters practically: `ViewportUtils` and `KeyboardNavigation`
+already receive `state`, so the mapping reaches them without signature churn.
+
+It is snapshot state, unlike the `visibleColumns` field it sits beside: the prefetcher reads the
+index inside a `snapshotFlow`, which re-evaluates only when a *tracked* read changes. A plain field
+would be untracked there and would ride on the `layoutInfo` read next to it — right only while
+something else keeps scrolling.
+
+`rowGroups` validation (ascending, non-overlapping, within `itemsCount`) is a `require` in the index
+builder, matching `IndexedListAdapter` in `TableBody.kt`. The index is built under
+`remember(itemsCount, rowGroups)`, so validation runs once per change, not per frame.
+
+### Public API
+
+```kotlin
+// Table / EditableTable — ONE parameter for the whole feature
+rowGroups: TableRowGroups? = null,
+
+@Stable
+public class TableRowGroups(
+    public val ranges: ImmutableList<IntRange>,
+    public val onMove: ((from: IntRange, to: IntRange) -> Unit)? = null,
+    public val header: (@Composable (rows: IntRange) -> Unit)? = null,
+)
+
+// TableDimensions / TableColors
+val rowGroupSpacing: Dp = 8.dp
+val rowGroupContainerColor: Color
+
+// RowGroups.kt
+public fun <T> List<T>.rowGroupsOf(groupIdOf: (T) -> Any?): ImmutableList<IntRange>
+public fun <T> MutableList<T>.moveRowGroup(from: IntRange, to: IntRange)
+```
+
+One config object rather than three parameters: `Table` already carries
+`@Suppress("LongParameterList")`, and the codebase already has this vocabulary — `TableSettings`,
+`TableColors`, `TableDimensions`, `TableCustomization`. `TableRowGroups` joins that row.
+
+`@Stable`, not `@Immutable`. `@Immutable` buys only static-expression promotion, which can never fire
+here because `ranges` is derived from rendered data inside a `remember`; and it would overclaim, since
+a class holding a `@Composable` slot is not a fixed value and its equality is by identity. The repo
+draws the same line already: `TableColors` / `TableSettings` are data-class values (`@Immutable`),
+`TableCustomization` carries composables (`@Stable`).
+
+Identity equality has a consequence worth stating: **hold the instance in `remember`**. A fresh
+`TableRowGroups` each recomposition stops `Table` from skipping. This is stricter than `TableSettings`,
+whose structural equality forgives a fresh instance.
+
+`onRowMove` is untouched; existing code compiles and behaves as before. The contract is explicit:
+when row reorder is enabled, `require(rowGroups?.onMove != null || rowGroups?.ranges.isNullOrEmpty())`
+— passing groups without a move callback fails loudly instead of silently breaking the drag. With
+reorder disabled, `rowGroups` is still honoured for its visual effect and no callback is required.
+
+Ranges rather than leader indices: the table already knows the block extent it just moved, so
+returning `IntRange` costs nothing and keeps the callback self-contained. `from.first` is the leader
+index for consumers that only need it. Returning `T` values instead of indices is not an option —
+`itemAt` may return `null` for not-yet-loaded rows.
+
+**Do not collapse `to` to a single index.** A downward move inserts the block after `to.last`; passing
+only the target's leader row drops the block *inside* the target group and splits it. Upward moves
+insert at `to.first`, where the leader happens to be correct — so the mistake looks direction-specific
+and survives casual testing. This is not hypothetical: the first version of the sample made exactly
+this error.
+
+There is deliberately no `onClick` for groups. A consumer that wants interaction puts its own
+`Modifier.clickable` inside `header`, which avoids defining how a library-level group click would
+compose with row clicks and drags.
+
+Consumer usage:
+
+```kotlin
+val rows: List<PlanRow> = uiState.rows
+
+Table(
+    itemsCount = rows.size,
+    itemAt = { rows.getOrNull(it) },
+    rowGroups = remember(rows) {
+        TableRowGroups(
+            ranges = rows.rowGroupsOf { it.groupId },   // [2..4, 7..8]
+            onMove = { from, to -> vm.moveBlock(from, to) },
+            header = { range -> GroupHeader(rows[range.first].groupId) },
+        )
+    },
+)
+```
+
+Grouping, renaming and dissolving a group never touch ranges: those operations change a row's
+`groupId` in the consumer's own data, a new list arrives, and `rowGroupsOf` recomputes. Ranges are
+derived state, not state to maintain.
+
+### Rendering
+
+```kotlin
+val rowUnits = state.rowUnits
+
+items(
+    count = rowUnits.unitCount,
+    key = { unit -> val lead = rowUnits.rowsOf(unit).first; rowKey(itemAt(lead), lead) },
+) { unit ->
+    val rows = rowUnits.rowsOf(unit)
+    ReorderableItem(state = reorderState, key = /* same key */) {
+        val rowScope = remember(this) { TableItemDragScope(this) }
+        context(rowScope) { RowUnit(rows, isGroup = rowUnits.isGroup(unit), ...) }
+    }
+}
+```
+
+The unit key is the **leader row's** `rowKey`. The block moves as a whole, so the leader stays the
+leader and the key is stable across a drag — reorderable never loses the dragged item.
+
+A group unit:
+
+```kotlin
+Column(
+    modifier = Modifier
+        .width(state.tableWidth)
+        .background(colors.rowGroupContainerColor)
+        .padding(
+            top = if (rowGroupHeader != null) 0.dp else dimensions.rowGroupSpacing,
+            bottom = if (nextIsGroup) 0.dp else dimensions.rowGroupSpacing,
+        ),
+) {
+    rows.forEach { TableBodyRow(index = it, ...) }
+}
+```
+
+Three details here were each settled by looking at the real thing on screen rather than at a mockup:
+
+**Every row keeps its own divider, including the group's last one.** A divider means "this row ended";
+suppressing it inside a group leaves the last row visually open. The block therefore draws no divider
+of its own, and the rule stays uniform: rows draw dividers, blocks draw margin.
+
+**The tint is what makes the group legible, and it can only live in the margin.** Each row paints its
+own opaque `Surface`, so a background *behind* the rows is invisible. Painting it on the `Column` that
+also carries the padding means the rows cover the middle while the gap bands show the tint — that band
+is the group's boundary. A bare gap with no tint disappears on a dark theme.
+
+**A block always opens with a top band and closes with a bottom gap only when the next unit is not a
+group.** Symmetric padding stacks between adjacent blocks — 8dp + 8dp of tinted band merged into one
+slab, erasing the boundary it exists to draw. The band that opens a block is the header when one is
+configured, so it is the *bottom* gap that gives way: suppressing the top instead would leave the
+second of two adjacent blocks nameless. `nextIsGroup` comes from `rowUnits.isGroup(unit + 1)`, so
+exactly one band separates any two units and a block at either end of the list keeps its outer band.
+
+A single-row unit takes the existing branch unchanged. The wrapper is pure vertical composition and
+adds **no horizontal insets** — this is load-bearing, not cosmetic: horizontal padding would shift
+group rows relative to the header. Column widths (`state.resolveColumnWidth`) and column order
+(`state.columnOrder`) live in `TableState` and are read per row per render, so column resizing and
+column reordering are unaffected. `ApplyAutoWidthEffect` only reads
+`visibleItemsInfo.isNotEmpty()` — no index arithmetic — so units are invisible to auto-width.
+
+A group of one row stays a group: gap and drag still apply.
+
+Callback translation:
+
+```kotlin
+rememberReorderableLazyListState(verticalState) { from, to ->
+    val fromRows = rowUnits.rowsOf(from.index)   // from.index is a unit index
+    val toRows = rowUnits.rowsOf(to.index)
+    onRowsMove?.invoke(fromRows, toRows) ?: onRowMove?.invoke(fromRows.first, toRows.first)
+}
+```
+
+**Constraint:** `rowGroups` must be derived from the same data snapshot as `itemAt`. In a
+`LazyColumn`, reorderable invokes `onMove` *during* the drag and waits for `layoutInfo` to change,
+so the consumer mutates its list synchronously and `rowGroups` must recompute in the same
+recomposition. Groups lagging the data by even one frame desynchronise unit boundaries from rows and
+break the drag. `remember(rows) { rows.rowGroupsOf { it.groupId } }` is the supported pattern;
+hand-maintained range state is not.
+
+### Embedded path
+
+`TableBodyEmbedded` renders every row eagerly through `ReorderableColumn`, which takes the backing
+list and reports `onSettle(fromIndex, toIndex)` **on drop**, not during the drag. The same
+`RowUnitIndex` applies: `IndexedListAdapter` is built over units instead of rows, each unit renders
+its rows in a `Column`, and `onSettle`'s unit indices translate through `rowsOf(...)` exactly as in
+the lazy path. `rowGroups` therefore means the same thing in both modes.
+
+The live-vs-settle difference is reorderable's, not ours, and it already applies to `onRowMove`
+today: in a `LazyColumn` the callback fires repeatedly mid-drag and the consumer must mutate
+synchronously; in an embedded table it fires once, after the drop. The design documents this
+asymmetry rather than hiding it, because for `TableRowGroups.onMove` it decides whether the consumer
+needs an optimistic in-drag move at all.
+
+### Index mapping
+
+Three places currently assume lazy-item index == row index. Each is fixed with one `state.rowUnits`
+call:
+
+- `ViewportUtils.ensureRowFullyVisible` — `visibleItemsInfo.firstOrNull { it.index == index }` and
+  `animateScrollToItem(index)` take `unitOf(index)`. Height estimates come from per-row
+  `rowHeightsPx` and under-count a group's gaps; the function already corrects the scroll from
+  actual `info.offset` afterwards, so this is a deliberate approximation, not a defect.
+- `KeyboardNavigation` PageUp/PageDown — `fullyVisible` counts visible lazy items (units) but is
+  added to a row index. Correct target: `rowsOf(unitOf(currentRow) ± fullyVisible).first`, clamped.
+- `TableViewportPrefetcher` — `lastVisible + 1` is the next *unit*; use
+  `rowsOf(lastVisibleUnit).last + 1`.
+
+`TableActiveFilters` needs no change: its `LazyRow` scrolls filter chips and clamps to
+`activeFilters.size`, an index space of its own that never touched rows.
+
+`rowGroups` and `state.groupBy` describe two different structures over one list. While reorder is
+on, the grouping menu is locked; with reorder off a user could group by column on top of
+`rowGroups`. Throwing from a menu click handler is unacceptable, so `groupBy != null` wins: row
+units fall back to identity, the gap disappears, rows render normally, and a warning is logged.
+
+## Testing and verification
+
+`table-core` has no tests today. Applying the existing `ua.wwind.convention.test` plugin is one line
+in `table-core/build.gradle.kts` and adds no new catalog entries.
+
+`commonTest` covers where the off-by-ones live:
+
+- `RowUnitIndexTest` — identity without groups; group at start / end / adjacent groups; single-row
+  group; round-trip `rowsOf(unitOf(row)).contains(row)` for every row; `require` failures on
+  overlap, wrong order, out-of-bounds.
+- `RowGroupsTest` — `rowGroupsOf` collapses only *adjacent* runs of an equal non-null `groupId`
+  (two disjoint runs of the same id yield two ranges — documented behavior, not a bug); `null` never
+  groups.
+- `MoveRowGroupTest` — block up, block down, to either edge, no-op, swapping two groups.
+
+Unit tests only prove the arithmetic. The feature is done when the real surface is driven: a
+`table-sample` demo with two groups among plain rows, run on the desktop target, dragging a group by
+its leader handle and observing that the block follows the cursor rather than jumping, lands between
+neighbours intact, shows the gap — and that a table *without* `rowGroups` behaves exactly as before.
+The same demo is driven a second time with `embedded = true` to exercise the settle-time path. The
+demo doubles as the API showcase for the docs.
+
+## Rollout
+
+- Minor version bump; `CHANGELOG.md` entry.
+- `docs/content/guides/row-reordering.md` gains a group section: `TableRowGroups` and its three
+  members, the `remember` requirement, the derived-state constraint, the "don't collapse `to`"
+  warning, the live-vs-settle callback difference, and the `groupBy` conflict rule.
+- KDoc on the new public API (Dokka publishes it).
+
+## Known limitations
+
+- Keyboard navigation to a row inside a group scrolls to the block, not the row.
+- A group's rows are not individually lazy: a very large group composes as one item.
+- No drop indicator between neighbours; drops remain swap-based (see Rejected alternatives).
+- **The embedded-table group path is verified by compilation only.** `TableBodyEmbedded` routes groups
+  through `ReorderableColumn`'s settle-time `onSettle`, and the index translation is the same
+  `RowUnitIndex` the scrolling path uses — but no test covers it and nobody has driven it on screen.
+  The scrolling path was verified by hand and produced four rendering defects that no test caught, so
+  this is a real gap, not a formality. It is also the less defended of the two paths:
+  `ReorderableColumn` captures `onSettle` once and keys its state on the list by structural equality,
+  where `rememberReorderableLazyListState` wraps the callback in `rememberUpdatedState`. Anything the
+  callback reads must therefore be routed through state rather than captured — review found exactly
+  this defect here, since a list of group leaders can compare equal across a change to `RowUnitIndex`.
+- `TableColors.rowGroupContainerColor` has no default value, so constructing `TableColors` directly is
+  source-breaking. Nothing in this repo does — only `TableDefaults.colors()` builds it, with named
+  arguments — but external code need not be so lucky, which is what the CHANGELOG note is for. The
+  factory takes the new colour as a *trailing* optional parameter: every parameter it has is a
+  `Color`, so inserting one in the middle would leave positional calls compiling while silently
+  rebinding the colours after it. `TableDimensions.rowGroupSpacing` defaults and is therefore
+  compatible.

--- a/docs/superpowers/specs/2026-07-17-row-blocks-nested-drag-design.md
+++ b/docs/superpowers/specs/2026-07-17-row-blocks-nested-drag-design.md
@@ -1,0 +1,216 @@
+# Row blocks: nested drag (within-block reorder + header block handle)
+
+**Status:** design, awaiting review. This is an increment on top of the row-blocks feature
+(`RowBlocks`, `RowBlocksState`, `RowUnit`) that is not yet released — so its public API may be
+reshaped freely, without breaking-change concerns. Lands as a single commit on top of the existing
+two branch commits (width fix + row-blocks feature); the spec rides in that same commit (no
+standalone `docs(...)` commit).
+
+## Goal
+
+Split row dragging into two independent levels:
+
+1. **Whole-block drag** moves from the block's **leader row** to the block's **header band**. The
+   header carries the drag handle for the whole block.
+2. **Within-block drag** is new: every row inside a block carries its own handle and can be
+   reordered, but only **within its own block** — a row can never leave its block.
+
+Standalone rows (no block id) are unchanged: they reorder as top-level units via their own row
+handle.
+
+## Interaction model
+
+Two nested reorder levels:
+
+| Level | Reorders | Trigger | Commit |
+|---|---|---|---|
+| Outer | units: standalone rows + whole blocks | standalone row → its row handle; block → **header handle** | `onCommit(RowBlockMove)` (unchanged) |
+| Inner | rows within one block | **every** row's handle | new `onRowReorderWithinBlock(RowWithinBlockMove)` |
+
+Behavior changes vs. the current feature:
+
+- The whole-block handle **moves off the leader row onto the header**. A block with no `blockHeader`
+  cannot be dragged as a whole (only its rows reorder internally). A dev warning fires when
+  `onCommit != null` but `blockHeader == null` (whole-block moves are impossible).
+- **Every** row of a block gets a handle now (within-block reorder), leader included.
+- `TableCellScope.isRowBlockLeader` is **removed**. It existed only to gate the leader-row handle,
+  which no longer exists as a concept; keeping a meaningless "leader" flag in the first release of
+  this API would only mislead. `TableRowContext.isInRowBlock` (used for row styling) stays.
+
+## Why nested engines (rejected alternatives)
+
+- **Flat row-level engine that rejects cross-block moves.** Re-introduces the v1 positional
+  geometry the current design deliberately escaped: vetoing individual moves in `onMove` desyncs the
+  reorder engine's predicted offset. Rejected.
+- **A separate managed state per block.** Duplicates the hard-won `reconcile` / optimistic-hold /
+  `settle` machinery of `RowBlocksState`. Rejected in favor of reusing one permutation.
+
+A nested `ReorderableColumn` gives the "row never leaves its block" constraint for free: the inner
+column contains only that block's rows, so the engine physically cannot move a row out of it.
+
+## Public API (`table-core/src/commonMain/kotlin/ua/wwind/table/RowBlocks.kt`)
+
+```kotlin
+@Stable
+public class RowBlocks<T : Any>(
+    public val blockOf: (T) -> Any?,
+    public val onCommit: ((RowBlockMove) -> Unit)? = null,
+    // Header slot now receives a scope carrying the whole-block drag handle:
+    public val blockHeader: (
+        @Composable context(RowBlockHeaderScope) (blockId: Any, rows: IntRange) -> Unit
+    )? = null,
+    // NEW: one event per completed within-block gesture; null disables within-block reorder.
+    public val onRowReorderWithinBlock: ((RowWithinBlockMove) -> Unit)? = null,
+)
+
+/** One completed within-block gesture: a single row moved among its block-mates. Anchors are the
+ *  visible neighbours inside the same block; null anchors mean the block's edge. */
+public class RowWithinBlockMove(
+    public val blockId: Any,
+    public val movedKey: Any,
+    public val afterKey: Any?,   // key of the visible row it now sits after within the block; null = block start
+    public val beforeKey: Any?,  // redundant anchor; null = block end
+)
+```
+
+`RowBlockHeaderScope : TableItemScope` is a distinct scope type (NOT a supertype of
+`TableCellScope`) so that a `Modifier.draggableHandle()` call inside the header binds unambiguously
+to the outer unit engine, while a `draggableHandle()` inside a cell binds to whatever engine that
+row is rendered under. It exposes a `context(RowBlockHeaderScope) fun Modifier.draggableHandle(...)`
+convenience mirroring the cell one.
+
+### Apply helper (`RowBlocks.kt`)
+
+```kotlin
+/** Lifts a within-block move to the SOURCE list. Relocates the single moved row among its
+ *  block-mates; block members hidden by the current filter keep their relative order, and the moved
+ *  row lands adjacent to the resolved visible anchor. Leaves the list untouched when neither anchor
+ *  resolves. */
+public fun <T> MutableList<T>.applyRowReorderWithinBlock(
+    move: RowWithinBlockMove,
+    keyOf: (T) -> Any,
+    blockOf: (T) -> Any?,
+)
+```
+
+Anchor resolution mirrors `applyRowBlockMove`: `afterKey` is primary, `beforeKey` the fallback for
+when the primary anchor is filtered out. Unlike `applyRowBlockMove` the moved set is a single key,
+and the insertion point is **not** expanded to a whole-block boundary — the row lands immediately
+adjacent to its in-block anchor.
+
+## Managed permutation (`table-core/.../state/RowBlocksState.kt`)
+
+Reuse the existing `viewOrder` / `upstream` / `reconcile` / optimistic-hold / `Derived` snapshot
+machinery. Additions:
+
+- A gesture-kind discriminator so `settle()` knows whether the completed gesture was a whole-block
+  move (emit `RowBlockMove` via `onCommit`) or a within-block move (emit `RowWithinBlockMove` via
+  `onRowReorderWithinBlock`).
+- `applyRowMoveWithinBlock(fromView: Int, toView: Int)`: permutes `viewOrder` **only within a single
+  run** (`moveRowGroup` with single-row ranges). Both endpoints must lie in the same run; a call that
+  would cross a run boundary is dropped (defensive — the inner engine cannot generate one). Because
+  every row keeps its block id, `derive()` recomputes identical runs — blocks never fragment from a
+  within-block move.
+- Within-block `settle()`: reads the dragged row's current view position, derives `blockId` and the
+  in-block neighbour keys (or nulls at the block's first/last visible row), emits the move, keeps the
+  optimistic order (no snap-back) until the consumer's applied move flows back through `reconcile`.
+- Paged policy for within-block mirrors the whole-block one: if a needed in-block landing neighbour is
+  still a placeholder, refuse the drop, snap back, bump `refusedDropCount`, emit nothing.
+
+The inner reorder is "managed" exactly as the outer embedded path is: the nested `ReorderableColumn`
+keys its engine state on the block's row list; `applyRowMoveWithinBlock` mutates `viewOrder`
+synchronously so the block's rows recompose in the new order and the engine's post-move layout read
+finds its prediction already satisfied.
+
+## Rendering (`table-core/.../component/body/RowUnit.kt`, `TableBody.kt`)
+
+For a **block** unit `RowUnit` renders:
+
+1. The **header band** under the **outer** unit scope (the ambient `TableItemScope` from the outer
+   `ReorderableItem` / `ReorderableColumn` item), passed into the `blockHeader` slot as
+   `RowBlockHeaderScope`. `draggableHandle()` there drives the whole-block (outer) gesture.
+2. A nested **`ReorderableColumn`** over the block's rows. Each row is rendered under the **inner**
+   scope; a `draggableHandle()` in a row cell drives the within-block (inner) gesture. The inner
+   column's `onSettle` calls `blocks.applyRowMoveWithinBlock(...)` then `blocks.settle()`, with the
+   same `gestureRemap`/height-eviction handling the outer settle uses.
+
+For a **standalone** unit `RowUnit` is unchanged: one row under the outer scope, its cell handle
+drives the outer gesture.
+
+Both outer paths get the nested column: the lazy `TableBody` (outer = `ReorderableItem` in a
+`LazyColumn`) and the embedded `TableBodyEmbedded` (outer = `ReorderableColumn`). Nesting a
+`ReorderableColumn` inside an outer `ReorderableItem` is the primary technical risk (see below).
+
+Inner autoscroll is bounded to the block's own height and is not expected to be needed; if the nested
+engine's autoscroll fights the outer list scroll it will be disabled for the inner column.
+
+The `isInRowBlock` / `isRowBlockLeader` params threaded through `TableBodyRow` / `TableRowItem` /
+`TableViewportPrefetcher` are simplified: `isInRowBlock` stays (row styling); the `isRowBlockLeader`
+param and its plumbing are removed.
+
+## Filtering & paging semantics (within-block)
+
+- **Filtering:** a within-block move reorders the moved **visible** row relative to its visible
+  block-mates. Hidden members of the block keep their relative order; on lift-to-source the moved row
+  is inserted immediately adjacent to the source position of the resolved visible anchor. This is the
+  within-block analogue of `applyRowBlockMove`'s anchor handling.
+- **Paging:** placeholder rows cannot anchor a within-block drop (their key does not exist yet); the
+  drop is refused and the view snaps back, same as the whole-block policy. Holding over the landing
+  spot loads the page and lets the retry land.
+
+## Sample (`table-sample`)
+
+- `TableColumns.kt`: drop the `if (isRowBlockLeader)` gate on the reorder-handle cell — render the
+  handle on every row when reorder is enabled. The scope wiring binds it to the correct engine.
+- `SampleApp.kt`: add `Modifier.draggableHandle()` to the `blockHeader` content so the whole block
+  drags from its header; wire `onRowReorderWithinBlock = { move -> viewModel.onEvent(RowWithinBlockMove(move)) }`.
+- `SampleViewModel.kt` + `SampleUiEvent`: new event that applies the within-block move to the master
+  list via `applyRowReorderWithinBlock`.
+
+## Docs
+
+Public docs are edited to the new API/logic directly (no v1/v2 archaeology):
+
+- `docs/content/guides/row-reordering.md`: whole-block drag is triggered from the header; document
+  within-block reorder, its handle-on-every-row model, and `applyRowReorderWithinBlock`.
+- `docs/content/reference/core-api.md`: add `onRowReorderWithinBlock`, `RowWithinBlockMove`,
+  `applyRowReorderWithinBlock`, the header scope; remove `isRowBlockLeader`.
+- `CHANGELOG.md`: fold into the unreleased row-blocks entry (still `1.11.0`) — the header-handle +
+  within-block reorder are part of the same unreleased feature, not a separate release line.
+
+## Testing
+
+- **jvmTest (unit):** `applyRowMoveWithinBlock` permutes only within a run and never fragments a
+  block; cross-run calls are dropped; within-block `settle()` emits the right `RowWithinBlockMove`
+  (anchors, edges, no-op when the row ends where it started); `applyRowReorderWithinBlock` lifts
+  correctly with hidden members and with unresolved anchors (no-op).
+- **Drive the real desktop surface** (`./gradlew :table-sample:run -PenableIos=false`) — mandatory,
+  green tests are not sufficient:
+  - Drag a row within a block: order changes inside the block, the row cannot leave the block, and
+    the commit lands the change after the pipeline applies it.
+  - Drag the block header: the whole block moves as one unit and lands intact.
+  - Standalone row drag still works; a table without blocks behaves exactly as before.
+
+## Risks
+
+1. **Nested reorder engines (primary).** `ReorderableColumn` nested inside an outer `ReorderableItem`
+   / `ReorderableColumn` may have gesture-capture or autoscroll conflicts. **Mitigation:** the first
+   implementation step is a minimal desktop spike — one block with a nested reorderable column, drag
+   an inner row, confirm the inner gesture is not hijacked by the outer engine and the block still
+   drags from its header. Validate on the real surface before building the managed within-block
+   permutation.
+2. **Within-block settle under async pipelines.** Reuses the whole-block reconcile/optimistic model;
+   covered by the paged-refusal policy above and by unit tests.
+
+## Out of scope
+
+- Cross-block row moves (explicitly disallowed).
+- Multi-row within-block selection drag (one row per within-block gesture).
+- Grouping (`groupBy`) interaction with blocks — unchanged; still mutually exclusive as documented.
+
+## Decisions (open to veto at spec review)
+
+- **(a)** Names: `onRowReorderWithinBlock` / `RowWithinBlockMove` / `applyRowReorderWithinBlock`.
+- **(b)** Remove `TableCellScope.isRowBlockLeader` entirely (unreleased; now meaningless).
+- **(c)** Within-block filtering: hidden members keep relative order; moved row lands adjacent to the
+  visible anchor.

--- a/docs/superpowers/specs/2026-07-17-row-blocks-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-17-row-blocks-redesign-design.md
@@ -1,0 +1,326 @@
+# Row blocks: managed drag redesign
+
+Supersedes `2026-07-15-row-group-drag-design.md`. That design shipped a correct render core behind a
+positional public contract; an independent five-reviewer audit traced every reported integration
+failure to that contract. This document keeps the proven core and replaces the contract.
+
+## Why the redesign
+
+The v1 public API was `TableRowGroups(ranges: List<IntRange>, onMove: (IntRange, IntRange) -> Unit,
+header)`: positional ranges over the currently rendered list, live move callbacks during the drag,
+and a hard requirement that the consumer mutates its list synchronously mid-gesture. The audit
+confirmed, by executed experiments:
+
+- **Sorting fragments blocks.** Ranges collapse adjacency; a plain `sortedBy` over a grouped list
+  renders one logical group as several bands with duplicated headers. Formally proven: under an
+  active injective sort, the view is invariant to any permutation of the source — **no drag
+  semantics exist while a sort is applied**. This is a theorem, not a policy choice.
+- **Filtered moves cannot be expressed correctly.** View-space ranges applied to the source list
+  silently move hidden rows the user never touched; the id-mapping workaround (as in the v1 sample)
+  either tears groups in the source or silently drops the move — and a dropped move is not neutral:
+  the reorder engine predicts the offset and waits on a mutex up to 1000 ms per attempt, so the drag
+  visibly freezes and snaps.
+- **The synchronous-mutation contract is unimplementable in ordinary architectures.** The v1 sample
+  itself routed moves through `MutableStateFlow -> combine -> stateIn` — an asynchronous chain —
+  violating the contract its own spec stated. If the reference consumer cannot satisfy the contract,
+  the contract is wrong.
+- **A one-frame lag between the rendered list and the declared ranges crashes the table**
+  (`require` in `RowUnitIndex.of`) — reachable by any consumer whose filter pipeline is async.
+- **Positional runtime state goes stale after a block move**: `selectedIndex`, `selectedCell`,
+  `editingRow`, `checkedIndices`, `rowHeightsPx` keep pointing at old positions.
+- **The embedded path renders the band header at width 0** (`horizontalState.viewportSize == 0`;
+  the scroll node is only attached by `draggableTable`, which the embedded path skips).
+- **Naming collides**: "group" already means column-value grouping (`groupBy`,
+  `groupContainerColor`, `ColumnSpec.groupHeader`); the drag feature reused the word one token away
+  (`rowGroupContainerColor`, `TableRowGroups.header`).
+
+The feature is unreleased, so breaking its API costs nothing now.
+
+## Locked decisions
+
+1. **The render core stays.** A block renders as ONE `LazyColumn` item; `RowUnitIndex` maps row
+   indices to unit indices and is the identity without blocks; scroll/keyboard/prefetch translate
+   through it. All of it is property-tested (bijection, coverage, footer boundary) and survives
+   unchanged. The reorder engine stays `sh.calvin.reorderable` — dragging one lazy item keeps its
+   swap-prediction geometry correct by construction.
+2. **Blocks are declared by identity, not by position.** The consumer supplies
+   `blockOf: (T) -> Any?`; the library derives adjacency runs itself, from the same snapshot it
+   renders. Stale or mismatched ranges become impossible by construction — the crash class above
+   disappears with them.
+3. **The drag is managed.** During a gesture the library mutates its own internal view permutation,
+   satisfying the engine's synchronous-layout expectation itself. The consumer's data does not
+   change mid-drag. On drop the library emits ONE semantic event. Lazy and embedded paths behave
+   identically (one event per completed gesture).
+4. **Naming: "block".** "group" remains exclusively the `groupBy` vocabulary. New API uses
+   `rowBlocks`, `RowBlocks`, `RowBlockMove`, `blockOf`, `rowBlockSpacing`,
+   `rowBlockContainerColor`.
+5. **Sorting and free drag are mutually exclusive** (theorem above). Sorting *within* blocks is a
+   library helper over consumer data. The existing reorder interaction lock is extended to be
+   consistent (see Behavior contract).
+6. **A filtered drag moves the whole block in the source list.** Hidden members travel with the
+   block, preserving relative order. This is the canonical semantics, implemented by a library
+   helper whose algorithm is property-proven (see Helpers).
+
+## Domain model
+
+- **S** — the consumer's source list (their single source of truth).
+- **V** — the list the consumer renders: `V = filter(S)` (sorting composes only via the
+  within-blocks helper; free sort is out of contract — theorem). V ⊆ S and order-preserving.
+- **Block** — a maximal run of adjacent rows in V sharing a non-null `blockOf(item)`. A row with
+  `blockOf == null` is a standalone unit. Block identity is the `blockOf` value; block *extent* in
+  V is derived by the library every time V changes.
+- **Drag unit** — a block or a standalone row; rendered as one lazy item (unchanged from v1).
+- **Move** — during the gesture, an internal permutation of units over V, owned by the library.
+  On drop, one `RowBlockMove` describing the result in stable keys.
+- **Lift** — translating the drop into S. Performed by the consumer with the provided helper
+  `applyRowBlockMove`, which needs only keys and `blockOf` — never positions.
+
+## Public API
+
+```kotlin
+// ua.wwind.table.RowBlocks.kt — ONE declaration, identical for every table kind
+
+@Stable
+public class RowBlocks<T : Any>(
+    /** Block identity; null = standalone row. Adjacent equal ids form one block. */
+    public val blockOf: (T) -> Any?,
+    /** Exactly one event per completed drag gesture; null = display-only blocks (no drag). */
+    public val onCommit: ((RowBlockMove) -> Unit)? = null,
+    /** Band content above a block. */
+    public val blockHeader: (@Composable (blockId: Any, rows: IntRange) -> Unit)? = null,
+)
+
+public class RowBlockMove(
+    /** Block id of the dragged unit; null when a standalone row moved. */
+    public val blockId: Any?,
+    /** Keys of the VISIBLE moved rows, in order. */
+    public val movedKeys: List<Any>,
+    /** Key of the row the unit now sits after, in the rendered order; null = start. */
+    public val afterKey: Any?,
+    /** Key of the row the unit now sits before; null = end. Redundant anchor for edge cases. */
+    public val beforeKey: Any?,
+)
+
+/**
+ * Applies [move] to the SOURCE list: relocates ALL rows whose blockOf equals move.blockId —
+ * including rows hidden by the current filter — preserving their relative order. The insertion
+ * point is expanded to the nearest whole-block boundary in the source, so no other block is ever
+ * split. Standalone rows (blockId == null) relocate just the moved keys.
+ */
+public fun <T> MutableList<T>.applyRowBlockMove(
+    move: RowBlockMove,
+    keyOf: (T) -> Any,
+    blockOf: (T) -> Any?,
+)
+
+// ua.wwind.table.RowBlockOrdering.kt — ordering helpers over consumer data
+
+/** Sorts rows within each block; blocks (and standalone rows) order by their minimal element.
+ *  Blocks never fragment, by construction. */
+public fun <T> List<T>.sortedWithinRowBlocks(
+    blockOf: (T) -> Any?,
+    comparator: Comparator<in T>,
+): List<T>
+
+/** Filters rows; optionally keeps every member of a block whose any member matches. */
+public fun <T> List<T>.filteredWholeRowBlocks(
+    blockOf: (T) -> Any?,
+    predicate: (T) -> Boolean,
+): List<T>
+```
+
+`RowBlocks` compares by identity — hold it in `remember`. The managed view permutation lives in an
+*internal* `RowBlocksState`, derived on every snapshot from `itemAt`/`blockOf`; consumers never
+construct or see it. Handle placement reads `TableCellScope.isRowBlockLeader: Boolean` (true on the
+first visible row of a block and on standalone rows) — replacing the v1 sample's O(n) leader
+detection. A stable `rowKey` is a documented hard requirement of block tables:
+`movedKeys`/`afterKey`/`beforeKey` are built from it, and the default index key is rejected with a
+warning when `rowBlocks` is passed.
+
+`Table`, `EditableTable` and the `table-paging` adapter all take the same parameter:
+`rowBlocks: RowBlocks<T>? = null`. The declaration, the semantics and the event type are identical
+everywhere; tables differ only in where their data lives, and therefore in what the consumer's
+`onCommit` does with the event — an in-memory consumer calls `applyRowBlockMove` on its list, a
+paged consumer forwards the event to its data layer. In the paged table, drag additionally follows
+the paged drop policy (anchor must be loaded, else the gesture snaps back — see Behavior contract /
+Paging); without `onCommit` blocks are display-only in every table kind.
+
+Theming: `TableDimensions.rowBlockSpacing` (default 8.dp) and `TableColors.rowBlockContainerColor`
+with default `Color.Unspecified`, resolved to `surfaceContainerHighest` at draw — the v1 required
+constructor parameter (a source break) is removed.
+
+v1 API (`TableRowGroups`, `rowGroupsOf`, `moveRowGroup`, `rowGroupSpacing`,
+`rowGroupContainerColor`) is deleted, not deprecated — it never shipped.
+
+## Behavior contract
+
+**Drag lifecycle.** Handle goes down → the engine swaps units → `RowBlocksState` applies each swap
+to its internal permutation synchronously (the engine's `layoutInfo` expectation is satisfied
+in-library; no timeout stalls are reachable). Drop → the state diffs the permutation against the
+pre-gesture order and emits ONE `RowBlockMove`; the permutation is kept optimistically until
+`items` changes (no snap-back). If `items` changes mid-gesture (external update), the gesture is
+cancelled and the permutation reset — documented policy.
+
+**Commit point side effects (in-library, at emit time):** `selectedIndex`, `selectedCell.rowIndex`,
+`editingRow` and `checkedIndices` are remapped through the same permutation; `rowHeightsPx` entries
+for shifted rows are cleared (cheapest correct option — heights re-measure). An active cell edit is
+completed/cancelled when a drag starts.
+
+**Sorting.** Header sort UI stays locked while reorder is enabled (as in v1) — and the lock becomes
+consistent: `state.setSort()` is normalized to a warning no-op under reorder, matching `initialSort`.
+Consumer-side sorting composes only through `sortedWithinRowBlocks`; the guide states the theorem
+plainly ("a free sort makes drag history unobservable — they cannot both apply"). If the derived
+runs show the same block id in disjoint runs (a fragmented block — evidence of a foreign sort or a
+member-splitting filter), the library logs one warning naming the id.
+
+**Filtering.** Allowed and first-class. The rendered list is the consumer's filtered V;
+`isBlockLeader` and band rendering follow V. A drag of a partially hidden block emits keys of
+visible members only; `applyRowBlockMove` relocates the whole block in S. Consumers who want
+match-whole-block filtering use `filteredWholeRowBlocks`.
+
+**groupBy.** Mutually exclusive, `groupBy` wins, warning logged (unchanged mechanics). Two
+additions: a public read-only `TableState.rowBlocksSuppressedByGroupBy: Boolean` so consumers can
+surface the conflict, and the column menu's group-by item is disabled while blocks are non-empty —
+the silent-disappearance path is closed in the UI. `onCommit` is not invoked while suppressed.
+
+**Paging.** Blocks work with `table-paging` in both display and drag modes; what paging cannot have
+is the *client-side list apply* — `applyRowBlockMove` needs the materialized source, which a paged
+consumer does not hold. The commit event itself is semantic (`blockId` + anchor keys) and needs no
+full list: paged consumers forward it to their data layer, which knows full block membership.
+
+- *Derivation*: the paging adapter accepts `blockOf: (T) -> Any?` (+ `blockHeader`, + optional
+  `onCommit`) and derives bands over loaded adjacent runs on each snapshot. An unloaded placeholder
+  breaks a run, so a partially loaded block renders a partial band that extends as pages arrive.
+  `isInRowBlock` is set for members, so they can be styled via `customization`.
+- *Drag*: allowed when `onCommit` is set. While the user holds the drag, pages under the pointer
+  load as usual, so anchors resolve naturally. **Drop policy**: if the landing neighbour is loaded,
+  the anchor keys resolve and the move commits; if it is still a placeholder, the gesture cancels
+  and the block snaps back to its origin — no event is emitted. A partially loaded dragged block
+  moves visually as its loaded fragment; `movedKeys` carries loaded members only, and the data
+  layer applies the move by `blockId`, covering members the client never loaded.
+- *Must-verify risk (test plan item)*: a page loading mid-gesture replaces placeholder index-keys
+  with item keys under the engine. The dragged row's own key is stable (it is loaded), but neighbour
+  key churn during a drag must be proven harmless in the compose harness with a fake paged source
+  before this mode ships; if it is not, the fallback policy is to cancel the gesture on page load.
+
+(v1 silently didn't forward the feature to paging at all.)
+
+**Selection/editing.** Remapped at commit (above). Documented residual: selection is positional
+between commits, as everywhere else in the table.
+
+**Keyboard/scroll/prefetch.** Unchanged from v1 (unit-aware paging, block-level `ensureRowFullyVisible`
+approximation, footer guard) — all reviewer-verified correct.
+
+## Rendering and internals
+
+- `RowUnit`, band/gap rules, `RowUnitIndex`, index translations: unchanged.
+- `TableBody` (lazy): `rememberReorderableLazyListState` callback becomes
+  `rowBlocks.applyUnitMove(from.index, to.index)`; commit fires from the drag-stop wrapper in
+  `TableItemDragScope`.
+- `TableBodyEmbedded`: `onSettle` → `applyUnitMove` + `settle()`. The `rememberUpdatedState`
+  trampoline remains (engine captures the callback once).
+- **Embedded band width fix:** `RowUnit` measures the header box with
+  `horizontalState.viewportSize.takeIf { it > 0 }?.toDp() ?: state.tableWidth` — in embedded mode
+  the scroll node is absent and the viewport is the whole table. (Same fallback documented as a
+  follow-up for the pre-existing `groupBy` header issue in embedded mode.)
+- Dead flag `TableRowContext.isGroup` (always false in v1) becomes `isInRowBlock`, set for rows
+  rendered inside a block — customization can finally style block members.
+- `moveRowGroup` survives as an `internal` view-permutation primitive with an overlap `require`.
+
+## What stays consumer-side, honestly
+
+- **P1 invariant**: every block is a contiguous run in S. The helpers preserve it and
+  `applyRowBlockMove` never breaks it, but the library cannot see S and cannot enforce it against
+  arbitrary consumer mutations. The fragmentation warning is detection, not prevention.
+- **The lift is a convention.** Where hidden members land relative to hidden neighbours of the
+  insertion point is unobservable in V; `applyRowBlockMove` picks block-boundary insertion. Other
+  placements are equally V-consistent; consumers with exotic needs implement their own lift from
+  `RowBlockMove` keys.
+- **Swap-based targeting** (no insertion indicator) is inherited from the engine. The commit event
+  is engine-agnostic, so a future insert-mode engine slots in without an API break.
+
+## Drag consistency: one atomic snapshot per frame
+
+Decision 3 (managed drag) mutates an internal `viewOrder` permutation per engine swap. The first
+desktop drag exposed a defect in *how the lazy path reads that permutation*, not in the permutation
+itself: the dragged block flew off after the first swap at normal speed (slow drags sometimes
+survived a few positions).
+
+**Root cause — a temporal read split.** The lazy `LazyColumn` item key was
+`rowKey(itemAt(leader), leader)`, where `leader` came from a `RowUnitIndex` captured at composition
+time while `itemAt` read the live `viewOrder` when the key lambda ran at measure. A swap moves
+`viewOrder` between those two reads, so the key of the *dragged* block changed for one frame →
+`LazyColumn` disposed and rebuilt that item → the drag handle nested inside it was torn down →
+`reorderable`'s handle `DisposableEffect` fired `onDragStopped` → the gesture ended. The single-row
+(no-blocks) path never hit this because its units are identity and its key reads one list; the
+embedded path never hit it because `ReorderableColumn` reports the net move once at drop, leaving
+`viewOrder` still for the whole gesture.
+
+**Fix — the derived view is one atomic object.** `RowBlocksState.derive()` now freezes the item at
+every view position into the same `Derived` value it builds `runs`/`units` from, and exposes it as
+`snapshot`. The lazy path reads `blocks.snapshot` once and draws unit boundaries, item, block id and
+key all from that single object (`snapshot.keyAt`, `snapshot.itemAt`, `snapshot.blockIdAt`). A key is
+now a pure function of a frozen snapshot: a stale measure-time invocation returns a stale-but-
+consistent key, never a torn one, so the dragged item keeps its identity across the whole gesture.
+The commit path, the semantic `RowBlockMove`, filtered-move correctness and the positional remap are
+untouched — the change is strictly *where the lazy item reads its identity from*.
+
+**Second consistency requirement — the leader test must ride the same snapshot.** With the key fixed,
+a *fast* down drag still died after one swap: the block's lazy item survived (its key was stable), but
+the drag handle nested inside it vanished. The handle is gated by `isRowBlockLeader`, which
+`TableRowItem` recomputed from `state.rowUnits` — a copy `Table` publishes from the same derivation,
+but read in a *different* scope that can lag the item's own snapshot by a frame under a fast gesture.
+For one frame the leader row failed its own is-leader test, the handle's `if (isRowBlockLeader)`
+branch left composition, and its `DisposableEffect` fired `onDragStopped`. Three independent reads of
+the permutation (the item index, the key, the leader test) is two too many. The fix threads
+`isInRowBlock`/`isRowBlockLeader` down from `RowUnit` — computed from the very `rows`/`isGroup` the
+snapshot handed it — through `TableBodyRow` into `TableRowItem`, so leader detection can never come
+from a different read than the row it gates. `state.rowUnits` stays only for offscreen prefetch and
+keyboard/scroll math, none of which gate a live handle.
+
+This is the v1 drag property ("one list, derived once") realized without the v1 contract: the single
+consistent list is the internal snapshot, and every reader on the drag path — index, key, leader
+test — resolves against it, while the drop still emits the id-based event.
+
+## Migration from the v1 branch
+
+Nothing shipped; this is an in-branch evolution, squashed to one feature commit at the end.
+Deleted: `TableRowGroups.kt`, public `rowGroupsOf`/`moveRowGroup`, `rowGroups` parameters,
+`rowGroupSpacing`/`rowGroupContainerColor`. Kept: `RowUnitIndex` (+tests), `RowUnit`,
+`TableBody` unit rendering, index translations, band visuals, docs structure. The sample loses its
+~90-line id-mapping ViewModel logic in favour of one `applyRowBlockMove` call, replaces the O(n)
+leader detection in the handle column with `TableCellScope.isRowBlockLeader`, and gains demos for
+within-block sorting and whole-block filtered moves. The sample also gains a column-visibility
+toggle (unrelated gap found during the width-fix investigation; cheap to include while the sidebar
+is open).
+
+## Test plan
+
+1. **Unit (pure):** run derivation from `blockOf` (incl. fragmented-id warning); `applyUnitMove`
+   permutations (up/down/edges/no-op/adjacent blocks); `settle()` emits exactly one event with
+   correct `movedKeys`/`afterKey`/`beforeKey` both directions; `applyRowBlockMove` property tests —
+   whole-block relocation under random filters, anchor inside a hidden foreign-block span, null
+   anchors, missing keys, S-permutation validity, no block ever fragments (port the reviewer's
+   3000-iteration harness); `sortedWithinRowBlocks` never fragments and is stable;
+   `filteredWholeRowBlocks`.
+2. **Compose harness (headless, existing infra):** blocks render with bands from `blockOf`
+   derivation; commit remaps selection/editing; groupBy suppression + flag + menu item disabled;
+   embedded band header has non-zero width; reconcile-on-external-change cancels the gesture;
+   recomposition-settle guard; **paged mode with a fake paged source** — bands extend as pages
+   "load", drop onto a placeholder cancels and emits nothing, drop onto a loaded anchor emits
+   correct keys, and neighbour key churn from a mid-gesture page load does not corrupt the drag
+   (the go/no-go check for shipping paged drag).
+3. **Real surface (desktop sample, by hand):** drag a block under an active filter with a hidden
+   middle member — the whole block relocates in the source after clearing the filter; within-block
+   sort demo; rename/ungroup flows; embedded demo — **the embedded path must be driven this time**;
+   the reviewer-confirmed freeze/snap symptom must be unreproducible.
+
+## Known limitations (carried or accepted)
+
+- Paged blocks: `applyRowBlockMove` (client-side list apply) is unavailable — commits must be
+  applied by the consumer's data layer via `blockId`; a drop onto an unloaded placeholder cancels
+  the gesture; partially loaded blocks drag as their loaded fragment until the data layer confirms.
+- A block taller than the viewport scrolls as a block; `ensureRowFullyVisible` targets the unit.
+- Large blocks compose as one item (not lazy) — cost documented; mitigations out of scope.
+- Striping (`index % 2`) runs through blocks by row index — cosmetic, unchanged.
+- Free consumer sort remains detectable but not preventable (P1/theorem above).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 # --- Project metadata ---
-version-name = "1.10.0"
-version-date = "24.06.2026"
-android-version-code = "42"
+version-name = "1.11.0"
+version-date = "16.07.2026"
+android-version-code = "43"
 
 # --- Android SDK & AGP ---
 android-compileSdk = "37"

--- a/table-core/build.gradle.kts
+++ b/table-core/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("ua.wwind.convention.compose")
     id("ua.wwind.convention.publishing")
     id("ua.wwind.convention.logging")
+    id("ua.wwind.convention.test")
 }
 
 kotlin {

--- a/table-core/build.gradle.kts
+++ b/table-core/build.gradle.kts
@@ -12,5 +12,11 @@ kotlin {
             implementation(libs.reorderable)
             implementation(libs.kotlinx.datetime)
         }
+        commonTest.dependencies {
+            implementation(libs.compose.ui.test)
+        }
+        jvmTest.dependencies {
+            implementation(compose.desktop.currentOs)
+        }
     }
 }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/RowBlockOrdering.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/RowBlockOrdering.kt
@@ -1,0 +1,58 @@
+package ua.wwind.table
+
+/**
+ * Sorts rows within each block while keeping every block whole — a plain `sortedBy` fragments
+ * blocks into duplicate bands. Each unit — a block or a standalone row — takes its position from
+ * its minimal member under [comparator], so the list still reads as sorted at unit granularity.
+ * The sort is stable both within a block and between units: ties keep their existing order, and
+ * re-applying the same sort changes nothing.
+ *
+ * With drag enabled, apply this one-shot to the SOURCE list — rewriting it — never as a persistent
+ * render-time projection. Unit order here follows [comparator], not drag history (ties excepted),
+ * so a live projection re-pins unit order after every committed block move, making the move
+ * invisible in the rendered list — the same theorem that rules out composing a free sort with drag,
+ * replayed at unit granularity.
+ */
+public fun <T> List<T>.sortedWithinRowBlocks(
+    blockOf: (T) -> Any?,
+    comparator: Comparator<in T>,
+): List<T> =
+    rowBlockRuns(blockOf)
+        .map { run -> run.sortedWith(comparator) }
+        .sortedWith(compareBy(comparator) { it.first() })
+        .flatten()
+
+/**
+ * Filters at block granularity: a block survives in full when ANY member matches, so the rendered
+ * blocks never show partially. The plain row-level filter stays first-class — hidden members simply
+ * travel with their block on a drag — this helper exists for consumers who want match-whole-block
+ * semantics instead.
+ */
+public fun <T> List<T>.filteredWholeRowBlocks(
+    blockOf: (T) -> Any?,
+    predicate: (T) -> Boolean,
+): List<T> =
+    rowBlockRuns(blockOf)
+        .filter { run -> run.any(predicate) }
+        .flatten()
+
+/**
+ * Splits the list into drag units by the same rule the table renders with: a maximal run of
+ * adjacent rows sharing a non-null block id is one unit, every other row is a singleton. Adjacency,
+ * not global grouping — a fragmented id (out-of-contract input) stays fragmented rather than being
+ * silently reordered into one place.
+ */
+private fun <T> List<T>.rowBlockRuns(blockOf: (T) -> Any?): List<List<T>> {
+    val runs = mutableListOf<MutableList<T>>()
+    var runId: Any? = null
+    for (item in this) {
+        val id = blockOf(item)
+        if (id != null && id == runId) {
+            runs.last() += item
+        } else {
+            runs += mutableListOf(item)
+            runId = id
+        }
+    }
+    return runs
+}

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/RowBlocks.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/RowBlocks.kt
@@ -5,33 +5,31 @@ import androidx.compose.runtime.Stable
 
 /**
  * Row blocks: runs of adjacent rows that render and drag as one unit, declared by identity rather
- * than by position.
+ * than by position — the library derives block extents from the same snapshot it renders, so they
+ * cannot go stale against an asynchronously filtered list. The consumer's data stays untouched
+ * during a gesture; the move arrives as one event at drop.
  *
- * The library derives block extents itself, from the same snapshot it renders — the consumer never
- * supplies index ranges, so the ranges can never go stale against an asynchronously filtered list.
- * During a drag the library permutes its own internal view; the consumer's data is untouched until
- * [onCommit] delivers exactly one [RowBlockMove] for the completed gesture.
+ * Passing a `RowBlocks` supersedes the per-row `onRowMove`: drag units are blocks, so every unit
+ * gesture reports through [onCommit] instead (a standalone move carries a null
+ * [RowBlockMove.blockId]). Dragging is split in two — the whole block moves from a handle in
+ * [blockHeader], while each row moves within its own block from its cell handle.
  *
- * Passing a `RowBlocks` supersedes the per-row `onRowMove` callback: drag units are blocks, so
- * per-row move semantics cannot apply. Every gesture — standalone rows included — reports through
- * [onCommit] (a standalone move carries a null [RowBlockMove.blockId]), `onRowMove` is never
- * invoked, and a null [onCommit] disables row drag entirely rather than falling back to it.
- *
- * Hold the instance in `remember`: it compares by identity — carrying a `@Composable` slot, it has
- * no meaningful structural equality — so a fresh instance per recomposition makes the `rowBlocks`
- * argument look changed and stops the table from skipping.
- *
- * Block tables require a stable `rowKey`: [RowBlockMove] anchors are keys, and the default
- * positional key cannot survive a move.
+ * Hold the instance in `remember`: it compares by identity, so a fresh instance per recomposition
+ * stops the table from skipping. A stable `rowKey` is required — move anchors are row keys.
  */
 @Stable
 public class RowBlocks<T : Any>(
     /** Block identity; null = standalone row. Adjacent equal ids form one block. */
     public val blockOf: (T) -> Any?,
-    /** Exactly one event per completed drag gesture; null = display-only blocks (no drag). */
+    /** One event per completed whole-block drag; null disables whole-block and standalone drag. */
     public val onCommit: ((RowBlockMove) -> Unit)? = null,
-    /** Band content above a block. */
-    public val blockHeader: (@Composable (blockId: Any, rows: IntRange) -> Unit)? = null,
+    /** Band content above a block; a `draggableHandle()` in its [RowBlockHeaderScope] drags the
+     *  whole block. A block with no header cannot be dragged as a whole. */
+    public val blockHeader: (
+        @Composable context(RowBlockHeaderScope) (blockId: Any, rows: IntRange) -> Unit
+    )? = null,
+    /** One event per within-block row reorder; null disables it. The row never leaves its block. */
+    public val onRowReorderWithinBlock: ((RowWithinBlockMove) -> Unit)? = null,
 )
 
 /**
@@ -54,20 +52,30 @@ public class RowBlockMove(
 )
 
 /**
- * Applies [move] to the SOURCE list — the lift from the rendered, possibly filtered view back to
- * the consumer's single source of truth.
+ * The result of one completed within-block drag gesture: a single row moved among its block-mates,
+ * expressed in stable keys. Anchors are the moved row's visible neighbours inside the same block; a
+ * null anchor means the block's edge (first/last visible row).
+ */
+public class RowWithinBlockMove(
+    /** Block the row belongs to (unchanged by the move). */
+    public val blockId: Any,
+    /** Key of the moved row. */
+    public val movedKey: Any,
+    /** Key of the visible block-mate the row now sits after; null = block start. */
+    public val afterKey: Any?,
+    /** Key of the visible block-mate the row now sits before; null = block end. Redundant anchor. */
+    public val beforeKey: Any?,
+)
+
+/**
+ * Applies [move] to the SOURCE list — the lift from the rendered, possibly filtered view back to the
+ * consumer's source of truth.
  *
- * Relocates ALL rows whose [blockOf] equals [RowBlockMove.blockId] — including rows hidden by the
- * current filter, which [RowBlockMove.movedKeys] cannot name — preserving their relative order.
- * The insertion point is expanded to the nearest whole-block boundary in the source, so no other
- * block is ever split: where hidden rows land relative to hidden neighbours of the anchor is
- * unobservable in the view, and block-boundary insertion is the one placement that keeps every
- * block contiguous. Standalone moves ([RowBlockMove.blockId] == null) relocate just the moved keys.
- *
- * [RowBlockMove.afterKey] is the primary anchor; when its row is gone from the list by the time
- * the move is applied, [RowBlockMove.beforeKey] pins the destination instead. When neither anchor
- * resolves the destination is unknowable, and the list is deliberately left untouched — guessing a
- * position would reorder data the user never dragged.
+ * Relocates ALL rows whose [blockOf] equals [RowBlockMove.blockId], including rows the filter hides
+ * and [RowBlockMove.movedKeys] cannot name, preserving their relative order; the insertion point
+ * expands to whole-block boundaries so no other block is split. Standalone moves relocate just the
+ * moved keys. [RowBlockMove.afterKey] is the primary anchor and [RowBlockMove.beforeKey] the
+ * fallback; with neither resolvable the list is left untouched rather than guessing a position.
  */
 public fun <T> MutableList<T>.applyRowBlockMove(
     move: RowBlockMove,
@@ -93,14 +101,9 @@ public fun <T> MutableList<T>.applyRowBlockMove(
 }
 
 /**
- * Destination in [rest] (the source minus the moved rows), or null when neither anchor resolves.
- *
- * The expansion direction follows each anchor's role in the view. [RowBlockMove.afterKey] is the
- * last visible row of the unit the drag landed behind, so hidden members of its block can only sit
- * further down in the source — the insertion walks forward past them. [RowBlockMove.beforeKey] is
- * the first visible row of the following unit, so its hidden block-mates can only sit above — the
- * insertion walks backward. Either way the filtered projection shows the moved unit exactly where
- * the drag put it.
+ * Destination in [rest], or null when neither anchor resolves. Each anchor expands over its own
+ * hidden block-mates — forward past `afterKey`'s, backward before `beforeKey`'s — so the filtered
+ * projection shows the unit exactly where the drag put it.
  */
 private fun <T> rowBlockInsertionIndex(
     rest: List<T>,
@@ -127,4 +130,57 @@ private fun <T> rowBlockInsertionIndex(
         while (start > 0 && blockOf(rest[start - 1]) == anchorBlock) start--
     }
     return start
+}
+
+/**
+ * Lifts a [RowWithinBlockMove] to the SOURCE list: relocates the single moved row among its
+ * block-mates, using [RowWithinBlockMove.afterKey] as the primary anchor and [beforeKey] as the
+ * fallback. Block members hidden by the current filter keep their relative order; the moved row
+ * lands immediately adjacent to the resolved visible anchor. The list is left untouched when the
+ * moved row is gone, its block id no longer matches, or neither anchor resolves.
+ */
+public fun <T> MutableList<T>.applyRowReorderWithinBlock(
+    move: RowWithinBlockMove,
+    keyOf: (T) -> Any,
+    blockOf: (T) -> Any?,
+) {
+    val movedIndex = indexOfFirst { keyOf(it) == move.movedKey }
+    if (movedIndex < 0) return
+    if (blockOf(this[movedIndex]) != move.blockId) return
+    val moving = removeAt(movedIndex)
+    val insertAt = withinBlockInsertionIndex(this, move, keyOf, blockOf)
+    if (insertAt == null) {
+        add(movedIndex, moving)
+        return
+    }
+    add(insertAt.coerceIn(0, size), moving)
+}
+
+/**
+ * Destination in [rest] for a within-block move, or null when neither anchor resolves. A null
+ * anchor means the block's edge, so the row lands at its first / after its last source member.
+ */
+private fun <T> withinBlockInsertionIndex(
+    rest: List<T>,
+    move: RowWithinBlockMove,
+    keyOf: (T) -> Any,
+    blockOf: (T) -> Any?,
+): Int? {
+    val afterKey = move.afterKey
+    if (afterKey != null) {
+        val i = rest.indexOfFirst { keyOf(it) == afterKey }
+        if (i >= 0) return i + 1
+    } else {
+        val first = rest.indexOfFirst { blockOf(it) == move.blockId }
+        if (first >= 0) return first
+    }
+    val beforeKey = move.beforeKey
+    if (beforeKey != null) {
+        val i = rest.indexOfFirst { keyOf(it) == beforeKey }
+        if (i >= 0) return i
+    } else {
+        val last = rest.indexOfLast { blockOf(it) == move.blockId }
+        if (last >= 0) return last + 1
+    }
+    return null
 }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/RowBlocks.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/RowBlocks.kt
@@ -1,0 +1,130 @@
+package ua.wwind.table
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+
+/**
+ * Row blocks: runs of adjacent rows that render and drag as one unit, declared by identity rather
+ * than by position.
+ *
+ * The library derives block extents itself, from the same snapshot it renders — the consumer never
+ * supplies index ranges, so the ranges can never go stale against an asynchronously filtered list.
+ * During a drag the library permutes its own internal view; the consumer's data is untouched until
+ * [onCommit] delivers exactly one [RowBlockMove] for the completed gesture.
+ *
+ * Passing a `RowBlocks` supersedes the per-row `onRowMove` callback: drag units are blocks, so
+ * per-row move semantics cannot apply. Every gesture — standalone rows included — reports through
+ * [onCommit] (a standalone move carries a null [RowBlockMove.blockId]), `onRowMove` is never
+ * invoked, and a null [onCommit] disables row drag entirely rather than falling back to it.
+ *
+ * Hold the instance in `remember`: it compares by identity — carrying a `@Composable` slot, it has
+ * no meaningful structural equality — so a fresh instance per recomposition makes the `rowBlocks`
+ * argument look changed and stops the table from skipping.
+ *
+ * Block tables require a stable `rowKey`: [RowBlockMove] anchors are keys, and the default
+ * positional key cannot survive a move.
+ */
+@Stable
+public class RowBlocks<T : Any>(
+    /** Block identity; null = standalone row. Adjacent equal ids form one block. */
+    public val blockOf: (T) -> Any?,
+    /** Exactly one event per completed drag gesture; null = display-only blocks (no drag). */
+    public val onCommit: ((RowBlockMove) -> Unit)? = null,
+    /** Band content above a block. */
+    public val blockHeader: (@Composable (blockId: Any, rows: IntRange) -> Unit)? = null,
+)
+
+/**
+ * The result of one completed block-drag gesture, expressed in stable row keys so it stays
+ * meaningful however the consumer's pipeline reorders or filters the source afterwards.
+ *
+ * Anchors are keys of the rendered (possibly filtered) list. [beforeKey] is deliberately redundant:
+ * when [afterKey] is hidden or gone by the time the consumer applies the move, the second anchor
+ * still pins the destination.
+ */
+public class RowBlockMove(
+    /** Block id of the dragged unit; null when a standalone row moved. */
+    public val blockId: Any?,
+    /** Keys of the VISIBLE moved rows, in order. */
+    public val movedKeys: List<Any>,
+    /** Key of the row the unit now sits after, in the rendered order; null = start. */
+    public val afterKey: Any?,
+    /** Key of the row the unit now sits before; null = end. Redundant anchor for edge cases. */
+    public val beforeKey: Any?,
+)
+
+/**
+ * Applies [move] to the SOURCE list — the lift from the rendered, possibly filtered view back to
+ * the consumer's single source of truth.
+ *
+ * Relocates ALL rows whose [blockOf] equals [RowBlockMove.blockId] — including rows hidden by the
+ * current filter, which [RowBlockMove.movedKeys] cannot name — preserving their relative order.
+ * The insertion point is expanded to the nearest whole-block boundary in the source, so no other
+ * block is ever split: where hidden rows land relative to hidden neighbours of the anchor is
+ * unobservable in the view, and block-boundary insertion is the one placement that keeps every
+ * block contiguous. Standalone moves ([RowBlockMove.blockId] == null) relocate just the moved keys.
+ *
+ * [RowBlockMove.afterKey] is the primary anchor; when its row is gone from the list by the time
+ * the move is applied, [RowBlockMove.beforeKey] pins the destination instead. When neither anchor
+ * resolves the destination is unknowable, and the list is deliberately left untouched — guessing a
+ * position would reorder data the user never dragged.
+ */
+public fun <T> MutableList<T>.applyRowBlockMove(
+    move: RowBlockMove,
+    keyOf: (T) -> Any,
+    blockOf: (T) -> Any?,
+) {
+    val belongsToMove: (T) -> Boolean =
+        when (val blockId = move.blockId) {
+            null -> {
+                val movedKeys = move.movedKeys.toSet()
+                ({ item -> keyOf(item) in movedKeys })
+            }
+            else -> ({ item -> blockOf(item) == blockId })
+        }
+    val moved = filter(belongsToMove)
+    if (moved.isEmpty()) return
+    val rest = filterNot(belongsToMove)
+    val insertAt = rowBlockInsertionIndex(rest, move, keyOf, blockOf) ?: return
+    clear()
+    addAll(rest.subList(0, insertAt))
+    addAll(moved)
+    addAll(rest.subList(insertAt, rest.size))
+}
+
+/**
+ * Destination in [rest] (the source minus the moved rows), or null when neither anchor resolves.
+ *
+ * The expansion direction follows each anchor's role in the view. [RowBlockMove.afterKey] is the
+ * last visible row of the unit the drag landed behind, so hidden members of its block can only sit
+ * further down in the source — the insertion walks forward past them. [RowBlockMove.beforeKey] is
+ * the first visible row of the following unit, so its hidden block-mates can only sit above — the
+ * insertion walks backward. Either way the filtered projection shows the moved unit exactly where
+ * the drag put it.
+ */
+private fun <T> rowBlockInsertionIndex(
+    rest: List<T>,
+    move: RowBlockMove,
+    keyOf: (T) -> Any,
+    blockOf: (T) -> Any?,
+): Int? {
+    val afterKey = move.afterKey ?: return 0
+    val afterAnchor = rest.indexOfFirst { keyOf(it) == afterKey }
+    if (afterAnchor >= 0) {
+        var end = afterAnchor
+        val anchorBlock = blockOf(rest[end])
+        if (anchorBlock != null) {
+            while (end + 1 < rest.size && blockOf(rest[end + 1]) == anchorBlock) end++
+        }
+        return end + 1
+    }
+    val beforeKey = move.beforeKey ?: return rest.size
+    val beforeAnchor = rest.indexOfFirst { keyOf(it) == beforeKey }
+    if (beforeAnchor < 0) return null
+    var start = beforeAnchor
+    val anchorBlock = blockOf(rest[start])
+    if (anchorBlock != null) {
+        while (start > 0 && blockOf(rest[start - 1]) == anchorBlock) start--
+    }
+    return start
+}

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/Table.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/Table.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -53,6 +54,7 @@ import ua.wwind.table.config.TableColors
 import ua.wwind.table.config.TableCustomization
 import ua.wwind.table.config.TableDefaults
 import ua.wwind.table.config.isInteractionLockByRowReorderEnabled
+import ua.wwind.table.config.isRowReorderEnabled
 import ua.wwind.table.interaction.ApplyAutoWidthEffect
 import ua.wwind.table.interaction.ApplyAutoWidthEmbeddedEffect
 import ua.wwind.table.interaction.ContextMenuState
@@ -62,12 +64,21 @@ import ua.wwind.table.interaction.tableKeyboardNavigation
 import ua.wwind.table.platform.getPlatform
 import ua.wwind.table.platform.isMobile
 import ua.wwind.table.state.LocalTableState
+import ua.wwind.table.state.RowBlocksState
+import ua.wwind.table.state.RowUnitIndex
 import ua.wwind.table.state.SortState
 import ua.wwind.table.state.TableState
+import ua.wwind.table.state.buildRowUnitIndex
 import ua.wwind.table.state.mapNotNullToImmutable
 import ua.wwind.table.strings.DefaultStrings
 import ua.wwind.table.strings.LocalStringProvider
 import ua.wwind.table.strings.StringProvider
+
+/**
+ * Shared default for `rowKey` across every table entry point, so a block table can recognize it:
+ * [RowBlockMove] anchors are row keys, and a positional key cannot survive the move it describes.
+ */
+internal val DefaultRowKey: (Any?, Int) -> Any = { _, index -> index }
 
 /**
  * Composable editable data table that renders a header and a virtualized list of rows.
@@ -116,10 +127,16 @@ public fun <T : Any, C, E> EditableTable(
     tableData: E,
     modifier: Modifier = Modifier,
     placeholderRow: (@Composable () -> Unit)? = null,
-    rowKey: (item: T?, index: Int) -> Any = { _, i -> i },
+    rowKey: (item: T?, index: Int) -> Any = DefaultRowKey,
     onRowClick: ((T) -> Unit)? = null,
     onRowLongClick: ((T) -> Unit)? = null,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)? = null,
+    /**
+     * Row blocks declared by identity: adjacent rows with equal [RowBlocks.blockOf] ids render and
+     * drag as one unit. Supersedes [onRowMove], which is never invoked while blocks are declared.
+     * Requires a stable [rowKey]; hold the instance in `remember` — see [RowBlocks].
+     */
+    rowBlocks: RowBlocks<T>? = null,
     contextMenu: (@Composable (item: T, pos: Offset, dismiss: () -> Unit) -> Unit)? = null,
     customization: TableCustomization<T, C> = DefaultTableCustomization(),
     colors: TableColors = TableDefaults.colors(),
@@ -152,6 +169,53 @@ public fun <T : Any, C, E> EditableTable(
 
     state.visibleColumns = visibleColumns
 
+    val blocksState =
+        rowBlocks?.let { blocks -> remember(blocks, rowKey) { RowBlocksState(blocks, rowKey) } }
+    // Feed the state the same snapshot this composition renders: block extents are derived here,
+    // never declared, so they cannot lag behind an asynchronously filtered list.
+    blocksState?.reconcile(itemsCount, itemAt)
+
+    // groupBy and row blocks describe two incompatible structures over one list. groupBy wins:
+    // blocks are suppressed rather than both rendered, and the conflict is surfaced through
+    // TableState instead of thrown from a menu click.
+    val rowBlocksSuppressed = blocksState != null && state.groupBy != null
+    val activeBlocks = if (rowBlocksSuppressed) null else blocksState
+    // Gate on blocksState, not activeBlocks: declaring rowBlocks retires onRowMove outright, and
+    // the groupBy suppression must not resurrect it — per-row drag appearing under a grouped view
+    // would silently swap move semantics. Suppressed blocks mean no row drag at all.
+    val effectiveOnRowMove = if (blocksState == null) onRowMove else null
+    state.rowBlocksSuppressedByGroupBy = rowBlocksSuppressed
+    state.rowBlocksNonEmpty = blocksState != null && blocksState.hasBlocks
+    LaunchedEffect(rowBlocksSuppressed) {
+        if (rowBlocksSuppressed) Logger.w { "rowBlocks ignored while groupBy is active" }
+    }
+    LaunchedEffect(rowBlocks, rowKey) {
+        if (rowBlocks != null && rowKey === DefaultRowKey) {
+            Logger.w {
+                "rowBlocks requires a stable rowKey: RowBlockMove anchors are row keys, " +
+                    "and the default positional key cannot survive a move"
+            }
+        }
+    }
+
+    // The rendered list is the blocks state's (possibly permuted) view while a gesture or an
+    // optimistic post-drop hold is in flight; it is the consumer's list otherwise.
+    val effectiveItemAt: (Int) -> T? =
+        remember(activeBlocks, itemAt) {
+            if (activeBlocks != null) activeBlocks::itemAt else itemAt
+        }
+    val effectiveRowKey: (item: T?, index: Int) -> Any =
+        remember(activeBlocks, rowKey) {
+            if (activeBlocks == null) {
+                rowKey
+            } else {
+                { item, viewIndex -> rowKey(item, activeBlocks.upstreamIndexOf(viewIndex)) }
+            }
+        }
+
+    val rowUnits = activeBlocks?.units ?: remember(itemsCount) { buildRowUnitIndex(itemsCount, null) }
+    state.rowUnits = rowUnits
+
     var contextMenuState by remember { mutableStateOf(ContextMenuState<T>()) }
     val tableFocusRequester = remember { FocusRequester() }
     val coroutineScope = rememberCoroutineScope()
@@ -170,13 +234,17 @@ public fun <T : Any, C, E> EditableTable(
         }
     }
 
-    // Set edit mode callbacks
+    // Set edit mode callbacks. The registered wrapper outlives this composition's resolver —
+    // effectiveItemAt is rebuilt whenever activeBlocks or itemAt changes — so read it through
+    // rememberUpdatedState instead of re-registering (same trampoline as the embedded settle path).
+    val currentEffectiveItemAt = rememberUpdatedState(effectiveItemAt)
     LaunchedEffect(state, onRowEditStart, onRowEditComplete, onEditCancelled) {
         state.setEditCallbacks(
             onStart =
                 onRowEditStart?.let { callback ->
                     { rowIndex: Int ->
-                        val item = itemAt(rowIndex)
+                        // Edit indices are view positions, so resolve through the rendered order.
+                        val item = currentEffectiveItemAt.value(rowIndex)
                         if (item != null) callback(item, rowIndex)
                     }
                 },
@@ -255,8 +323,8 @@ public fun <T : Any, C, E> EditableTable(
                         TableBodySection(
                             embedded = embedded,
                             itemsCount = itemsCount,
-                            itemAt = itemAt,
-                            rowKey = rowKey,
+                            itemAt = effectiveItemAt,
+                            rowKey = effectiveRowKey,
                             visibleColumns = visibleColumns,
                             state = state,
                             colors = colors,
@@ -266,8 +334,10 @@ public fun <T : Any, C, E> EditableTable(
                             placeholderRow = placeholderRow,
                             onRowClick = onRowClick,
                             onRowLongClick = onRowLongClick,
-                            onRowMove = onRowMove,
+                            onRowMove = effectiveOnRowMove,
+                            blocks = activeBlocks,
                             onContextMenu = onContextMenuHandler,
+                            rowUnits = rowUnits,
                             verticalState = verticalState,
                             horizontalState = horizontalState,
                             requestTableFocus = { tableFocusRequester.requestFocus() },
@@ -359,10 +429,16 @@ public fun <T : Any, C> Table(
     columns: ImmutableList<ColumnSpec<T, C, Unit>>,
     modifier: Modifier = Modifier,
     placeholderRow: (@Composable () -> Unit)? = null,
-    rowKey: (item: T?, index: Int) -> Any = { _, i -> i },
+    rowKey: (item: T?, index: Int) -> Any = DefaultRowKey,
     onRowClick: ((T) -> Unit)? = null,
     onRowLongClick: ((T) -> Unit)? = null,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)? = null,
+    /**
+     * Row blocks declared by identity: adjacent rows with equal [RowBlocks.blockOf] ids render and
+     * drag as one unit. Supersedes [onRowMove], which is never invoked while blocks are declared.
+     * Requires a stable [rowKey]; hold the instance in `remember` — see [RowBlocks].
+     */
+    rowBlocks: RowBlocks<T>? = null,
     contextMenu: (@Composable (item: T, pos: Offset, dismiss: () -> Unit) -> Unit)? = null,
     customization: TableCustomization<T, C> = DefaultTableCustomization(),
     colors: TableColors = TableDefaults.colors(),
@@ -387,6 +463,7 @@ public fun <T : Any, C> Table(
         onRowClick = onRowClick,
         onRowLongClick = onRowLongClick,
         onRowMove = onRowMove,
+        rowBlocks = rowBlocks,
         contextMenu = contextMenu,
         customization = customization,
         colors = colors,
@@ -453,10 +530,16 @@ public fun <T : Any, C, E> Table(
     tableData: E,
     modifier: Modifier = Modifier,
     placeholderRow: (@Composable () -> Unit)? = null,
-    rowKey: (item: T?, index: Int) -> Any = { _, i -> i },
+    rowKey: (item: T?, index: Int) -> Any = DefaultRowKey,
     onRowClick: ((T) -> Unit)? = null,
     onRowLongClick: ((T) -> Unit)? = null,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)? = null,
+    /**
+     * Row blocks declared by identity: adjacent rows with equal [RowBlocks.blockOf] ids render and
+     * drag as one unit. Supersedes [onRowMove], which is never invoked while blocks are declared.
+     * Requires a stable [rowKey]; hold the instance in `remember` — see [RowBlocks].
+     */
+    rowBlocks: RowBlocks<T>? = null,
     contextMenu: (@Composable (item: T, pos: Offset, dismiss: () -> Unit) -> Unit)? = null,
     customization: TableCustomization<T, C> = DefaultTableCustomization(),
     colors: TableColors = TableDefaults.colors(),
@@ -481,6 +564,7 @@ public fun <T : Any, C, E> Table(
         onRowClick = onRowClick,
         onRowLongClick = onRowLongClick,
         onRowMove = onRowMove,
+        rowBlocks = rowBlocks,
         contextMenu = contextMenu,
         customization = customization,
         colors = colors,
@@ -605,7 +689,9 @@ private fun <T : Any, C, E> TableBodySection(
     onRowClick: ((T) -> Unit)?,
     onRowLongClick: ((T) -> Unit)?,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)?,
+    blocks: RowBlocksState<T>?,
     onContextMenu: ((item: T, pos: Offset) -> Unit)?,
+    rowUnits: RowUnitIndex,
     verticalState: LazyListState,
     horizontalState: ScrollState,
     requestTableFocus: () -> Unit,
@@ -630,7 +716,9 @@ private fun <T : Any, C, E> TableBodySection(
                 onRowClick = onRowClick,
                 onRowLongClick = onRowLongClick,
                 onRowMove = onRowMove,
+                blocks = blocks,
                 onContextMenu = onContextMenu,
+                rowUnits = rowUnits,
                 horizontalState = horizontalState,
                 requestTableFocus = requestTableFocus,
             )
@@ -648,7 +736,9 @@ private fun <T : Any, C, E> TableBodySection(
                 onRowClick = onRowClick,
                 onRowLongClick = onRowLongClick,
                 onRowMove = onRowMove,
+                blocks = blocks,
                 onContextMenu = onContextMenu,
+                rowUnits = rowUnits,
                 rowEmbedded = rowEmbedded,
                 verticalState = verticalState,
                 horizontalState = horizontalState,

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/Table.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/Table.kt
@@ -197,6 +197,15 @@ public fun <T : Any, C, E> EditableTable(
             }
         }
     }
+    LaunchedEffect(rowBlocks) {
+        if (rowBlocks != null && rowBlocks.onCommit != null && rowBlocks.blockHeader == null) {
+            Logger.w {
+                "RowBlocks.onCommit is set but blockHeader is null: a block's whole-block drag " +
+                    "handle lives in its header, so blocks cannot be dragged as a unit without one. " +
+                    "Provide a blockHeader, or set onCommit = null for within-block-only reordering"
+            }
+        }
+    }
 
     // The rendered list is the blocks state's (possibly permuted) view while a gesture or an
     // optimistic post-drop hold is in flight; it is the consumer's list otherwise.

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/TableCellScope.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/TableCellScope.kt
@@ -16,34 +16,15 @@ import sh.calvin.reorderable.ReorderableItem
  * so cell content can access item-level helpers in a more natural way.
  */
 @Stable
-public interface TableCellScope : TableItemScope {
-    /**
-     * True on the first visible row of a row block and on standalone rows — exactly the rows that
-     * may carry a drag handle. The table already knows its unit boundaries, so a handle cell reads
-     * this instead of re-deriving block extents from the consumer's data on every row.
-     */
-    public val isRowBlockLeader: Boolean
-}
+public interface TableCellScope : TableItemScope
 
 @Stable
 internal class TableCellScopeImpl(
-    private val delegate: TableItemScope,
-    override val isRowBlockLeader: Boolean,
+    delegate: TableItemScope,
 ) : TableCellScope, TableItemScope by delegate
 
 @Immutable
-internal object DefaultTableCellScope : TableCellScope, TableItemScope by DefaultTableItemScope {
-    /** Contexts without units (measurement, group headers) treat every row as standalone. */
-    override val isRowBlockLeader: Boolean get() = true
-}
-
-/**
- * Convenience accessor for [TableCellScope.isRowBlockLeader] inside the `cell { ... }` DSL, whose
- * context parameter is anonymous and therefore has no name to qualify the member with.
- */
-public context(cellScope: TableCellScope)
-val isRowBlockLeader: Boolean
-    get() = cellScope.isRowBlockLeader
+internal object DefaultTableCellScope : TableCellScope, TableItemScope by DefaultTableItemScope
 
 /**
  * Makes this modifier act as a drag handle for the current table item from cell content.

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/TableCellScope.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/TableCellScope.kt
@@ -16,13 +16,34 @@ import sh.calvin.reorderable.ReorderableItem
  * so cell content can access item-level helpers in a more natural way.
  */
 @Stable
-public interface TableCellScope : TableItemScope
+public interface TableCellScope : TableItemScope {
+    /**
+     * True on the first visible row of a row block and on standalone rows — exactly the rows that
+     * may carry a drag handle. The table already knows its unit boundaries, so a handle cell reads
+     * this instead of re-deriving block extents from the consumer's data on every row.
+     */
+    public val isRowBlockLeader: Boolean
+}
 
 @Stable
-internal class TableCellScopeImpl(private val delegate: TableItemScope) : TableCellScope, TableItemScope by delegate
+internal class TableCellScopeImpl(
+    private val delegate: TableItemScope,
+    override val isRowBlockLeader: Boolean,
+) : TableCellScope, TableItemScope by delegate
 
 @Immutable
-internal object DefaultTableCellScope : TableCellScope, TableItemScope by DefaultTableItemScope
+internal object DefaultTableCellScope : TableCellScope, TableItemScope by DefaultTableItemScope {
+    /** Contexts without units (measurement, group headers) treat every row as standalone. */
+    override val isRowBlockLeader: Boolean get() = true
+}
+
+/**
+ * Convenience accessor for [TableCellScope.isRowBlockLeader] inside the `cell { ... }` DSL, whose
+ * context parameter is anonymous and therefore has no name to qualify the member with.
+ */
+public context(cellScope: TableCellScope)
+val isRowBlockLeader: Boolean
+    get() = cellScope.isRowBlockLeader
 
 /**
  * Makes this modifier act as a drag handle for the current table item from cell content.

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/TableItemScope.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/TableItemScope.kt
@@ -89,9 +89,17 @@ internal object DefaultTableItemScope : TableItemScope {
     ): Modifier = modifier
 }
 
+/**
+ * Lazy-path drag scope. The optional hooks are the library's half of the managed-drag contract:
+ * the block commit must fire exactly once per completed gesture, and only the handle that started
+ * the gesture observes its end — so the hooks wrap the consumer's handle callbacks here instead of
+ * asking every consumer to call the commit themselves.
+ */
 @Stable
 internal class TableItemDragScope(
-    private val delegate: ReorderableCollectionItemScope
+    private val delegate: ReorderableCollectionItemScope,
+    private val onDragStartedHook: (() -> Unit)? = null,
+    private val onDragStoppedHook: (() -> Unit)? = null,
 ) : TableItemScope, ReorderableCollectionItemScope by delegate {
     override fun applyDraggableHandle(
         modifier: Modifier,
@@ -105,8 +113,14 @@ internal class TableItemDragScope(
             modifier.draggableHandle(
                 enabled = enabled,
                 interactionSource = interactionSource,
-                onDragStarted = onDragStarted,
-                onDragStopped = onDragStopped,
+                onDragStarted = { startedPosition ->
+                    onDragStartedHook?.invoke()
+                    onDragStarted(startedPosition)
+                },
+                onDragStopped = {
+                    onDragStoppedHook?.invoke()
+                    onDragStopped()
+                },
                 dragGestureDetector = dragGestureDetector
             )
         }
@@ -123,16 +137,30 @@ internal class TableItemDragScope(
             modifier.longPressDraggableHandle(
                 enabled = enabled,
                 interactionSource = interactionSource,
-                onDragStarted = onDragStarted,
-                onDragStopped = onDragStopped,
+                onDragStarted = { startedPosition ->
+                    onDragStartedHook?.invoke()
+                    onDragStarted(startedPosition)
+                },
+                onDragStopped = {
+                    onDragStoppedHook?.invoke()
+                    onDragStopped()
+                },
             )
         }
     }
 }
 
+/**
+ * Embedded-path drag scope. The optional start hook is the library's half of the managed-drag
+ * contract on this path: an edit in flight must complete or cancel before the gesture shifts row
+ * positions, and only the handle that starts the gesture observes its start. No stop hook exists
+ * here — the embedded engine reports the gesture's net result through its settle callback, which
+ * is where the commit rides instead.
+ */
 @Stable
 internal class TableItemListDragScope(
-    private val delegate: ReorderableListItemScope
+    private val delegate: ReorderableListItemScope,
+    private val onDragStartedHook: (() -> Unit)? = null,
 ) : TableItemScope, ReorderableListItemScope by delegate {
     override fun applyDraggableHandle(
         modifier: Modifier,
@@ -146,7 +174,10 @@ internal class TableItemListDragScope(
             modifier.draggableHandle(
                 enabled = enabled,
                 interactionSource = interactionSource,
-                onDragStarted = onDragStarted,
+                onDragStarted = { startedPosition ->
+                    onDragStartedHook?.invoke()
+                    onDragStarted(startedPosition)
+                },
                 onDragStopped = { onDragStopped() },
                 dragGestureDetector = dragGestureDetector
             )
@@ -164,7 +195,10 @@ internal class TableItemListDragScope(
             modifier.longPressDraggableHandle(
                 enabled = enabled,
                 interactionSource = interactionSource,
-                onDragStarted = onDragStarted,
+                onDragStarted = { startedPosition ->
+                    onDragStartedHook?.invoke()
+                    onDragStarted(startedPosition)
+                },
                 onDragStopped = { onDragStopped() },
             )
         }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/TableItemScope.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/TableItemScope.kt
@@ -69,6 +69,39 @@ public interface TableItemScope {
     ): Modifier
 }
 
+/**
+ * Scope for a row block's header band. Distinct from [TableCellScope] (not a supertype of it) so a
+ * [Modifier.draggableHandle] call here binds unambiguously to the whole-block (outer unit) engine,
+ * while the same call inside a cell binds to whatever engine that row is rendered under.
+ */
+@Stable
+public interface RowBlockHeaderScope : TableItemScope
+
+@Stable
+internal class RowBlockHeaderScopeImpl(
+    delegate: TableItemScope,
+) : RowBlockHeaderScope, TableItemScope by delegate
+
+/**
+ * Makes this modifier the drag handle for the whole block, from its header band. The node must be a
+ * descendant of the block's [ReorderableItem].
+ */
+public context(scope: RowBlockHeaderScope)
+fun Modifier.draggableHandle(
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource? = null,
+    onDragStarted: (startedPosition: Offset) -> Unit = {},
+    onDragStopped: () -> Unit = {},
+    dragGestureDetector: DragGestureDetector = DragGestureDetector.Press,
+): Modifier = scope.applyDraggableHandle(
+    modifier = this,
+    enabled = enabled,
+    interactionSource = interactionSource,
+    onDragStarted = onDragStarted,
+    onDragStopped = onDragStopped,
+    dragGestureDetector = dragGestureDetector,
+)
+
 @Immutable
 internal object DefaultTableItemScope : TableItemScope {
     override fun applyDraggableHandle(
@@ -90,10 +123,8 @@ internal object DefaultTableItemScope : TableItemScope {
 }
 
 /**
- * Lazy-path drag scope. The optional hooks are the library's half of the managed-drag contract:
- * the block commit must fire exactly once per completed gesture, and only the handle that started
- * the gesture observes its end — so the hooks wrap the consumer's handle callbacks here instead of
- * asking every consumer to call the commit themselves.
+ * Lazy-path drag scope. The hooks wrap the consumer's handle callbacks so the block commit fires
+ * exactly once per gesture, observed by the handle that started it.
  */
 @Stable
 internal class TableItemDragScope(
@@ -151,11 +182,8 @@ internal class TableItemDragScope(
 }
 
 /**
- * Embedded-path drag scope. The optional start hook is the library's half of the managed-drag
- * contract on this path: an edit in flight must complete or cancel before the gesture shifts row
- * positions, and only the handle that starts the gesture observes its start. No stop hook exists
- * here — the embedded engine reports the gesture's net result through its settle callback, which
- * is where the commit rides instead.
+ * Embedded-path drag scope. Only a start hook: the embedded engine reports the gesture's net result
+ * through its settle callback, which is where the commit rides instead.
  */
 @Stable
 internal class TableItemListDragScope(

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/RowUnit.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/RowUnit.kt
@@ -1,0 +1,171 @@
+package ua.wwind.table.component.body
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import ua.wwind.table.ColumnSpec
+import ua.wwind.table.TableItemScope
+import ua.wwind.table.config.TableColors
+import ua.wwind.table.config.TableCustomization
+import ua.wwind.table.config.resolveRowBlockContainerColor
+import ua.wwind.table.state.TableState
+
+/**
+ * Renders one drag unit: either a single row (identical to the pre-blocks layout) or a block —
+ * its rows stacked and divided exactly like standalone rows, over a
+ * [TableColors.rowBlockContainerColor] background that also spans the vertical gap around them, so
+ * the block reads as one card.
+ *
+ * Every row keeps its own divider, the last one included, and the block adds none: each rule sits
+ * directly under the row it closes, inside the padded content, so the divider rhythm is the same
+ * inside a block as anywhere else in the table. The tinted band is therefore pure margin around the
+ * block, never crossed or trailed by a rule.
+ *
+ * A block **always opens with a top band**: the [blockHeader] when there is one, otherwise a
+ * `rowBlockSpacing` gap. It **closes with a bottom gap only when [nextIsGroup] is false** — a
+ * following block opens with a band of its own, so drawing this one's bottom gap too would stack two
+ * tinted regions between them and merge the pair into a single fat slab, erasing the very boundary
+ * the band exists to draw. Suppressing the *bottom* gap rather than the next block's top band is
+ * what keeps that band a header when one is configured: suppressing the top instead would leave the
+ * second of two adjacent blocks nameless.
+ *
+ * The rule leaves exactly one band between any two units, and still gives a block at either end of
+ * the list its own outer band.
+ *
+ * The header wraps its own content rather than being pinned to `rowBlockSpacing`, but is floored at
+ * it: [nextIsGroup] drops a block's bottom gap on the promise that the next block opens with a band,
+ * and a header free to measure zero could quietly break that promise — a slot that renders nothing
+ * while its leader is still loading would butt two blocks together with no boundary at all. The
+ * floor makes a header that draws nothing collapse to exactly the gap it replaced. The header is
+ * also offset by the horizontal scroll so it stays in the viewport while the table scrolls sideways
+ * — the same technique the `groupBy` header cell uses.
+ *
+ * The wrapper adds **no horizontal insets**: any horizontal padding here would shift block rows
+ * relative to the header and break column alignment.
+ */
+@Composable
+@Suppress("LongParameterList")
+context(_: TableItemScope)
+internal fun <T : Any, C, E> RowUnit(
+    rows: IntRange,
+    isGroup: Boolean,
+    /** True when the following unit is a block, which opens with a band of its own. */
+    nextIsGroup: Boolean,
+    /** Identity of the block this unit renders; null for single-row units. */
+    blockId: Any?,
+    /** Optional content for the band above a block; replaces the block's top gap. */
+    blockHeader: (@Composable (blockId: Any, rows: IntRange) -> Unit)?,
+    itemAt: (Int) -> T?,
+    visibleColumns: ImmutableList<ColumnSpec<T, C, E>>,
+    state: TableState<C>,
+    colors: TableColors,
+    customization: TableCustomization<T, C>,
+    tableData: E,
+    rowEmbedded: (@Composable (rowIndex: Int, item: T) -> Unit)?,
+    placeholderRow: (@Composable () -> Unit)?,
+    onRowClick: ((T) -> Unit)?,
+    onRowLongClick: ((T) -> Unit)?,
+    onContextMenu: ((T, Offset) -> Unit)?,
+    horizontalState: ScrollState,
+    requestTableFocus: () -> Unit,
+) {
+    if (!isGroup) {
+        TableBodyRow(
+            index = rows.first,
+            // A standalone unit is a single row, and it is its own leader — it carries a drag handle.
+            isInRowBlock = false,
+            isRowBlockLeader = true,
+            itemAt = itemAt,
+            visibleColumns = visibleColumns,
+            state = state,
+            colors = colors,
+            customization = customization,
+            tableData = tableData,
+            rowEmbedded = rowEmbedded,
+            placeholderRow = placeholderRow,
+            onRowClick = onRowClick,
+            onRowLongClick = onRowLongClick,
+            onContextMenu = onContextMenu,
+            horizontalState = horizontalState,
+            requestTableFocus = requestTableFocus,
+        )
+        return
+    }
+
+    // A header cannot render without its block id: runs only form over loaded rows, so a block
+    // unit always has one — the null check is for the type system, not a reachable state.
+    val header = blockHeader?.takeIf { blockId != null }
+    Column(
+        modifier =
+            Modifier
+                .width(state.tableWidth)
+                .background(resolveRowBlockContainerColor(colors))
+                .padding(
+                    top =
+                        if (header != null) {
+                            0.dp
+                        } else {
+                            state.dimensions.rowBlockSpacing
+                        },
+                    bottom =
+                        if (nextIsGroup) {
+                            0.dp
+                        } else {
+                            state.dimensions.rowBlockSpacing
+                        },
+                ),
+    ) {
+        if (header != null && blockId != null) {
+            // Only the lazy path attaches the horizontal scroll node; on the embedded path the
+            // viewport reports 0 and the whole table is the viewport.
+            val viewportWidth =
+                with(LocalDensity.current) { horizontalState.viewportSize.takeIf { it > 0 }?.toDp() }
+                    ?: state.tableWidth
+            Box(
+                modifier =
+                    Modifier
+                        .heightIn(min = state.dimensions.rowBlockSpacing)
+                        .graphicsLayer {
+                            translationX = horizontalState.value.toFloat()
+                        },
+            ) {
+                Box(modifier = Modifier.width(viewportWidth)) {
+                    header(blockId, rows)
+                }
+            }
+        }
+        rows.forEach { row ->
+            TableBodyRow(
+                index = row,
+                // Leader is the block's first row; both flags come from this same [rows] range, so the
+                // handle's gate tracks the row's own position and cannot lag a fast drag.
+                isInRowBlock = true,
+                isRowBlockLeader = row == rows.first,
+                itemAt = itemAt,
+                visibleColumns = visibleColumns,
+                state = state,
+                colors = colors,
+                customization = customization,
+                tableData = tableData,
+                rowEmbedded = rowEmbedded,
+                placeholderRow = placeholderRow,
+                onRowClick = onRowClick,
+                onRowLongClick = onRowLongClick,
+                onContextMenu = onContextMenu,
+                horizontalState = horizontalState,
+                requestTableFocus = requestTableFocus,
+            )
+        }
+    }
+}

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/RowUnit.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/RowUnit.kt
@@ -8,13 +8,21 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
+import sh.calvin.reorderable.ReorderableColumn
+import sh.calvin.reorderable.ReorderableItem
 import ua.wwind.table.ColumnSpec
+import ua.wwind.table.DefaultTableItemScope
+import ua.wwind.table.RowBlockHeaderScope
+import ua.wwind.table.RowBlockHeaderScopeImpl
+import ua.wwind.table.TableItemListDragScope
 import ua.wwind.table.TableItemScope
 import ua.wwind.table.config.TableColors
 import ua.wwind.table.config.TableCustomization
@@ -22,41 +30,22 @@ import ua.wwind.table.config.resolveRowBlockContainerColor
 import ua.wwind.table.state.TableState
 
 /**
- * Renders one drag unit: either a single row (identical to the pre-blocks layout) or a block —
- * its rows stacked and divided exactly like standalone rows, over a
- * [TableColors.rowBlockContainerColor] background that also spans the vertical gap around them, so
- * the block reads as one card.
+ * Renders one drag unit: a single row, or a block drawn as one card over a
+ * [TableColors.rowBlockContainerColor] background that also spans the gap around its rows.
  *
- * Every row keeps its own divider, the last one included, and the block adds none: each rule sits
- * directly under the row it closes, inside the padded content, so the divider rhythm is the same
- * inside a block as anywhere else in the table. The tinted band is therefore pure margin around the
- * block, never crossed or trailed by a rule.
- *
- * A block **always opens with a top band**: the [blockHeader] when there is one, otherwise a
- * `rowBlockSpacing` gap. It **closes with a bottom gap only when [nextIsGroup] is false** — a
- * following block opens with a band of its own, so drawing this one's bottom gap too would stack two
- * tinted regions between them and merge the pair into a single fat slab, erasing the very boundary
- * the band exists to draw. Suppressing the *bottom* gap rather than the next block's top band is
- * what keeps that band a header when one is configured: suppressing the top instead would leave the
- * second of two adjacent blocks nameless.
- *
- * The rule leaves exactly one band between any two units, and still gives a block at either end of
- * the list its own outer band.
- *
- * The header wraps its own content rather than being pinned to `rowBlockSpacing`, but is floored at
- * it: [nextIsGroup] drops a block's bottom gap on the promise that the next block opens with a band,
- * and a header free to measure zero could quietly break that promise — a slot that renders nothing
- * while its leader is still loading would butt two blocks together with no boundary at all. The
- * floor makes a header that draws nothing collapse to exactly the gap it replaced. The header is
- * also offset by the horizontal scroll so it stays in the viewport while the table scrolls sideways
- * — the same technique the `groupBy` header cell uses.
- *
- * The wrapper adds **no horizontal insets**: any horizontal padding here would shift block rows
+ * A block opens with a band — the [blockHeader] or a `rowBlockSpacing` gap — and closes with a
+ * bottom gap only when [nextIsGroup] is false, so two adjacent blocks never stack two tinted
+ * regions into one slab. The header is floored at `rowBlockSpacing` for the same reason: one that
+ * measures zero would butt two blocks together. No horizontal insets — they would shift the rows
  * relative to the header and break column alignment.
+ *
+ * Drag has two levels: the header renders under the ambient outer scope (its handle drags the whole
+ * block), while a non-null [onRowMoveWithinBlock] wraps the rows in a nested [ReorderableColumn]
+ * holding only this block's rows — so a row handle reorders within the block and can never leave it.
  */
 @Composable
 @Suppress("LongParameterList")
-context(_: TableItemScope)
+context(itemScope: TableItemScope)
 internal fun <T : Any, C, E> RowUnit(
     rows: IntRange,
     isGroup: Boolean,
@@ -64,8 +53,19 @@ internal fun <T : Any, C, E> RowUnit(
     nextIsGroup: Boolean,
     /** Identity of the block this unit renders; null for single-row units. */
     blockId: Any?,
-    /** Optional content for the band above a block; replaces the block's top gap. */
-    blockHeader: (@Composable (blockId: Any, rows: IntRange) -> Unit)?,
+    /** Optional content for the band above a block; replaces the block's top gap. Its
+     *  [RowBlockHeaderScope] receiver carries the whole-block drag handle. */
+    blockHeader: (@Composable context(RowBlockHeaderScope) (blockId: Any, rows: IntRange) -> Unit)?,
+    /** View-space within-block move `(fromView, toView)`. Null disables within-block reorder — the
+     *  block's rows render without an inner drag engine. */
+    onRowMoveWithinBlock: ((fromView: Int, toView: Int) -> Unit)?,
+    /** Fires once when a within-block gesture starts (edit cancellation). */
+    onWithinBlockDragStarted: (() -> Unit)?,
+    /** Stable key for the row at a view index — feeds the nested column's Compose node identity. */
+    rowKeyAt: (Int) -> Any,
+    /** Bumped on every refused drop; folded into the nested column's list equality so a refusal
+     *  rebuilds the inner engine and clears its leftover drag offsets. */
+    withinBlockRefusalCount: Int,
     itemAt: (Int) -> T?,
     visibleColumns: ImmutableList<ColumnSpec<T, C, E>>,
     state: TableState<C>,
@@ -81,11 +81,11 @@ internal fun <T : Any, C, E> RowUnit(
     requestTableFocus: () -> Unit,
 ) {
     if (!isGroup) {
+        // A standalone unit is a single row rendered under the ambient outer scope; its cell handle
+        // drives the outer (unit) engine.
         TableBodyRow(
             index = rows.first,
-            // A standalone unit is a single row, and it is its own leader — it carries a drag handle.
             isInRowBlock = false,
-            isRowBlockLeader = true,
             itemAt = itemAt,
             visibleColumns = visibleColumns,
             state = state,
@@ -132,6 +132,9 @@ internal fun <T : Any, C, E> RowUnit(
             val viewportWidth =
                 with(LocalDensity.current) { horizontalState.viewportSize.takeIf { it > 0 }?.toDp() }
                     ?: state.tableWidth
+            // Rendered under the ambient outer scope so the header's drag handle drives the whole
+            // block through the outer engine.
+            val headerScope = remember(itemScope) { RowBlockHeaderScopeImpl(itemScope) }
             Box(
                 modifier =
                     Modifier
@@ -141,31 +144,76 @@ internal fun <T : Any, C, E> RowUnit(
                         },
             ) {
                 Box(modifier = Modifier.width(viewportWidth)) {
-                    header(blockId, rows)
+                    context(headerScope) { header(blockId, rows) }
                 }
             }
         }
-        rows.forEach { row ->
-            TableBodyRow(
-                index = row,
-                // Leader is the block's first row; both flags come from this same [rows] range, so the
-                // handle's gate tracks the row's own position and cannot lag a fast drag.
-                isInRowBlock = true,
-                isRowBlockLeader = row == rows.first,
-                itemAt = itemAt,
-                visibleColumns = visibleColumns,
-                state = state,
-                colors = colors,
-                customization = customization,
-                tableData = tableData,
-                rowEmbedded = rowEmbedded,
-                placeholderRow = placeholderRow,
-                onRowClick = onRowClick,
-                onRowLongClick = onRowLongClick,
-                onContextMenu = onContextMenu,
-                horizontalState = horizontalState,
-                requestTableFocus = requestTableFocus,
-            )
+
+        if (onRowMoveWithinBlock != null) {
+            // Embedded-style: onSettle reports the net move at drop, so the settle applies once.
+            val blockItems = EmbeddedUnitList(rows.map { itemAt(it) }, withinBlockRefusalCount)
+            ReorderableColumn(
+                list = blockItems,
+                onSettle = { fromLocal, toLocal ->
+                    onRowMoveWithinBlock(rows.first + fromLocal, rows.first + toLocal)
+                },
+            ) { localIndex, _, _ ->
+                val rowIndex = rows.first + localIndex
+                key(rowKeyAt(rowIndex)) {
+                    ReorderableItem {
+                        val innerScope: TableItemScope =
+                            remember(this) {
+                                TableItemListDragScope(
+                                    this,
+                                    onDragStartedHook = { onWithinBlockDragStarted?.invoke() },
+                                )
+                            }
+                        context(innerScope) {
+                            TableBodyRow(
+                                index = rowIndex,
+                                isInRowBlock = true,
+                                itemAt = itemAt,
+                                visibleColumns = visibleColumns,
+                                state = state,
+                                colors = colors,
+                                customization = customization,
+                                tableData = tableData,
+                                rowEmbedded = rowEmbedded,
+                                placeholderRow = placeholderRow,
+                                onRowClick = onRowClick,
+                                onRowLongClick = onRowLongClick,
+                                onContextMenu = onContextMenu,
+                                horizontalState = horizontalState,
+                                requestTableFocus = requestTableFocus,
+                            )
+                        }
+                    }
+                }
+            }
+        } else {
+            // Within-block reorder disabled: rows are inert (no handle binds anywhere), the block
+            // still drags whole from its header.
+            rows.forEach { row ->
+                context(DefaultTableItemScope) {
+                    TableBodyRow(
+                        index = row,
+                        isInRowBlock = true,
+                        itemAt = itemAt,
+                        visibleColumns = visibleColumns,
+                        state = state,
+                        colors = colors,
+                        customization = customization,
+                        tableData = tableData,
+                        rowEmbedded = rowEmbedded,
+                        placeholderRow = placeholderRow,
+                        onRowClick = onRowClick,
+                        onRowLongClick = onRowLongClick,
+                        onContextMenu = onContextMenu,
+                        horizontalState = horizontalState,
+                        requestTableFocus = requestTableFocus,
+                    )
+                }
+            }
         }
     }
 }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableBody.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableBody.kt
@@ -58,18 +58,24 @@ internal fun <T : Any, C, E> TableBody(
     modifier: Modifier = Modifier,
 ) {
     val showFooter = state.settings.showFooter && !state.settings.footerPinned
-    // With blocks the drag is managed: units are blocks, so per-row onRowMove semantics cannot
-    // apply and display-only blocks (no onCommit) render without any drag at all.
+    // With blocks the drag is managed: units are blocks, so per-row onRowMove cannot apply. A block
+    // table drags when it can move whole blocks or reorder rows within one; neither = display-only.
     val rowReorderEnabled =
         state.settings.isRowReorderEnabled &&
-            (if (blocks != null) blocks.config.onCommit != null else onRowMove != null)
+            (
+                if (blocks != null) {
+                    blocks.config.onCommit != null || blocks.config.onRowReorderWithinBlock != null
+                } else {
+                    onRowMove != null
+                }
+            )
+    val withinBlockEnabled =
+        rowReorderEnabled && blocks != null && blocks.config.onRowReorderWithinBlock != null
     val reorderState =
         if (rowReorderEnabled) {
             rememberReorderableLazyListState(verticalState) { from, to ->
                 if (blocks != null) {
-                    // Synchronous by design: the engine re-reads layout right after this call and
-                    // expects the swap already applied — the library's own permutation satisfies
-                    // that, the consumer's data stays untouched until the commit.
+                    // Synchronous by design: the engine re-reads layout right after this call.
                     blocks.applyUnitMove(from.index, to.index)
                 } else {
                     onRowMove?.invoke(rowUnits.rowsOf(from.index).first, rowUnits.rowsOf(to.index).first)
@@ -96,12 +102,10 @@ internal fun <T : Any, C, E> TableBody(
                 // Read the displacement before settle() — settling forgets the pre-gesture order.
                 val remap = blocks.gestureRemap()
                 val move = blocks.settle()
-                // A settle can refuse the drop (paged policy: the anchor is still a placeholder)
-                // and snap the view back; positional state then describes the restored order and
-                // remapping it through the dead gesture's displacement would corrupt it.
+                // A refused drop snaps the view back; remapping positional state through the dead
+                // gesture's displacement would corrupt it.
                 if (move != null && remap != null) {
-                    // Positions whose content changed: cached heights describe other rows now, and
-                    // re-measuring is the cheapest correct option.
+                    // Cached heights describe other rows now; re-measuring is the cheapest fix.
                     for (viewIndex in 0 until blocks.itemsCount) {
                         if (remap(viewIndex) != viewIndex) state.rowHeightsPx.remove(viewIndex)
                     }
@@ -111,27 +115,37 @@ internal fun <T : Any, C, E> TableBody(
         } else {
             null
         }
-    // The engine remembers its per-item scope for as long as the item's key survives — longer than
-    // any one composition of this body, and across a TableState recreation (rememberTableState
-    // swaps instances on settings/dimensions changes). Hooks frozen into that scope would keep
-    // mutating the dead state — cancelling its edits, remapping its selection — while the live one
-    // never hears about the drop. Same trampoline as the embedded settle path: the scope gets
-    // stable lambdas that read the current hooks at gesture time.
+    // The nested within-block column reports its gesture once, at drop: apply the row move then
+    // settle it, with the same remap and paged-refusal handling as the whole-block hook.
+    val onRowMoveWithinBlock: ((fromView: Int, toView: Int) -> Unit)? =
+        if (withinBlockEnabled) {
+            { fromView, toView ->
+                blocks.applyRowMoveWithinBlock(fromView, toView)
+                val remap = blocks.gestureRemap()
+                val move = blocks.settleWithinBlock()
+                if (move != null && remap != null) {
+                    for (viewIndex in 0 until blocks.itemsCount) {
+                        if (remap(viewIndex) != viewIndex) state.rowHeightsPx.remove(viewIndex)
+                    }
+                    state.remapRowPositions(remap)
+                }
+            }
+        } else {
+            null
+        }
+    // The engine keeps a per-item scope longer than any composition of this body — and across a
+    // TableState swap — so the scope gets stable lambdas that read the current hooks at gesture time.
     val currentOnBlockDragStarted = rememberUpdatedState(onBlockDragStarted)
     val currentOnBlockDragStopped = rememberUpdatedState(onBlockDragStopped)
+    val currentOnRowMoveWithinBlock = rememberUpdatedState(onRowMoveWithinBlock)
 
     LazyColumn(
         modifier = modifier,
         state = verticalState,
         userScrollEnabled = enableScrolling,
     ) {
-        // Everything the drag reads about the permutation — unit boundaries, item, block id, key AND
-        // the is-leader test that gates the handle — must come from ONE snapshot read. [snapshot] is
-        // that read: [units] below is its own [RowUnitIndex], and [RowUnit] derives each row's
-        // is-leader flag from the same [rows] it hands down, so no reader falls back on the separately
-        // published state.rowUnits, which can lag this snapshot by a frame under a fast drag. Without
-        // blocks the units are identity and itemAt is the consumer's own, so the plain params already
-        // form one source.
+        // Everything the drag reads about the permutation — unit boundaries, item, block id, key —
+        // must come from ONE snapshot read; state.rowUnits can lag it by a frame under a fast drag.
         val snap = blocks?.snapshot
         val units = snap?.units ?: rowUnits
         val unitItemAt: (Int) -> T? = if (snap != null) snap::itemAt else itemAt
@@ -149,6 +163,9 @@ internal fun <T : Any, C, E> TableBody(
             val nextIsGroup = unit < units.unitCount - 1 && units.isGroup(unit + 1)
             val blockId = if (isGroup) snap?.blockIdAt(rows.first) else null
             val key = if (snap != null) snap.keyAt(rows.first) else rowKey(itemAt(rows.first), rows.first)
+            // Stable per-row key for the nested within-block column's node identity — drawn from the
+            // same snapshot as everything else the drag reads.
+            val rowKeyAt: (Int) -> Any = { i -> if (snap != null) snap.keyAt(i) else rowKey(itemAt(i), i) }
             val currentReorderState = reorderState
             if (currentReorderState != null) {
                 ReorderableItem(state = currentReorderState, key = key) {
@@ -167,6 +184,15 @@ internal fun <T : Any, C, E> TableBody(
                             nextIsGroup = nextIsGroup,
                             blockId = blockId,
                             blockHeader = blocks?.config?.blockHeader,
+                            onRowMoveWithinBlock =
+                                if (withinBlockEnabled) {
+                                    { fromView, toView -> currentOnRowMoveWithinBlock.value?.invoke(fromView, toView) }
+                                } else {
+                                    null
+                                },
+                            onWithinBlockDragStarted = { currentOnBlockDragStarted.value?.invoke() },
+                            rowKeyAt = rowKeyAt,
+                            withinBlockRefusalCount = blocks?.refusedDropCount ?: 0,
                             itemAt = unitItemAt,
                             visibleColumns = visibleColumns,
                             state = state,
@@ -191,6 +217,10 @@ internal fun <T : Any, C, E> TableBody(
                         nextIsGroup = nextIsGroup,
                         blockId = blockId,
                         blockHeader = blocks?.config?.blockHeader,
+                        onRowMoveWithinBlock = null,
+                        onWithinBlockDragStarted = null,
+                        rowKeyAt = rowKeyAt,
+                        withinBlockRefusalCount = blocks?.refusedDropCount ?: 0,
                         itemAt = unitItemAt,
                         visibleColumns = visibleColumns,
                         state = state,
@@ -275,64 +305,47 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
 ) {
     if (itemsCount <= 0 && !state.settings.showFooter) return
 
-    // With blocks the drag is managed: units are blocks, so per-row onRowMove semantics cannot
-    // apply and display-only blocks (no onCommit) render without any drag at all.
+    // With blocks the drag is managed: units are blocks, so per-row onRowMove cannot apply. A block
+    // table drags when it can move whole blocks or reorder rows within one; neither = display-only.
     val rowReorderEnabled =
         state.settings.isRowReorderEnabled &&
-            (if (blocks != null) blocks.config.onCommit != null else onRowMove != null)
+            (
+                if (blocks != null) {
+                    blocks.config.onCommit != null || blocks.config.onRowReorderWithinBlock != null
+                } else {
+                    onRowMove != null
+                }
+            )
+    val withinBlockEnabled =
+        rowReorderEnabled && blocks != null && blocks.config.onRowReorderWithinBlock != null
 
-    // One element per drag unit, holding that unit's leading item. `ReorderableColumn` keys its
-    // internal drag state on this list *by equality*, and only rebuilds it — clearing the drag
-    // offsets left over from a drop — when the contents change. Elements must therefore track the
-    // items, not the unit indices: `0..unitCount-1` never changes and would strand those offsets.
-    // An eager snapshot, not a view over `itemAt`: a lazy view reads live data, so consecutive
-    // instances compare equal whenever unit geometry survives an upstream change — masking rebuilds
-    // the engine needs — and the settle guard below would compare a list against itself.
-    // Rebuilt on every composition, never memoized: without blocks `rowUnits` keys on the count
-    // alone and a consumer's `itemAt` routinely keeps one identity over live data, so any remember
-    // over them would survive an in-place list change — handing the engine, the row keys and the
-    // settle guard a stale snapshot. The engine dedupes equal contents itself, and the embedded
-    // path is sized for lists where an O(n) rebuild is noise. Wrapped with the refusal count
-    // because a refused drop is the one gesture that nets to zero over the leaders — see
-    // [EmbeddedUnitList].
+    // One element per drag unit, holding that unit's leading item. `ReorderableColumn` keys its drag
+    // state on this list by equality, so elements must track items (not unit indices, which never
+    // change) and must never be memoized (a stale snapshot would mask rebuilds the engine needs).
     val unitList: List<T?> =
         EmbeddedUnitList(
             List(rowUnits.unitCount) { unit -> itemAt(rowUnits.rowsOf(unit).first) },
             blocks?.refusedDropCount ?: 0,
         )
 
-    // `ReorderableColumn` captures `onSettle` once, when it builds that state, and never refreshes it
-    // — unlike the lazy path, whose `rememberReorderableLazyListState` wraps the callback in
-    // `rememberUpdatedState`. Leaders do not distinguish every layout this callback reads: inserting a
-    // row *into* a group changes `rowUnits` while leaving the leaders — and so the list — equal, so a
-    // captured callback would keep translating units against a stale index and report rows that no
-    // longer match the data. Route through the state, so the callback that runs is the current one.
+    // `ReorderableColumn` captures `onSettle` once and never refreshes it, so route through the
+    // state: equal leaders can hide a changed `rowUnits`, and a captured callback would then
+    // translate units against a stale index.
     val settleUnits: (List<T?>, Int, Int) -> Unit = settle@{ engineUnits, fromUnit, toUnit ->
-        // Unit indices mean nothing outside the list the engine laid out. When the list changes
-        // under an in-flight drag the engine rebuilds, and nothing in its contract stops the OLD
-        // state's disposal from delivering the dead gesture's settle here — through the trampoline
-        // above, which no snapshot latch in RowBlocksState can catch because embedded swaps arrive
-        // only at drop. Applying those indices to the new geometry could commit a move the user
-        // never made, so a settle is honored only when the engine's list still matches the rendered
-        // one; dropping the rest is the documented cancel-on-external-change policy. An engine that
-        // survived the change (equal leaders) keeps its indices meaningful and settles normally.
+        // Unit indices mean nothing outside the list the engine laid out: a rebuilt engine can still
+        // deliver the dead gesture's settle, and applying it would commit a move nobody made.
         if (engineUnits != unitList) return@settle
         if (blocks != null) {
-            // The embedded engine reports the gesture's net result once, at drop, so one unit move
-            // reproduces the whole drag and the commit settles in the same callback — the same
-            // exactly-one-event contract the lazy path keeps via its drag-stop wrapper.
+            // The embedded engine reports the gesture's net result once, at drop, so the commit
+            // settles in this same callback.
             blocks.applyUnitMove(fromUnit, toUnit)
             // Read the displacement before settle() — settling forgets the pre-gesture order.
             val remap = blocks.gestureRemap()
             val move = blocks.settle()
-            // A settle can refuse the drop (paged policy: the anchor is still a placeholder). The
-            // model snaps back, and the refusal count bumped inside settle() rebuilds the engine —
-            // whose leftover drag offsets would otherwise keep showing the dropped order over the
-            // restored one. Positional state then describes the restored order, and remapping it
-            // through the dead gesture's displacement would corrupt it.
+            // A refused drop snaps the model back; remapping positional state through the dead
+            // gesture's displacement would corrupt it.
             if (move != null && remap != null) {
-                // Positions whose content changed: cached heights describe other rows now, and
-                // re-measuring is the cheapest correct option.
+                // Cached heights describe other rows now; re-measuring is the cheapest fix.
                 for (viewIndex in 0 until blocks.itemsCount) {
                     if (remap(viewIndex) != viewIndex) state.rowHeightsPx.remove(viewIndex)
                 }
@@ -344,9 +357,7 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
     }
     val currentSettleUnits = rememberUpdatedState(settleUnits)
 
-    // An edit in flight validates against row positions that are about to shift. Same trampoline
-    // as the settle path: the per-item scope outlives any one composition of this body, so it gets
-    // a stable lambda that reads the current hook at gesture time.
+    // An edit in flight validates against row positions that are about to shift.
     val onBlockDragStarted: (() -> Unit)? =
         if (blocks != null) {
             {
@@ -356,6 +367,29 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
             null
         }
     val currentOnBlockDragStarted = rememberUpdatedState(onBlockDragStarted)
+
+    // The nested within-block column reports its gesture once, at drop: apply the row move then
+    // settle it, with the same remap and paged-refusal handling as the whole-block path.
+    val onRowMoveWithinBlock: ((fromView: Int, toView: Int) -> Unit)? =
+        if (withinBlockEnabled) {
+            { fromView, toView ->
+                blocks.applyRowMoveWithinBlock(fromView, toView)
+                val remap = blocks.gestureRemap()
+                val move = blocks.settleWithinBlock()
+                if (move != null && remap != null) {
+                    for (viewIndex in 0 until blocks.itemsCount) {
+                        if (remap(viewIndex) != viewIndex) state.rowHeightsPx.remove(viewIndex)
+                    }
+                    state.remapRowPositions(remap)
+                }
+            }
+        } else {
+            null
+        }
+    val currentOnRowMoveWithinBlock = rememberUpdatedState(onRowMoveWithinBlock)
+
+    // Stable per-row key for the nested within-block column's node identity.
+    val rowKeyAt: (Int) -> Any = { i -> rowKey(itemAt(i), i) }
 
     Column {
         if (rowReorderEnabled) {
@@ -385,6 +419,15 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
                                         rowUnits.isGroup(unitIndex + 1),
                                 blockId = if (isGroup) blocks?.blockIdAt(rows.first) else null,
                                 blockHeader = blocks?.config?.blockHeader,
+                                onRowMoveWithinBlock =
+                                    if (withinBlockEnabled) {
+                                        { fromView, toView -> currentOnRowMoveWithinBlock.value?.invoke(fromView, toView) }
+                                    } else {
+                                        null
+                                    },
+                                onWithinBlockDragStarted = { currentOnBlockDragStarted.value?.invoke() },
+                                rowKeyAt = rowKeyAt,
+                                withinBlockRefusalCount = blocks?.refusedDropCount ?: 0,
                                 itemAt = itemAt,
                                 visibleColumns = visibleColumns,
                                 state = state,
@@ -416,6 +459,10 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
                                 rowUnits.isGroup(unitIndex + 1),
                         blockId = if (isGroup) blocks?.blockIdAt(rows.first) else null,
                         blockHeader = blocks?.config?.blockHeader,
+                        onRowMoveWithinBlock = null,
+                        onWithinBlockDragStarted = null,
+                        rowKeyAt = rowKeyAt,
+                        withinBlockRefusalCount = blocks?.refusedDropCount ?: 0,
                         itemAt = itemAt,
                         visibleColumns = visibleColumns,
                         state = state,
@@ -465,10 +512,9 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
 context(_: TableItemScope)
 internal fun <T : Any, C, E> TableBodyRow(
     index: Int,
-    /** Passed through to [TableRowItem]; both are derived by [RowUnit] from the unit snapshot that
-     *  produced [index], keeping the leader test in step with the rendered position. */
+    /** Passed through to [TableRowItem]; derived by [RowUnit] from the unit snapshot that produced
+     *  [index], so row styling stays in step with the rendered position. */
     isInRowBlock: Boolean,
-    isRowBlockLeader: Boolean,
     itemAt: (Int) -> T?,
     visibleColumns: ImmutableList<ColumnSpec<T, C, E>>,
     state: TableState<C>,
@@ -527,7 +573,6 @@ internal fun <T : Any, C, E> TableBodyRow(
         item = item,
         index = index,
         isInRowBlock = isInRowBlock,
-        isRowBlockLeader = isRowBlockLeader,
         visibleColumns = visibleColumns,
         state = state,
         colors = colors,
@@ -551,14 +596,11 @@ internal fun <T : Any, C, E> TableBodyRow(
 }
 
 /**
- * The embedded engine's input list. `ReorderableColumn` clears the drag offsets left over from a
- * drop only by rebuilding its remembered state, and it rebuilds only when this list compares
- * unequal — but a REFUSED drop (paged policy) restores the view order, so the leaders alone
- * compare equal while the offsets still show the dropped order. Folding the refusal count into
- * equality makes every refusal a rebuild; the elements themselves stay untouched, so row identity
- * and the content lambdas are unaffected.
+ * The embedded engine's input list. A refused drop restores the view order, so the elements alone
+ * compare equal while the engine's drag offsets still show the dropped order; folding the refusal
+ * count into equality is what forces the rebuild that clears them.
  */
-private class EmbeddedUnitList<E>(
+internal class EmbeddedUnitList<E>(
     private val elements: List<E>,
     private val refusedDrops: Int,
 ) : List<E> by elements {

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableBody.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableBody.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
@@ -27,6 +28,8 @@ import ua.wwind.table.component.footer.TableFooter
 import ua.wwind.table.config.TableColors
 import ua.wwind.table.config.TableCustomization
 import ua.wwind.table.config.isRowReorderEnabled
+import ua.wwind.table.state.RowBlocksState
+import ua.wwind.table.state.RowUnitIndex
 import ua.wwind.table.state.TableState
 
 @Composable
@@ -45,7 +48,9 @@ internal fun <T : Any, C, E> TableBody(
     onRowClick: ((T) -> Unit)?,
     onRowLongClick: ((T) -> Unit)?,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)?,
+    blocks: RowBlocksState<T>?,
     onContextMenu: ((T, Offset) -> Unit)?,
+    rowUnits: RowUnitIndex,
     verticalState: LazyListState,
     horizontalState: ScrollState,
     requestTableFocus: () -> Unit,
@@ -53,34 +58,116 @@ internal fun <T : Any, C, E> TableBody(
     modifier: Modifier = Modifier,
 ) {
     val showFooter = state.settings.showFooter && !state.settings.footerPinned
-    val rowReorderEnabled = state.settings.isRowReorderEnabled && onRowMove != null
+    // With blocks the drag is managed: units are blocks, so per-row onRowMove semantics cannot
+    // apply and display-only blocks (no onCommit) render without any drag at all.
+    val rowReorderEnabled =
+        state.settings.isRowReorderEnabled &&
+            (if (blocks != null) blocks.config.onCommit != null else onRowMove != null)
     val reorderState =
         if (rowReorderEnabled) {
             rememberReorderableLazyListState(verticalState) { from, to ->
-                onRowMove.invoke(from.index, to.index)
+                if (blocks != null) {
+                    // Synchronous by design: the engine re-reads layout right after this call and
+                    // expects the swap already applied — the library's own permutation satisfies
+                    // that, the consumer's data stays untouched until the commit.
+                    blocks.applyUnitMove(from.index, to.index)
+                } else {
+                    onRowMove?.invoke(rowUnits.rowsOf(from.index).first, rowUnits.rowsOf(to.index).first)
+                }
             }
         } else {
             null
         }
+
+    // Commit side effects ride the drag lifecycle of the handle that owns the gesture, so the
+    // event fires exactly once per completed drag no matter how many items recomposed meanwhile.
+    val onBlockDragStarted: (() -> Unit)? =
+        if (blocks != null) {
+            {
+                // An edit in flight validates against row positions that are about to shift.
+                if (!state.tryCompleteEditing()) state.cancelEditing()
+            }
+        } else {
+            null
+        }
+    val onBlockDragStopped: (() -> Unit)? =
+        if (blocks != null) {
+            {
+                // Read the displacement before settle() — settling forgets the pre-gesture order.
+                val remap = blocks.gestureRemap()
+                val move = blocks.settle()
+                // A settle can refuse the drop (paged policy: the anchor is still a placeholder)
+                // and snap the view back; positional state then describes the restored order and
+                // remapping it through the dead gesture's displacement would corrupt it.
+                if (move != null && remap != null) {
+                    // Positions whose content changed: cached heights describe other rows now, and
+                    // re-measuring is the cheapest correct option.
+                    for (viewIndex in 0 until blocks.itemsCount) {
+                        if (remap(viewIndex) != viewIndex) state.rowHeightsPx.remove(viewIndex)
+                    }
+                    state.remapRowPositions(remap)
+                }
+            }
+        } else {
+            null
+        }
+    // The engine remembers its per-item scope for as long as the item's key survives — longer than
+    // any one composition of this body, and across a TableState recreation (rememberTableState
+    // swaps instances on settings/dimensions changes). Hooks frozen into that scope would keep
+    // mutating the dead state — cancelling its edits, remapping its selection — while the live one
+    // never hears about the drop. Same trampoline as the embedded settle path: the scope gets
+    // stable lambdas that read the current hooks at gesture time.
+    val currentOnBlockDragStarted = rememberUpdatedState(onBlockDragStarted)
+    val currentOnBlockDragStopped = rememberUpdatedState(onBlockDragStopped)
 
     LazyColumn(
         modifier = modifier,
         state = verticalState,
         userScrollEnabled = enableScrolling,
     ) {
-        items(count = itemsCount, key = { index -> rowKey(itemAt(index), index) }) { index ->
-            val key = rowKey(itemAt(index), index)
+        // Everything the drag reads about the permutation — unit boundaries, item, block id, key AND
+        // the is-leader test that gates the handle — must come from ONE snapshot read. [snapshot] is
+        // that read: [units] below is its own [RowUnitIndex], and [RowUnit] derives each row's
+        // is-leader flag from the same [rows] it hands down, so no reader falls back on the separately
+        // published state.rowUnits, which can lag this snapshot by a frame under a fast drag. Without
+        // blocks the units are identity and itemAt is the consumer's own, so the plain params already
+        // form one source.
+        val snap = blocks?.snapshot
+        val units = snap?.units ?: rowUnits
+        val unitItemAt: (Int) -> T? = if (snap != null) snap::itemAt else itemAt
+        items(
+            count = units.unitCount,
+            key = { unit ->
+                val leader = units.rowsOf(unit).first
+                if (snap != null) snap.keyAt(leader) else rowKey(itemAt(leader), leader)
+            },
+        ) { unit ->
+            val rows = units.rowsOf(unit)
+            val isGroup = units.isGroup(unit)
+            // Units only; the footer is a separate lazy item and never a group, so the bound keeps
+            // the lookup in range and a trailing block still draws its closing gap above the footer.
+            val nextIsGroup = unit < units.unitCount - 1 && units.isGroup(unit + 1)
+            val blockId = if (isGroup) snap?.blockIdAt(rows.first) else null
+            val key = if (snap != null) snap.keyAt(rows.first) else rowKey(itemAt(rows.first), rows.first)
             val currentReorderState = reorderState
             if (currentReorderState != null) {
                 ReorderableItem(state = currentReorderState, key = key) {
                     val rowScope: TableItemScope =
                         remember(this) {
-                            TableItemDragScope(this)
+                            TableItemDragScope(
+                                this,
+                                onDragStartedHook = { currentOnBlockDragStarted.value?.invoke() },
+                                onDragStoppedHook = { currentOnBlockDragStopped.value?.invoke() },
+                            )
                         }
                     context(rowScope) {
-                        TableBodyRow(
-                            index = index,
-                            itemAt = itemAt,
+                        RowUnit(
+                            rows = rows,
+                            isGroup = isGroup,
+                            nextIsGroup = nextIsGroup,
+                            blockId = blockId,
+                            blockHeader = blocks?.config?.blockHeader,
+                            itemAt = unitItemAt,
                             visibleColumns = visibleColumns,
                             state = state,
                             colors = colors,
@@ -98,9 +185,13 @@ internal fun <T : Any, C, E> TableBody(
                 }
             } else {
                 context(DefaultTableItemScope) {
-                    TableBodyRow(
-                        index = index,
-                        itemAt = itemAt,
+                    RowUnit(
+                        rows = rows,
+                        isGroup = isGroup,
+                        nextIsGroup = nextIsGroup,
+                        blockId = blockId,
+                        blockHeader = blocks?.config?.blockHeader,
+                        itemAt = unitItemAt,
                         visibleColumns = visibleColumns,
                         state = state,
                         colors = colors,
@@ -176,33 +267,124 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
     onRowClick: ((T) -> Unit)?,
     onRowLongClick: ((T) -> Unit)?,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)?,
+    blocks: RowBlocksState<T>?,
     onContextMenu: ((T, Offset) -> Unit)?,
+    rowUnits: RowUnitIndex,
     horizontalState: ScrollState,
     requestTableFocus: () -> Unit,
 ) {
     if (itemsCount <= 0 && !state.settings.showFooter) return
 
-    val rowMoveCallback = onRowMove
-    val rowReorderEnabled = state.settings.isRowReorderEnabled && rowMoveCallback != null
-    val itemList = remember(itemsCount, itemAt) { IndexedListAdapter(itemsCount, itemAt) }
+    // With blocks the drag is managed: units are blocks, so per-row onRowMove semantics cannot
+    // apply and display-only blocks (no onCommit) render without any drag at all.
+    val rowReorderEnabled =
+        state.settings.isRowReorderEnabled &&
+            (if (blocks != null) blocks.config.onCommit != null else onRowMove != null)
+
+    // One element per drag unit, holding that unit's leading item. `ReorderableColumn` keys its
+    // internal drag state on this list *by equality*, and only rebuilds it — clearing the drag
+    // offsets left over from a drop — when the contents change. Elements must therefore track the
+    // items, not the unit indices: `0..unitCount-1` never changes and would strand those offsets.
+    // An eager snapshot, not a view over `itemAt`: a lazy view reads live data, so consecutive
+    // instances compare equal whenever unit geometry survives an upstream change — masking rebuilds
+    // the engine needs — and the settle guard below would compare a list against itself.
+    // Rebuilt on every composition, never memoized: without blocks `rowUnits` keys on the count
+    // alone and a consumer's `itemAt` routinely keeps one identity over live data, so any remember
+    // over them would survive an in-place list change — handing the engine, the row keys and the
+    // settle guard a stale snapshot. The engine dedupes equal contents itself, and the embedded
+    // path is sized for lists where an O(n) rebuild is noise. Wrapped with the refusal count
+    // because a refused drop is the one gesture that nets to zero over the leaders — see
+    // [EmbeddedUnitList].
+    val unitList: List<T?> =
+        EmbeddedUnitList(
+            List(rowUnits.unitCount) { unit -> itemAt(rowUnits.rowsOf(unit).first) },
+            blocks?.refusedDropCount ?: 0,
+        )
+
+    // `ReorderableColumn` captures `onSettle` once, when it builds that state, and never refreshes it
+    // — unlike the lazy path, whose `rememberReorderableLazyListState` wraps the callback in
+    // `rememberUpdatedState`. Leaders do not distinguish every layout this callback reads: inserting a
+    // row *into* a group changes `rowUnits` while leaving the leaders — and so the list — equal, so a
+    // captured callback would keep translating units against a stale index and report rows that no
+    // longer match the data. Route through the state, so the callback that runs is the current one.
+    val settleUnits: (List<T?>, Int, Int) -> Unit = settle@{ engineUnits, fromUnit, toUnit ->
+        // Unit indices mean nothing outside the list the engine laid out. When the list changes
+        // under an in-flight drag the engine rebuilds, and nothing in its contract stops the OLD
+        // state's disposal from delivering the dead gesture's settle here — through the trampoline
+        // above, which no snapshot latch in RowBlocksState can catch because embedded swaps arrive
+        // only at drop. Applying those indices to the new geometry could commit a move the user
+        // never made, so a settle is honored only when the engine's list still matches the rendered
+        // one; dropping the rest is the documented cancel-on-external-change policy. An engine that
+        // survived the change (equal leaders) keeps its indices meaningful and settles normally.
+        if (engineUnits != unitList) return@settle
+        if (blocks != null) {
+            // The embedded engine reports the gesture's net result once, at drop, so one unit move
+            // reproduces the whole drag and the commit settles in the same callback — the same
+            // exactly-one-event contract the lazy path keeps via its drag-stop wrapper.
+            blocks.applyUnitMove(fromUnit, toUnit)
+            // Read the displacement before settle() — settling forgets the pre-gesture order.
+            val remap = blocks.gestureRemap()
+            val move = blocks.settle()
+            // A settle can refuse the drop (paged policy: the anchor is still a placeholder). The
+            // model snaps back, and the refusal count bumped inside settle() rebuilds the engine —
+            // whose leftover drag offsets would otherwise keep showing the dropped order over the
+            // restored one. Positional state then describes the restored order, and remapping it
+            // through the dead gesture's displacement would corrupt it.
+            if (move != null && remap != null) {
+                // Positions whose content changed: cached heights describe other rows now, and
+                // re-measuring is the cheapest correct option.
+                for (viewIndex in 0 until blocks.itemsCount) {
+                    if (remap(viewIndex) != viewIndex) state.rowHeightsPx.remove(viewIndex)
+                }
+                state.remapRowPositions(remap)
+            }
+        } else {
+            onRowMove?.invoke(rowUnits.rowsOf(fromUnit).first, rowUnits.rowsOf(toUnit).first)
+        }
+    }
+    val currentSettleUnits = rememberUpdatedState(settleUnits)
+
+    // An edit in flight validates against row positions that are about to shift. Same trampoline
+    // as the settle path: the per-item scope outlives any one composition of this body, so it gets
+    // a stable lambda that reads the current hook at gesture time.
+    val onBlockDragStarted: (() -> Unit)? =
+        if (blocks != null) {
+            {
+                if (!state.tryCompleteEditing()) state.cancelEditing()
+            }
+        } else {
+            null
+        }
+    val currentOnBlockDragStarted = rememberUpdatedState(onBlockDragStarted)
 
     Column {
         if (rowReorderEnabled) {
             ReorderableColumn(
-                list = itemList,
-                onSettle = { fromIndex, toIndex ->
-                    rowMoveCallback.invoke(fromIndex, toIndex)
-                },
-            ) { index, item, _ ->
-                key(rowKey(item, index)) {
+                list = unitList,
+                // `unitList` is captured alongside the callback: the guard in settleUnits needs to
+                // know which list THIS engine laid out, and the engine keeps the capture for life.
+                onSettle = { fromUnit, toUnit -> currentSettleUnits.value(unitList, fromUnit, toUnit) },
+            ) { unitIndex, leadingItem, _ ->
+                val rows = rowUnits.rowsOf(unitIndex)
+                val isGroup = rowUnits.isGroup(unitIndex)
+                key(rowKey(leadingItem, rows.first)) {
                     ReorderableItem {
                         val rowScope: TableItemScope =
                             remember(this) {
-                                TableItemListDragScope(this)
+                                TableItemListDragScope(
+                                    this,
+                                    onDragStartedHook = { currentOnBlockDragStarted.value?.invoke() },
+                                )
                             }
                         context(rowScope) {
-                            TableBodyRow(
-                                index = index,
+                            RowUnit(
+                                rows = rows,
+                                isGroup = isGroup,
+                                nextIsGroup =
+                                    unitIndex < rowUnits.unitCount - 1 &&
+                                        rowUnits.isGroup(unitIndex + 1),
+                                blockId = if (isGroup) blocks?.blockIdAt(rows.first) else null,
+                                blockHeader = blocks?.config?.blockHeader,
                                 itemAt = itemAt,
                                 visibleColumns = visibleColumns,
                                 state = state,
@@ -222,10 +404,18 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
                 }
             }
         } else {
-            for (index in 0 until itemsCount) {
+            for (unitIndex in 0 until rowUnits.unitCount) {
+                val rows = rowUnits.rowsOf(unitIndex)
+                val isGroup = rowUnits.isGroup(unitIndex)
                 context(DefaultTableItemScope) {
-                    TableBodyRow(
-                        index = index,
+                    RowUnit(
+                        rows = rows,
+                        isGroup = isGroup,
+                        nextIsGroup =
+                            unitIndex < rowUnits.unitCount - 1 &&
+                                rowUnits.isGroup(unitIndex + 1),
+                        blockId = if (isGroup) blocks?.blockIdAt(rows.first) else null,
+                        blockHeader = blocks?.config?.blockHeader,
                         itemAt = itemAt,
                         visibleColumns = visibleColumns,
                         state = state,
@@ -270,26 +460,15 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
     }
 }
 
-private class IndexedListAdapter<T>(
-    private val itemsCount: Int,
-    private val itemAt: (Int) -> T
-) : AbstractList<T>() {
-    override val size: Int
-        get() = itemsCount
-
-    override fun get(index: Int): T {
-        require(index in 0 until itemsCount) {
-            "Index $index is out of bounds for list size $itemsCount"
-        }
-        return itemAt(index)
-    }
-}
-
 @Composable
 @Suppress("LongParameterList")
 context(_: TableItemScope)
-private fun <T : Any, C, E> TableBodyRow(
+internal fun <T : Any, C, E> TableBodyRow(
     index: Int,
+    /** Passed through to [TableRowItem]; both are derived by [RowUnit] from the unit snapshot that
+     *  produced [index], keeping the leader test in step with the rendered position. */
+    isInRowBlock: Boolean,
+    isRowBlockLeader: Boolean,
     itemAt: (Int) -> T?,
     visibleColumns: ImmutableList<ColumnSpec<T, C, E>>,
     state: TableState<C>,
@@ -347,6 +526,8 @@ private fun <T : Any, C, E> TableBodyRow(
     TableRowItem(
         item = item,
         index = index,
+        isInRowBlock = isInRowBlock,
+        isRowBlockLeader = isRowBlockLeader,
         visibleColumns = visibleColumns,
         state = state,
         colors = colors,
@@ -367,4 +548,22 @@ private fun <T : Any, C, E> TableBodyRow(
             thickness = state.dimensions.dividerThickness,
         )
     }
+}
+
+/**
+ * The embedded engine's input list. `ReorderableColumn` clears the drag offsets left over from a
+ * drop only by rebuilding its remembered state, and it rebuilds only when this list compares
+ * unequal — but a REFUSED drop (paged policy) restores the view order, so the leaders alone
+ * compare equal while the offsets still show the dropped order. Folding the refusal count into
+ * equality makes every refusal a rebuild; the elements themselves stay untouched, so row identity
+ * and the content lambdas are unaffected.
+ */
+private class EmbeddedUnitList<E>(
+    private val elements: List<E>,
+    private val refusedDrops: Int,
+) : List<E> by elements {
+    override fun equals(other: Any?): Boolean =
+        other is EmbeddedUnitList<*> && refusedDrops == other.refusedDrops && elements == other.elements
+
+    override fun hashCode(): Int = 31 * elements.hashCode() + refusedDrops
 }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableRowItem.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableRowItem.kt
@@ -79,6 +79,13 @@ context(rowScope: TableItemScope)
 internal fun <T : Any, C, E> TableRowItem(
     item: T?,
     index: Int,
+    /** Whether [index] falls inside a row block; supplied by the caller from the same unit snapshot
+     *  that produced [index], so it can never disagree with the rendered position. */
+    isInRowBlock: Boolean,
+    /** Whether [index] is the leader (first) row of its unit — every standalone row, or a block's
+     *  first row. Gates the drag handle, so it MUST track [index]'s own snapshot, not the separately
+     *  published state.rowUnits, which lags by a frame under a fast drag and would drop the handle. */
+    isRowBlockLeader: Boolean,
     visibleColumns: ImmutableList<ColumnSpec<T, C, E>>,
     state: TableState<C>,
     colors: ua.wwind.table.config.TableColors,
@@ -97,6 +104,10 @@ internal fun <T : Any, C, E> TableRowItem(
     val isDynamicRowHeight = state.settings.rowHeightMode == RowHeightMode.Dynamic
     val settings = state.settings
 
+    // isInRowBlock / isRowBlockLeader are passed in from the caller (RowUnit), derived from the same
+    // unit snapshot as [index]. Recomputing them here from state.rowUnits reopened a frame-lag split
+    // that dropped the drag handle mid-gesture on a fast drag.
+
     val defaultRowBackgroundColor =
         when {
             isSelected -> colors.rowSelectedContainerColor
@@ -112,7 +123,7 @@ internal fun <T : Any, C, E> TableRowItem(
                     index = index,
                     isSelected = isSelected,
                     isStriped = state.settings.stripedRows && (index % 2 != 0),
-                    isGroup = false,
+                    isInRowBlock = isInRowBlock,
                     isDeleted = false,
                 )
             customization.resolveRowStyle(ctx)
@@ -171,6 +182,8 @@ internal fun <T : Any, C, E> TableRowItem(
                         item = item,
                         tableData = tableData,
                         isSelected = isSelected,
+                        isInRowBlock = isInRowBlock,
+                        isRowBlockLeader = isRowBlockLeader,
                         settings = settings,
                         horizontalState = horizontalState,
                         finalRowColor = finalRowColor,
@@ -209,6 +222,8 @@ private fun <C, T : Any, E> RenderTableRowItem(
     item: T,
     tableData: E,
     isSelected: Boolean,
+    isInRowBlock: Boolean,
+    isRowBlockLeader: Boolean,
     settings: TableSettings,
     horizontalState: ScrollState,
     finalRowColor: Color,
@@ -238,7 +253,7 @@ private fun <C, T : Any, E> RenderTableRowItem(
                                 isStriped =
                                     state.settings.stripedRows &&
                                         (index % 2 != 0),
-                                isGroup = false,
+                                isInRowBlock = isInRowBlock,
                                 isDeleted = false,
                             ),
                         column = spec.key,
@@ -396,7 +411,10 @@ private fun <C, T : Any, E> RenderTableRowItem(
                         }
                     }
                 } else {
-                    val cellScope = remember(rowScope) { TableCellScopeImpl(rowScope) }
+                    val cellScope =
+                        remember(rowScope, isRowBlockLeader) {
+                            TableCellScopeImpl(rowScope, isRowBlockLeader)
+                        }
                     context(cellScope) {
                         spec.cell(this@TableCell, item, tableData)
                     }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableRowItem.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableRowItem.kt
@@ -82,10 +82,6 @@ internal fun <T : Any, C, E> TableRowItem(
     /** Whether [index] falls inside a row block; supplied by the caller from the same unit snapshot
      *  that produced [index], so it can never disagree with the rendered position. */
     isInRowBlock: Boolean,
-    /** Whether [index] is the leader (first) row of its unit — every standalone row, or a block's
-     *  first row. Gates the drag handle, so it MUST track [index]'s own snapshot, not the separately
-     *  published state.rowUnits, which lags by a frame under a fast drag and would drop the handle. */
-    isRowBlockLeader: Boolean,
     visibleColumns: ImmutableList<ColumnSpec<T, C, E>>,
     state: TableState<C>,
     colors: ua.wwind.table.config.TableColors,
@@ -104,9 +100,8 @@ internal fun <T : Any, C, E> TableRowItem(
     val isDynamicRowHeight = state.settings.rowHeightMode == RowHeightMode.Dynamic
     val settings = state.settings
 
-    // isInRowBlock / isRowBlockLeader are passed in from the caller (RowUnit), derived from the same
-    // unit snapshot as [index]. Recomputing them here from state.rowUnits reopened a frame-lag split
-    // that dropped the drag handle mid-gesture on a fast drag.
+    // isInRowBlock is passed in from the caller (RowUnit), derived from the same unit snapshot as
+    // [index], so it can never disagree with the rendered position.
 
     val defaultRowBackgroundColor =
         when {
@@ -183,7 +178,6 @@ internal fun <T : Any, C, E> TableRowItem(
                         tableData = tableData,
                         isSelected = isSelected,
                         isInRowBlock = isInRowBlock,
-                        isRowBlockLeader = isRowBlockLeader,
                         settings = settings,
                         horizontalState = horizontalState,
                         finalRowColor = finalRowColor,
@@ -223,7 +217,6 @@ private fun <C, T : Any, E> RenderTableRowItem(
     tableData: E,
     isSelected: Boolean,
     isInRowBlock: Boolean,
-    isRowBlockLeader: Boolean,
     settings: TableSettings,
     horizontalState: ScrollState,
     finalRowColor: Color,
@@ -412,8 +405,8 @@ private fun <C, T : Any, E> RenderTableRowItem(
                     }
                 } else {
                     val cellScope =
-                        remember(rowScope, isRowBlockLeader) {
-                            TableCellScopeImpl(rowScope, isRowBlockLeader)
+                        remember(rowScope) {
+                            TableCellScopeImpl(rowScope)
                         }
                     context(cellScope) {
                         spec.cell(this@TableCell, item, tableData)

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableViewportPrefetcher.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableViewportPrefetcher.kt
@@ -58,8 +58,17 @@ internal fun <T : Any, C, E> TableViewportPrefetcher(
         snapshotFlow<Pair<Int, Int>> {
             val li = verticalState.layoutInfo
             val viewport = (li.viewportEndOffset - li.viewportStartOffset).coerceAtLeast(0)
-            val lastVisible = li.visibleItemsInfo.maxByOrNull { it.index }?.index ?: -1
-            Pair(viewport, (lastVisible + 1).coerceAtMost(itemsCount))
+            // Lazy items are units; the prefetch loop below walks rows, so translate back to rows.
+            val lastVisibleUnit = li.visibleItemsInfo.maxByOrNull { it.index }?.index ?: -1
+            val units = state.rowUnits
+            val nextRow =
+                when {
+                    lastVisibleUnit < 0 -> 0
+                    // The footer is an extra lazy item at index == unitCount; it has no rows.
+                    lastVisibleUnit >= units.unitCount -> itemsCount
+                    else -> units.rowsOf(lastVisibleUnit).last + 1
+                }
+            Pair(viewport, nextRow.coerceAtMost(itemsCount))
         }.distinctUntilChanged()
             .collect { pair ->
                 val (vp, start) = pair
@@ -93,12 +102,18 @@ internal fun <T : Any, C, E> TableViewportPrefetcher(
                 if (known != null) {
                     known
                 } else {
+                    // Leader / in-block flags from the same units this row is measured against.
+                    // Offscreen measurement, no live gesture, so state.rowUnits is the right source.
+                    val pfUnits = state.rowUnits
+                    val pfUnit = pfUnits.unitOf(i)
                     val measurables =
                         subcompose(slotId = i) {
                             context(DefaultTableItemScope) {
                                 TableRowItem(
                                     item = itemAt(i),
                                     index = i,
+                                    isInRowBlock = pfUnits.isGroup(pfUnit),
+                                    isRowBlockLeader = pfUnits.rowsOf(pfUnit).first == i,
                                     visibleColumns = visibleColumns,
                                     state = state,
                                     colors = colors,

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableViewportPrefetcher.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableViewportPrefetcher.kt
@@ -102,8 +102,8 @@ internal fun <T : Any, C, E> TableViewportPrefetcher(
                 if (known != null) {
                     known
                 } else {
-                    // Leader / in-block flags from the same units this row is measured against.
-                    // Offscreen measurement, no live gesture, so state.rowUnits is the right source.
+                    // In-block flag from the same units this row is measured against. Offscreen
+                    // measurement, no live gesture, so state.rowUnits is the right source.
                     val pfUnits = state.rowUnits
                     val pfUnit = pfUnits.unitOf(i)
                     val measurables =
@@ -113,7 +113,6 @@ internal fun <T : Any, C, E> TableViewportPrefetcher(
                                     item = itemAt(i),
                                     index = i,
                                     isInRowBlock = pfUnits.isGroup(pfUnit),
-                                    isRowBlockLeader = pfUnits.rowsOf(pfUnit).first == i,
                                     visibleColumns = visibleColumns,
                                     state = state,
                                     colors = colors,

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/header/ColumnHeaderDropdownMenuBox.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/header/ColumnHeaderDropdownMenuBox.kt
@@ -111,6 +111,10 @@ internal fun <T : Any, C, E> ColumnHeaderDropdownMenuBox(
             } else {
                 DropdownMenuItem(
                     text = { Text(strings.get(UiString.GroupBy)) },
+                    // Activating groupBy would silently suppress visible row blocks (the two are
+                    // mutually exclusive); disabling the item surfaces that instead of letting the
+                    // blocks vanish on a menu click.
+                    enabled = !state.rowBlocksNonEmpty,
                     onClick = {
                         state.groupBy(spec.key)
                         if (spec.sortable && state.sort?.column != spec.key) {

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/config/TableColors.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/config/TableColors.kt
@@ -1,7 +1,11 @@
 package ua.wwind.table.config
 
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.takeOrElse
 
 /** Color palette used by the table header and rows. */
 @Immutable
@@ -14,4 +18,20 @@ public data class TableColors(
     val groupContainerColor: Color,
     val footerContainerColor: Color,
     val footerContentColor: Color,
+    /**
+     * Container painted behind a row block declared via `rowBlocks`. Appended with a default —
+     * never inserted as a required parameter — so pre-blocks positional constructor calls keep
+     * compiling; [Color.Unspecified] resolves to `surfaceContainerHighest` at draw.
+     */
+    val rowBlockContainerColor: Color = Color.Unspecified,
 )
+
+/**
+ * Resolved at draw rather than defaulted in [TableDefaults.colors] so that a [TableColors] built
+ * directly — without the composable factory — still lands on the themed band color instead of
+ * painting a transparent band.
+ */
+@Composable
+@ReadOnlyComposable
+internal fun resolveRowBlockContainerColor(colors: TableColors): Color =
+    colors.rowBlockContainerColor.takeOrElse { MaterialTheme.colorScheme.surfaceContainerHighest }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/config/TableCustomization.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/config/TableCustomization.kt
@@ -40,9 +40,20 @@ public data class TableRowContext<T : Any, C>(
     val index: Int,
     val isSelected: Boolean,
     val isStriped: Boolean,
-    val isGroup: Boolean,
+    /** True for rows rendered inside a row block declared via `rowBlocks`, so members can be styled. */
+    val isInRowBlock: Boolean,
     val isDeleted: Boolean,
-)
+) {
+    /**
+     * Shipped under a name that collides with column-value grouping (`groupBy`), which never sets
+     * it — row blocks do. Kept as a forwarder so released consumers compile through the rename.
+     */
+    @Deprecated(
+        "Renamed: \"group\" is the groupBy vocabulary; this flag marks row block membership.",
+        ReplaceWith("isInRowBlock"),
+    )
+    public val isGroup: Boolean get() = isInRowBlock
+}
 
 @Immutable
 public data class TableCellContext<T : Any, C>(

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/config/TableDefaults.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/config/TableDefaults.kt
@@ -14,7 +14,12 @@ public object TableDefaults {
      */
     public val NoBorder: BorderStroke = BorderStroke(0.dp, Color.Transparent)
 
-    /** Convenience factory for default [TableColors] derived from [androidx.compose.material3.MaterialTheme]. */
+    /**
+     * Convenience factory for default [TableColors] derived from [androidx.compose.material3.MaterialTheme].
+     *
+     * New parameters are appended, never inserted: every parameter here is a [Color], so inserting one
+     * would leave positional calls compiling while silently binding to the wrong colors.
+     */
     @Composable
     public fun colors(
         headerContainerColor: Color = MaterialTheme.colorScheme.surfaceContainer,
@@ -27,6 +32,8 @@ public object TableDefaults {
         footerContainerColor: Color = MaterialTheme.colorScheme.surfaceContainer,
         footerContentColor: Color =
             MaterialTheme.colorScheme.contentColorFor(footerContainerColor),
+        /** Kept [Color.Unspecified] here too: the band color resolves at draw for every construction path. */
+        rowBlockContainerColor: Color = Color.Unspecified,
     ): TableColors =
         TableColors(
             headerContainerColor = headerContainerColor,
@@ -35,6 +42,7 @@ public object TableDefaults {
             rowSelectedContainerColor = rowSelectedContainerColor,
             stripedRowContainerColor = stripedRowContainerColor,
             groupContainerColor = groupContainerColor,
+            rowBlockContainerColor = rowBlockContainerColor,
             footerContainerColor = footerContainerColor,
             footerContentColor = footerContentColor,
         )

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/config/TableDimensions.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/config/TableDimensions.kt
@@ -21,9 +21,12 @@ public data class TableDimensions(
         level = DeprecationLevel.WARNING,
     )
     val fixedColumnDividerThickness: Dp = pinnedColumnDividerThickness,
+    /** Vertical gap rendered above and below a row block declared via `rowBlocks`. */
+    val rowBlockSpacing: Dp = 8.dp,
 ) {
     init {
         require(dividerThickness >= 1.dp) { "dividerThickness must be at least 1.dp" }
         require(pinnedColumnDividerThickness >= 1.dp) { "pinnedColumnDividerThickness must be at least 1.dp" }
+        require(rowBlockSpacing >= 0.dp) { "rowBlockSpacing must not be negative" }
     }
 }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/interaction/KeyboardNavigation.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/interaction/KeyboardNavigation.kt
@@ -112,7 +112,18 @@ internal fun <T : Any, C> Modifier.tableKeyboardNavigation(
                                     val bottom = item.offset + item.size
                                     top >= 0 && bottom <= viewportHeight
                                 }.coerceAtLeast(1)
-                        val target = currentRow + fullyVisible
+                        // `fullyVisible` counts lazy items (units), so page by units and land on the
+                        // target unit's first row. Without groups this reduces to currentRow + fullyVisible.
+                        val units = state.rowUnits
+                        val target =
+                            if (units.unitCount <= 0) {
+                                currentRow
+                            } else {
+                                val targetUnit =
+                                    (units.unitOf(currentRow) + fullyVisible)
+                                        .coerceAtMost(units.unitCount - 1)
+                                units.rowsOf(targetUnit).first
+                            }
                         ensureFocus(target, currentColIndex)
                         true
                     }
@@ -128,7 +139,15 @@ internal fun <T : Any, C> Modifier.tableKeyboardNavigation(
                                     val bottom = item.offset + item.size
                                     top >= 0 && bottom <= viewportHeight
                                 }.coerceAtLeast(1)
-                        val target = currentRow - fullyVisible
+                        // See PageDown: page by units, then land on the target unit's first row.
+                        val units = state.rowUnits
+                        val target =
+                            if (units.unitCount <= 0) {
+                                currentRow
+                            } else {
+                                val targetUnit = (units.unitOf(currentRow) - fullyVisible).coerceAtLeast(0)
+                                units.rowsOf(targetUnit).first
+                            }
                         ensureFocus(target, currentColIndex)
                         true
                     }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/interaction/ViewportUtils.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/interaction/ViewportUtils.kt
@@ -8,7 +8,15 @@ import androidx.compose.ui.unit.dp
 import ua.wwind.table.ColumnSpec
 import ua.wwind.table.state.TableState
 
-/** Ensure that the given [index] row becomes fully visible in the viewport (supports dynamic row heights). */
+/**
+ * Ensure that the given [index] row becomes fully visible in the viewport (supports dynamic row heights).
+ *
+ * [index] is a row index; the backing `LazyColumn` is indexed by *units* (a unit is a single row or a
+ * declared group of adjacent rows), so it is translated once via [TableState.rowUnits] and the unit
+ * index is used for every `layoutInfo` lookup and scroll call. Height estimates stay keyed by row
+ * (`state.rowHeightsPx`): they under-count a group's internal gap, which is acceptable because every
+ * branch fine-tunes the final scroll from the measured `info.offset` once the target unit is visible.
+ */
 public suspend fun <C> ensureRowFullyVisible(
     index: Int,
     verticalState: LazyListState,
@@ -16,16 +24,17 @@ public suspend fun <C> ensureRowFullyVisible(
     density: Density,
     movement: Int = 0,
 ) {
+    val unitIndex = state.rowUnits.unitOf(index)
     val layout = verticalState.layoutInfo
     val visible = layout.visibleItemsInfo
     if (visible.isEmpty()) {
-        verticalState.animateScrollToItem(index)
+        verticalState.animateScrollToItem(unitIndex)
         return
     }
 
     val firstVisibleIndex = visible.first().index
     val lastVisibleIndex = visible.last().index
-    val targetInfo = visible.firstOrNull { it.index == index }
+    val targetInfo = visible.firstOrNull { it.index == unitIndex }
     val viewportHeight = (layout.viewportEndOffset - layout.viewportStartOffset).coerceAtLeast(0)
 
     if (targetInfo != null) {
@@ -39,29 +48,29 @@ public suspend fun <C> ensureRowFullyVisible(
         return
     }
 
-    if (index < firstVisibleIndex) {
+    if (unitIndex < firstVisibleIndex) {
         // If moving upward and the target is immediately above, scroll just enough to reveal it at the top.
         val prevIndex = firstVisibleIndex - 1
-        if (movement < 0 && index == prevIndex) {
+        if (movement < 0 && unitIndex == prevIndex) {
             val estimatedHeight =
                 state.rowHeightsPx[index] ?: with(density) { state.dimensions.rowHeight.toPx() }.toInt()
             val firstTop = visible.first().offset
             val delta = (firstTop - estimatedHeight)
             if (delta != 0) verticalState.animateScrollBy(delta.toFloat())
             // Fine-tune once it becomes visible
-            val info = verticalState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == index }
+            val info = verticalState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == unitIndex }
             if (info != null && info.offset < 0) verticalState.animateScrollBy(info.offset.toFloat())
         } else {
             // Fallback: align to top
-            verticalState.animateScrollToItem(index)
+            verticalState.animateScrollToItem(unitIndex)
         }
         return
     }
 
-    if (index > lastVisibleIndex) {
-        // If moving downward and the target is the next row after the last visible, reveal just one row.
+    if (unitIndex > lastVisibleIndex) {
+        // If moving downward and the target is the next unit after the last visible, reveal just one unit.
         val nextIndex = lastVisibleIndex + 1
-        if (movement > 0 && index == nextIndex) {
+        if (movement > 0 && unitIndex == nextIndex) {
             val estimatedHeight =
                 state.rowHeightsPx[index] ?: with(density) { state.dimensions.rowHeight.toPx() }.toInt()
             val last = visible.last()
@@ -70,7 +79,7 @@ public suspend fun <C> ensureRowFullyVisible(
             val delta = (lastBottom - desiredTop).coerceAtLeast(0)
             if (delta != 0) verticalState.animateScrollBy(delta.toFloat())
             // Fine-tune now that it's visible
-            val info = verticalState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == index }
+            val info = verticalState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == unitIndex }
             if (info != null) {
                 val bottom = info.offset + info.size
                 val overflow = bottom - viewportHeight
@@ -83,9 +92,11 @@ public suspend fun <C> ensureRowFullyVisible(
 
             fun heightOf(i: Int): Int = state.rowHeightsPx[i] ?: defaultHeight
 
-            // Sum heights between the last visible row and the target (excluding the target)
+            // Sum heights between the last visible row and the target (excluding the target).
+            // `lastVisibleIndex` is a unit index, so translate it back to the last row it renders
+            // before walking rows; with no groups this is exactly `lastVisibleIndex + 1`.
             var betweenSum = 0
-            var i = lastVisibleIndex + 1
+            var i = state.rowUnits.rowsOf(lastVisibleIndex).last + 1
             while (i < index) {
                 betweenSum += heightOf(i)
                 i++
@@ -99,7 +110,7 @@ public suspend fun <C> ensureRowFullyVisible(
             if (delta != 0) verticalState.animateScrollBy(delta.toFloat())
 
             // Fine-tune once it becomes visible (avoid off-by-one and dynamic height adjustments)
-            val info = verticalState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == index }
+            val info = verticalState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == unitIndex }
             if (info != null) {
                 val bottom = info.offset + info.size
                 val overflow = bottom - viewportHeight

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/state/RowBlocksState.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/state/RowBlocksState.kt
@@ -7,26 +7,18 @@ import androidx.compose.runtime.setValue
 import co.touchlab.kermit.Logger
 import ua.wwind.table.RowBlockMove
 import ua.wwind.table.RowBlocks
+import ua.wwind.table.RowWithinBlockMove
 
-/** A maximal run of adjacent rows sharing one non-null block id; [rows] is in view (rendered) space. */
+/** A maximal run of adjacent rows sharing one non-null block id; [rows] is in view space. */
 internal class RowBlockRun(
     val id: Any,
     val rows: IntRange,
 )
 
 /**
- * The managed side of [RowBlocks]: owns the view permutation a drag gesture mutates, so the reorder
- * engine's synchronous-layout expectation is satisfied inside the library instead of being imposed
- * on the consumer (whose pipeline is typically asynchronous and cannot apply moves mid-gesture).
- *
- * The upstream list is what the consumer renders; the view order is a permutation over it that is
- * identity except between a drag's first swap and the moment the consumer's applied move flows back
- * through [reconcile]. Block runs are re-derived from the permuted order on every change, so unit
- * boundaries can never disagree with what is on screen.
- *
- * Backed by snapshot state throughout — the order and the gesture fields alike — so composition
- * that reads [runs], [units], [itemAt] or [isDragActive] recomposes on change, and a rolled-back
- * snapshot cannot leave a gesture half-cancelled.
+ * Owns the view permutation a drag mutates, so the reorder engine's synchronous-layout expectation
+ * is met inside the library rather than imposed on the consumer's asynchronous pipeline.
+ * Snapshot-backed throughout, so a rolled-back snapshot cannot leave a gesture half-cancelled.
  */
 internal class RowBlocksState<T : Any>(
     val config: RowBlocks<T>,
@@ -42,24 +34,20 @@ internal class RowBlocksState<T : Any>(
     /** Upstream indices of the dragged unit; non-null exactly while a gesture is in progress. */
     private var draggedRows: List<Int>? by mutableStateOf(null)
 
-    /** [viewOrder] at gesture start; [settle] emits nothing when the gesture ends back on it. */
+    /** [viewOrder] at gesture start; a gesture ending back on it emits nothing. */
     private var preGestureOrder: List<Int>? by mutableStateOf(null)
 
-    /** Set when [reconcile] cancels an in-flight gesture; the engine's late swaps for that dead
-     *  gesture are dropped until the pointer goes up and [settle] releases the latch. */
+    /** Drops the engine's late swaps for a gesture [reconcile] already cancelled. */
     private var cancelledUntilSettle: Boolean by mutableStateOf(false)
 
     /**
-     * Bumps once per refused drop (paged policy in [settle]). A refusal restores [viewOrder], so
-     * over any list derived from it the whole gesture nets to zero — invisible to the embedded
-     * engine, which clears the drag offsets left over from a drop only when its input list
-     * compares unequal. Folding this count into that list's equality is what turns a refusal into
-     * the rebuild that snaps the view back with the model.
+     * Folded into the embedded engine's list equality: a refused drop nets to zero over that list,
+     * so only this count forces the rebuild that clears its leftover drag offsets.
      */
     var refusedDropCount: Int by mutableStateOf(0)
         private set
 
-    /** Ids already reported as fragmented — the warning names each offender once, not per snapshot. */
+    /** Each offending id warns once, not per snapshot. */
     private val warnedFragmentedIds = mutableSetOf<Any>()
 
     private val derived: Derived by derivedStateOf { derive() }
@@ -68,42 +56,27 @@ internal class RowBlocksState<T : Any>(
 
     val isDragActive: Boolean get() = draggedRows != null
 
-    /** Block runs over the current view order, for band rendering and leader detection. */
     val runs: List<RowBlockRun> get() = derived.runs
 
-    /** Unit index over the current view order; drives the lazy items and the engine's unit space. */
     val units: RowUnitIndex get() = derived.units
 
-    /**
-     * The current derived view as one atomic object. A drag's lazy items must read their unit
-     * boundaries, item, block id and key all from this single value; mixing it with the live
-     * [itemAt]/[units] getters reintroduces the mid-gesture key churn it exists to prevent.
-     */
+    /** The derived view as one atomic value; a drag reads unit, item, block id and key from it. */
     val snapshot: Derived get() = derived
 
-    /**
-     * Whether the current order holds at least one block. Derived separately from [runs] so a
-     * reader that only cares about presence (the column menu's group-by lock) invalidates when
-     * presence flips, not on every permutation that rebuilds the run list.
-     */
+    /** Separate from [runs] so presence-only readers invalidate on flips, not on every permutation. */
     val hasBlocks: Boolean by derivedStateOf { derived.runs.isNotEmpty() }
 
-    /**
-     * Out-of-range probes answer with a placeholder instead of throwing: effects and prefetchers
-     * can run one frame behind a reconcile that shrank the list, and crashing on that lag is the
-     * v1 failure mode this design exists to close.
-     */
+    /** Null for stale probes: effects can run a frame behind a reconcile that shrank the list. */
     fun itemAt(viewIndex: Int): T? {
         val order = viewOrder
         if (viewIndex !in order.indices) return null
         return upstream[order[viewIndex]]
     }
 
-    /** Upstream index rendered at [viewIndex]; stale probes fall back to the raw index — the same
-     *  argument the consumer's rowKey would receive from a table without blocks. */
+    /** Stale probes fall back to the raw index — what a table without blocks would pass to rowKey. */
     fun upstreamIndexOf(viewIndex: Int): Int = viewOrder.getOrElse(viewIndex) { viewIndex }
 
-    /** Block id of the row at [viewIndex]; null for standalone rows, placeholders and stale probes. */
+    /** Null for standalone rows, placeholders and stale probes. */
     fun blockIdAt(viewIndex: Int): Any? {
         val order = viewOrder
         if (viewIndex !in order.indices) return null
@@ -111,14 +84,9 @@ internal class RowBlocksState<T : Any>(
     }
 
     /**
-     * How the active gesture has displaced view positions so far: pre-gesture position -> current
-     * position; null when no gesture is active or nothing moved. Must be read BEFORE [settle] —
-     * settling forgets the pre-gesture order — and applied only when the settle actually commits:
-     * a refused drop snaps the view back, so the displacement read here no longer describes it.
-     *
-     * This is what lets positional runtime state (selection, editing, cached row heights) follow
-     * the rows it pointed at across the drop. Total over any [Int]: stale positions that survived
-     * from an older list pass through unmapped rather than crash the commit.
+     * Pre-gesture position -> current position, so positional state (selection, editing, cached row
+     * heights) follows its rows across the drop. Read BEFORE settling, and apply only on a commit:
+     * a refused drop snaps the view back and this no longer describes it.
      */
     fun gestureRemap(): ((Int) -> Int)? {
         val before = preGestureOrder ?: return null
@@ -133,19 +101,10 @@ internal class RowBlocksState<T : Any>(
     }
 
     /**
-     * Feeds the current snapshot of the consumer's data. A changed list resets the permutation to
-     * identity — cancelling an in-flight gesture, because swap geometry computed against the old
-     * list is meaningless over the new one; the engine's remaining swaps for that gesture are then
-     * dropped until [settle] — while an unchanged list keeps the optimistic post-drop order until
-     * the consumer's applied move (or any other change) arrives.
-     *
-     * One change survives a gesture: a placeholder fill-in (rows appear where nulls sat, nothing
-     * else touched). That is a paged source loading pages under the held pointer — positions do not
-     * move, so the permutation and the engine's swap geometry stay exactly as valid as before, and
-     * cancelling would make every drop near an unloaded region impossible: the anchors there only
-     * resolve BECAUSE the hold lets their page arrive. An eviction (a loaded row turning back into
-     * a placeholder) is not symmetric — the row's key and block membership vanish under the engine
-     * — so it cancels like any other change.
+     * Feeds the consumer's current data. A changed list resets the permutation and cancels an
+     * in-flight gesture — swap geometry computed against the old list is meaningless over the new
+     * one. A placeholder fill-in is the exception: it moves nothing, and cancelling on it would make
+     * every drop near an unloaded region impossible.
      */
     fun reconcile(
         itemsCount: Int,
@@ -166,8 +125,7 @@ internal class RowBlocksState<T : Any>(
         warnAboutFragmentedIds(newUpstream)
     }
 
-    /** True when [newUpstream] only fills previously unloaded positions: same size, and every row
-     *  that was already loaded is unchanged — the one list change that moves nothing. */
+    /** Same size and every already-loaded row unchanged — the one list change that moves nothing. */
     private fun isPlaceholderFillIn(newUpstream: List<T?>): Boolean {
         val old = upstream
         if (newUpstream.size != old.size) return false
@@ -179,15 +137,9 @@ internal class RowBlocksState<T : Any>(
     }
 
     /**
-     * Applies one engine swap to the view permutation, synchronously — by the time the engine
-     * re-reads layout the order already matches its prediction. [fromUnit] is always the dragged
-     * unit: the engine moves nothing else, so the first call pins down what [settle] will report.
-     *
-     * Swaps that cannot apply are dropped, not rejected: after [reconcile] cancels a gesture, the
-     * engine — whose geometry was computed against the previous frame's layout — can still deliver
-     * swaps for it, out of bounds over the new order or in bounds but belonging to the dead
-     * gesture. Throwing here would crash mid-drag on any consumer whose pipeline updates the list
-     * asynchronously; dropping is what the documented cancel-on-external-change policy means.
+     * Applies one engine swap synchronously, so the order already matches the engine's prediction by
+     * the time it re-reads layout. Swaps that cannot apply are dropped rather than thrown: a
+     * cancelled gesture can still deliver swaps computed against the previous frame.
      */
     fun applyUnitMove(
         fromUnit: Int,
@@ -206,15 +158,9 @@ internal class RowBlocksState<T : Any>(
     }
 
     /**
-     * Ends the gesture and emits its net result — at most one [RowBlockMove] per gesture, none when
-     * the unit ended where it started. After a commit the permuted order is kept (no snap-back):
-     * the consumer's applied move arrives through [reconcile] and takes over seamlessly.
-     *
-     * Paged drop policy: a placeholder cannot anchor a move — its key does not exist yet, and a
-     * made-up key would place the block against a row the user never saw. When a needed landing
-     * neighbour is still unloaded the gesture cancels and the view snaps back to its pre-gesture
-     * order; nothing is emitted. Holding the drag over the landing spot is the natural retry —
-     * rendering the placeholders there is what makes their page load.
+     * Ends the gesture and emits at most one [RowBlockMove]; the permuted order is kept so the
+     * consumer's applied move takes over seamlessly. A placeholder cannot anchor a move, so a drop
+     * whose landing neighbour is unloaded is refused and the view snaps back.
      */
     fun settle(): RowBlockMove? {
         val dragged = draggedRows
@@ -224,9 +170,8 @@ internal class RowBlocksState<T : Any>(
         preGestureOrder = null
         if (dragged == null || before == null || viewOrder == before) return null
         val order = viewOrder
-        // The dragged unit's extent NOW, not at gesture start: a page loaded mid-gesture can
-        // reveal members that merged into the dragged run and landed with it — reporting the
-        // stale extent would anchor the move on a row inside its own block.
+        // The extent NOW, not at gesture start: a page loaded mid-gesture can merge members into the
+        // dragged run, and the stale extent would anchor the move inside the block itself.
         val leaderView = order.indexOf(dragged.first())
         if (leaderView < 0) return null
         val units = derived.units
@@ -251,13 +196,74 @@ internal class RowBlocksState<T : Any>(
         return move
     }
 
+    /**
+     * Moves the dragged row between two view positions inside the SAME run. Endpoints outside one
+     * run are dropped — a defensive guard, since the nested engine cannot generate them. The moved
+     * row keeps its block id, so [derive] recomputes an identical run and the block never fragments.
+     */
+    fun applyRowMoveWithinBlock(
+        fromView: Int,
+        toView: Int,
+    ) {
+        if (cancelledUntilSettle) return
+        val order = viewOrder
+        if (fromView !in order.indices || toView !in order.indices) return
+        val units = derived.units
+        val fromUnit = units.unitOf(fromView)
+        if (!units.isGroup(fromUnit) || units.unitOf(toView) != fromUnit) return
+        if (draggedRows == null) {
+            preGestureOrder = viewOrder
+            draggedRows = listOf(order[fromView])
+        }
+        viewOrder = viewOrder.toMutableList().also { it.moveRowGroup(fromView..fromView, toView..toView) }
+    }
+
+    /**
+     * Ends a within-block gesture and emits at most one [RowWithinBlockMove], anchored on the moved
+     * row's neighbours inside its run. Same paged refusal as [settle].
+     */
+    fun settleWithinBlock(): RowWithinBlockMove? {
+        val dragged = draggedRows
+        val before = preGestureOrder
+        cancelledUntilSettle = false
+        draggedRows = null
+        preGestureOrder = null
+        if (dragged == null || before == null || viewOrder == before) return null
+        val order = viewOrder
+        val movedUpstream = dragged.first()
+        val movedView = order.indexOf(movedUpstream)
+        if (movedView < 0) return null
+        val units = derived.units
+        val unit = units.unitOf(movedView)
+        if (!units.isGroup(unit)) return null
+        val runRows = units.rowsOf(unit)
+        val afterView = if (movedView > runRows.first) movedView - 1 else null
+        val beforeView = if (movedView < runRows.last) movedView + 1 else null
+        val afterLoaded = afterView == null || upstream[order[afterView]] != null
+        val beforeLoaded = beforeView == null || upstream[order[beforeView]] != null
+        if (!afterLoaded || !beforeLoaded) {
+            viewOrder = before
+            refusedDropCount++
+            return null
+        }
+        val blockId = upstream[movedUpstream]?.let(config.blockOf) ?: return null
+        val move =
+            RowWithinBlockMove(
+                blockId = blockId,
+                movedKey = keyAt(movedUpstream),
+                afterKey = afterView?.let { keyAt(order[it]) },
+                beforeKey = beforeView?.let { keyAt(order[it]) },
+            )
+        config.onRowReorderWithinBlock?.invoke(move)
+        return move
+    }
+
     private fun keyAt(upstreamIndex: Int): Any = rowKey(upstream[upstreamIndex], upstreamIndex)
 
     private fun derive(): Derived {
         val order = viewOrder
-        // Freeze the item at every view position from the SAME order/upstream read the runs and
-        // units are built over. This list is what makes [Derived] one atomic snapshot: a lazy item's
-        // key, item and unit all resolve against it, never against a viewOrder that moved on.
+        // Frozen from the same order/upstream read as the runs below — that is what makes [Derived]
+        // one atomic snapshot.
         val items = List(order.size) { upstream[order[it]] }
         val runs = mutableListOf<RowBlockRun>()
         var runStart = -1
@@ -279,19 +285,9 @@ internal class RowBlocksState<T : Any>(
     }
 
     /**
-     * A block id split across disjoint runs means something upstream reordered block members apart —
-     * a foreign sort or a member-splitting filter. Detection only: the library cannot see the source
-     * list to prevent it.
-     *
-     * Checked at [reconcile], not inside [derive]: the derived computation must stay free of side
-     * effects (it can run speculatively in a snapshot that is never applied, or concurrently from
-     * several readers), and a unit move can only merge runs — never split them — so the consumer's
-     * own order is the only place fragmentation can appear.
-     *
-     * Placeholders (null items) are skipped, unlike in [derive]: a not-yet-loaded row breaks the
-     * rendered band but proves nothing about the upstream order — it may well be an unloaded member
-     * of the surrounding block, a state paging reaches routinely — so it neither continues nor
-     * finishes a run here. Once the row loads, a real foreign member warns on the next reconcile.
+     * Warns when one block id occupies disjoint runs — evidence of a foreign sort or a
+     * member-splitting filter. Runs at [reconcile], not in [derive], which must stay side-effect
+     * free; placeholders are skipped because an unloaded row proves nothing about upstream order.
      */
     private fun warnAboutFragmentedIds(items: List<T?>) {
         val finishedRuns = mutableSetOf<Any>()
@@ -312,17 +308,13 @@ internal class RowBlocksState<T : Any>(
     }
 
     /**
-     * One atomic snapshot of the permuted view: [runs] and [units] for the layout, plus the per-view-
-     * position [items] frozen from the same [viewOrder]/[upstream] read. Every lookup a lazy item
-     * needs — its item, block id and key — resolves against this one object, so a reader holding a
-     * [snapshot] can never see [units] from one permutation and an item from the next. That temporal
-     * split is what tore the dragged block's key — and the drag handle inside it — out of composition
-     * mid-gesture, which the reorder engine reads as the drag ending.
+     * One atomic snapshot of the permuted view. Every lookup a lazy item needs resolves against this
+     * object, so no reader can mix units from one permutation with an item from the next — the split
+     * that used to tear the dragged block's key out of composition mid-gesture.
      */
     internal inner class Derived(
         val runs: List<RowBlockRun>,
         val units: RowUnitIndex,
-        /** Item at each view position, frozen from the order this was derived over. */
         val items: List<T?>,
         /** View position -> upstream index, frozen — supplies the key's index argument. */
         private val order: List<Int>,
@@ -331,24 +323,15 @@ internal class RowBlocksState<T : Any>(
 
         fun blockIdAt(viewIndex: Int): Any? = items.getOrNull(viewIndex)?.let(config.blockOf)
 
-        /**
-         * The same key [Table]'s effectiveRowKey produces — rowKey(item, upstreamIndex) — but read
-         * off this frozen snapshot instead of live state, so a unit's boundary and its key are always
-         * drawn from one permutation. Out-of-range probes fall back to the raw index, matching the
-         * consumer's rowKey contract for a table without blocks.
-         */
+        /** The same key the table's effectiveRowKey produces, but read off this frozen snapshot. */
         fun keyAt(viewIndex: Int): Any =
             rowKey(items.getOrNull(viewIndex), order.getOrElse(viewIndex) { viewIndex })
     }
 }
 
 /**
- * Moves the rows in [from] so that the block swaps with [to]: moving down lands the block after
- * [to], moving up lands it before [to] — mirroring the reorder engine's swap semantics so a unit
- * move translates to one call.
- *
- * Both ranges are interpreted against the list's current contents. Overlapping ranges have no
- * meaningful swap semantics and are rejected; identical ranges are a no-op.
+ * Moves [from] so the block swaps with [to]: down lands it after [to], up lands it before — the
+ * reorder engine's own swap semantics. Overlapping ranges are rejected; identical ranges are a no-op.
  */
 internal fun <T> MutableList<T>.moveRowGroup(
     from: IntRange,

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/state/RowBlocksState.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/state/RowBlocksState.kt
@@ -1,0 +1,370 @@
+package ua.wwind.table.state
+
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import co.touchlab.kermit.Logger
+import ua.wwind.table.RowBlockMove
+import ua.wwind.table.RowBlocks
+
+/** A maximal run of adjacent rows sharing one non-null block id; [rows] is in view (rendered) space. */
+internal class RowBlockRun(
+    val id: Any,
+    val rows: IntRange,
+)
+
+/**
+ * The managed side of [RowBlocks]: owns the view permutation a drag gesture mutates, so the reorder
+ * engine's synchronous-layout expectation is satisfied inside the library instead of being imposed
+ * on the consumer (whose pipeline is typically asynchronous and cannot apply moves mid-gesture).
+ *
+ * The upstream list is what the consumer renders; the view order is a permutation over it that is
+ * identity except between a drag's first swap and the moment the consumer's applied move flows back
+ * through [reconcile]. Block runs are re-derived from the permuted order on every change, so unit
+ * boundaries can never disagree with what is on screen.
+ *
+ * Backed by snapshot state throughout — the order and the gesture fields alike — so composition
+ * that reads [runs], [units], [itemAt] or [isDragActive] recomposes on change, and a rolled-back
+ * snapshot cannot leave a gesture half-cancelled.
+ */
+internal class RowBlocksState<T : Any>(
+    val config: RowBlocks<T>,
+    private val rowKey: (item: T?, index: Int) -> Any,
+    private val warn: (String) -> Unit = { Logger.w { it } },
+) {
+    /** The consumer's rendered list, in its own order. */
+    private var upstream: List<T?> by mutableStateOf(emptyList())
+
+    /** View position -> upstream index. Identity outside a gesture / optimistic hold. */
+    private var viewOrder: List<Int> by mutableStateOf(emptyList())
+
+    /** Upstream indices of the dragged unit; non-null exactly while a gesture is in progress. */
+    private var draggedRows: List<Int>? by mutableStateOf(null)
+
+    /** [viewOrder] at gesture start; [settle] emits nothing when the gesture ends back on it. */
+    private var preGestureOrder: List<Int>? by mutableStateOf(null)
+
+    /** Set when [reconcile] cancels an in-flight gesture; the engine's late swaps for that dead
+     *  gesture are dropped until the pointer goes up and [settle] releases the latch. */
+    private var cancelledUntilSettle: Boolean by mutableStateOf(false)
+
+    /**
+     * Bumps once per refused drop (paged policy in [settle]). A refusal restores [viewOrder], so
+     * over any list derived from it the whole gesture nets to zero — invisible to the embedded
+     * engine, which clears the drag offsets left over from a drop only when its input list
+     * compares unequal. Folding this count into that list's equality is what turns a refusal into
+     * the rebuild that snaps the view back with the model.
+     */
+    var refusedDropCount: Int by mutableStateOf(0)
+        private set
+
+    /** Ids already reported as fragmented — the warning names each offender once, not per snapshot. */
+    private val warnedFragmentedIds = mutableSetOf<Any>()
+
+    private val derived: Derived by derivedStateOf { derive() }
+
+    val itemsCount: Int get() = viewOrder.size
+
+    val isDragActive: Boolean get() = draggedRows != null
+
+    /** Block runs over the current view order, for band rendering and leader detection. */
+    val runs: List<RowBlockRun> get() = derived.runs
+
+    /** Unit index over the current view order; drives the lazy items and the engine's unit space. */
+    val units: RowUnitIndex get() = derived.units
+
+    /**
+     * The current derived view as one atomic object. A drag's lazy items must read their unit
+     * boundaries, item, block id and key all from this single value; mixing it with the live
+     * [itemAt]/[units] getters reintroduces the mid-gesture key churn it exists to prevent.
+     */
+    val snapshot: Derived get() = derived
+
+    /**
+     * Whether the current order holds at least one block. Derived separately from [runs] so a
+     * reader that only cares about presence (the column menu's group-by lock) invalidates when
+     * presence flips, not on every permutation that rebuilds the run list.
+     */
+    val hasBlocks: Boolean by derivedStateOf { derived.runs.isNotEmpty() }
+
+    /**
+     * Out-of-range probes answer with a placeholder instead of throwing: effects and prefetchers
+     * can run one frame behind a reconcile that shrank the list, and crashing on that lag is the
+     * v1 failure mode this design exists to close.
+     */
+    fun itemAt(viewIndex: Int): T? {
+        val order = viewOrder
+        if (viewIndex !in order.indices) return null
+        return upstream[order[viewIndex]]
+    }
+
+    /** Upstream index rendered at [viewIndex]; stale probes fall back to the raw index — the same
+     *  argument the consumer's rowKey would receive from a table without blocks. */
+    fun upstreamIndexOf(viewIndex: Int): Int = viewOrder.getOrElse(viewIndex) { viewIndex }
+
+    /** Block id of the row at [viewIndex]; null for standalone rows, placeholders and stale probes. */
+    fun blockIdAt(viewIndex: Int): Any? {
+        val order = viewOrder
+        if (viewIndex !in order.indices) return null
+        return upstream[order[viewIndex]]?.let(config.blockOf)
+    }
+
+    /**
+     * How the active gesture has displaced view positions so far: pre-gesture position -> current
+     * position; null when no gesture is active or nothing moved. Must be read BEFORE [settle] —
+     * settling forgets the pre-gesture order — and applied only when the settle actually commits:
+     * a refused drop snaps the view back, so the displacement read here no longer describes it.
+     *
+     * This is what lets positional runtime state (selection, editing, cached row heights) follow
+     * the rows it pointed at across the drop. Total over any [Int]: stale positions that survived
+     * from an older list pass through unmapped rather than crash the commit.
+     */
+    fun gestureRemap(): ((Int) -> Int)? {
+        val before = preGestureOrder ?: return null
+        val order = viewOrder
+        if (before == order) return null
+        val currentPositions = HashMap<Int, Int>(order.size)
+        order.forEachIndexed { viewIndex, upstreamIndex -> currentPositions[upstreamIndex] = viewIndex }
+        return remap@{ position ->
+            val upstreamIndex = before.getOrNull(position) ?: return@remap position
+            currentPositions[upstreamIndex] ?: position
+        }
+    }
+
+    /**
+     * Feeds the current snapshot of the consumer's data. A changed list resets the permutation to
+     * identity — cancelling an in-flight gesture, because swap geometry computed against the old
+     * list is meaningless over the new one; the engine's remaining swaps for that gesture are then
+     * dropped until [settle] — while an unchanged list keeps the optimistic post-drop order until
+     * the consumer's applied move (or any other change) arrives.
+     *
+     * One change survives a gesture: a placeholder fill-in (rows appear where nulls sat, nothing
+     * else touched). That is a paged source loading pages under the held pointer — positions do not
+     * move, so the permutation and the engine's swap geometry stay exactly as valid as before, and
+     * cancelling would make every drop near an unloaded region impossible: the anchors there only
+     * resolve BECAUSE the hold lets their page arrive. An eviction (a loaded row turning back into
+     * a placeholder) is not symmetric — the row's key and block membership vanish under the engine
+     * — so it cancels like any other change.
+     */
+    fun reconcile(
+        itemsCount: Int,
+        itemAt: (Int) -> T?,
+    ) {
+        val newUpstream = List(itemsCount.coerceAtLeast(0)) { itemAt(it) }
+        if (newUpstream == upstream) return
+        if (isPlaceholderFillIn(newUpstream)) {
+            upstream = newUpstream
+            warnAboutFragmentedIds(newUpstream)
+            return
+        }
+        if (draggedRows != null) cancelledUntilSettle = true
+        upstream = newUpstream
+        viewOrder = List(newUpstream.size) { it }
+        draggedRows = null
+        preGestureOrder = null
+        warnAboutFragmentedIds(newUpstream)
+    }
+
+    /** True when [newUpstream] only fills previously unloaded positions: same size, and every row
+     *  that was already loaded is unchanged — the one list change that moves nothing. */
+    private fun isPlaceholderFillIn(newUpstream: List<T?>): Boolean {
+        val old = upstream
+        if (newUpstream.size != old.size) return false
+        for (index in old.indices) {
+            val loaded = old[index] ?: continue
+            if (loaded != newUpstream[index]) return false
+        }
+        return true
+    }
+
+    /**
+     * Applies one engine swap to the view permutation, synchronously — by the time the engine
+     * re-reads layout the order already matches its prediction. [fromUnit] is always the dragged
+     * unit: the engine moves nothing else, so the first call pins down what [settle] will report.
+     *
+     * Swaps that cannot apply are dropped, not rejected: after [reconcile] cancels a gesture, the
+     * engine — whose geometry was computed against the previous frame's layout — can still deliver
+     * swaps for it, out of bounds over the new order or in bounds but belonging to the dead
+     * gesture. Throwing here would crash mid-drag on any consumer whose pipeline updates the list
+     * asynchronously; dropping is what the documented cancel-on-external-change policy means.
+     */
+    fun applyUnitMove(
+        fromUnit: Int,
+        toUnit: Int,
+    ) {
+        if (cancelledUntilSettle) return
+        val units = derived.units
+        if (fromUnit !in 0 until units.unitCount || toUnit !in 0 until units.unitCount) return
+        if (draggedRows == null) {
+            preGestureOrder = viewOrder
+            draggedRows = units.rowsOf(fromUnit).map { viewOrder[it] }
+        }
+        val fromRows = units.rowsOf(fromUnit)
+        val toRows = units.rowsOf(toUnit)
+        viewOrder = viewOrder.toMutableList().also { it.moveRowGroup(fromRows, toRows) }
+    }
+
+    /**
+     * Ends the gesture and emits its net result — at most one [RowBlockMove] per gesture, none when
+     * the unit ended where it started. After a commit the permuted order is kept (no snap-back):
+     * the consumer's applied move arrives through [reconcile] and takes over seamlessly.
+     *
+     * Paged drop policy: a placeholder cannot anchor a move — its key does not exist yet, and a
+     * made-up key would place the block against a row the user never saw. When a needed landing
+     * neighbour is still unloaded the gesture cancels and the view snaps back to its pre-gesture
+     * order; nothing is emitted. Holding the drag over the landing spot is the natural retry —
+     * rendering the placeholders there is what makes their page load.
+     */
+    fun settle(): RowBlockMove? {
+        val dragged = draggedRows
+        val before = preGestureOrder
+        cancelledUntilSettle = false
+        draggedRows = null
+        preGestureOrder = null
+        if (dragged == null || before == null || viewOrder == before) return null
+        val order = viewOrder
+        // The dragged unit's extent NOW, not at gesture start: a page loaded mid-gesture can
+        // reveal members that merged into the dragged run and landed with it — reporting the
+        // stale extent would anchor the move on a row inside its own block.
+        val leaderView = order.indexOf(dragged.first())
+        if (leaderView < 0) return null
+        val units = derived.units
+        val rows = units.rowsOf(units.unitOf(leaderView))
+        val first = rows.first
+        val last = rows.last
+        val afterAnchorLoaded = first == 0 || upstream[order[first - 1]] != null
+        val beforeAnchorLoaded = last == order.lastIndex || upstream[order[last + 1]] != null
+        if (!afterAnchorLoaded || !beforeAnchorLoaded) {
+            viewOrder = before
+            refusedDropCount++
+            return null
+        }
+        val move =
+            RowBlockMove(
+                blockId = upstream[dragged.first()]?.let(config.blockOf),
+                movedKeys = (first..last).map { keyAt(order[it]) },
+                afterKey = if (first == 0) null else keyAt(order[first - 1]),
+                beforeKey = if (last == order.lastIndex) null else keyAt(order[last + 1]),
+            )
+        config.onCommit?.invoke(move)
+        return move
+    }
+
+    private fun keyAt(upstreamIndex: Int): Any = rowKey(upstream[upstreamIndex], upstreamIndex)
+
+    private fun derive(): Derived {
+        val order = viewOrder
+        // Freeze the item at every view position from the SAME order/upstream read the runs and
+        // units are built over. This list is what makes [Derived] one atomic snapshot: a lazy item's
+        // key, item and unit all resolve against it, never against a viewOrder that moved on.
+        val items = List(order.size) { upstream[order[it]] }
+        val runs = mutableListOf<RowBlockRun>()
+        var runStart = -1
+        var runId: Any? = null
+        for (viewIndex in order.indices) {
+            val id = items[viewIndex]?.let(config.blockOf)
+            if (id != null && id == runId) continue
+            if (runStart >= 0) runs += RowBlockRun(requireNotNull(runId), runStart..viewIndex - 1)
+            if (id != null) {
+                runStart = viewIndex
+                runId = id
+            } else {
+                runStart = -1
+                runId = null
+            }
+        }
+        if (runStart >= 0) runs += RowBlockRun(requireNotNull(runId), runStart..order.lastIndex)
+        return Derived(runs, buildRowUnitIndex(order.size, runs.map { it.rows }), items, order)
+    }
+
+    /**
+     * A block id split across disjoint runs means something upstream reordered block members apart —
+     * a foreign sort or a member-splitting filter. Detection only: the library cannot see the source
+     * list to prevent it.
+     *
+     * Checked at [reconcile], not inside [derive]: the derived computation must stay free of side
+     * effects (it can run speculatively in a snapshot that is never applied, or concurrently from
+     * several readers), and a unit move can only merge runs — never split them — so the consumer's
+     * own order is the only place fragmentation can appear.
+     *
+     * Placeholders (null items) are skipped, unlike in [derive]: a not-yet-loaded row breaks the
+     * rendered band but proves nothing about the upstream order — it may well be an unloaded member
+     * of the surrounding block, a state paging reaches routinely — so it neither continues nor
+     * finishes a run here. Once the row loads, a real foreign member warns on the next reconcile.
+     */
+    private fun warnAboutFragmentedIds(items: List<T?>) {
+        val finishedRuns = mutableSetOf<Any>()
+        var runId: Any? = null
+        for (item in items) {
+            if (item == null) continue
+            val id = config.blockOf(item)
+            if (id == runId) continue
+            runId?.let { finishedRuns += it }
+            runId = id
+            if (id != null && id in finishedRuns && warnedFragmentedIds.add(id)) {
+                warn(
+                    "Row block id $id appears in non-adjacent runs; blocks are defined by " +
+                        "adjacency — check for a foreign sort or a filter splitting block members",
+                )
+            }
+        }
+    }
+
+    /**
+     * One atomic snapshot of the permuted view: [runs] and [units] for the layout, plus the per-view-
+     * position [items] frozen from the same [viewOrder]/[upstream] read. Every lookup a lazy item
+     * needs — its item, block id and key — resolves against this one object, so a reader holding a
+     * [snapshot] can never see [units] from one permutation and an item from the next. That temporal
+     * split is what tore the dragged block's key — and the drag handle inside it — out of composition
+     * mid-gesture, which the reorder engine reads as the drag ending.
+     */
+    internal inner class Derived(
+        val runs: List<RowBlockRun>,
+        val units: RowUnitIndex,
+        /** Item at each view position, frozen from the order this was derived over. */
+        val items: List<T?>,
+        /** View position -> upstream index, frozen — supplies the key's index argument. */
+        private val order: List<Int>,
+    ) {
+        fun itemAt(viewIndex: Int): T? = items.getOrNull(viewIndex)
+
+        fun blockIdAt(viewIndex: Int): Any? = items.getOrNull(viewIndex)?.let(config.blockOf)
+
+        /**
+         * The same key [Table]'s effectiveRowKey produces — rowKey(item, upstreamIndex) — but read
+         * off this frozen snapshot instead of live state, so a unit's boundary and its key are always
+         * drawn from one permutation. Out-of-range probes fall back to the raw index, matching the
+         * consumer's rowKey contract for a table without blocks.
+         */
+        fun keyAt(viewIndex: Int): Any =
+            rowKey(items.getOrNull(viewIndex), order.getOrElse(viewIndex) { viewIndex })
+    }
+}
+
+/**
+ * Moves the rows in [from] so that the block swaps with [to]: moving down lands the block after
+ * [to], moving up lands it before [to] — mirroring the reorder engine's swap semantics so a unit
+ * move translates to one call.
+ *
+ * Both ranges are interpreted against the list's current contents. Overlapping ranges have no
+ * meaningful swap semantics and are rejected; identical ranges are a no-op.
+ */
+internal fun <T> MutableList<T>.moveRowGroup(
+    from: IntRange,
+    to: IntRange,
+) {
+    require(!from.isEmpty() && !to.isEmpty()) { "moveRowGroup ranges must not be empty" }
+    require(from.first >= 0 && from.last < size) { "from range $from is out of bounds for size $size" }
+    require(to.first >= 0 && to.last < size) { "to range $to is out of bounds for size $size" }
+    if (from == to) return
+    require(from.last < to.first || to.last < from.first) {
+        "moveRowGroup ranges must not overlap, got from=$from and to=$to"
+    }
+
+    val blockSize = from.last - from.first + 1
+    val block = ArrayList<T>(blockSize)
+    repeat(blockSize) { block += removeAt(from.first) }
+    val insertAt = if (to.first > from.first) to.last - blockSize + 1 else to.first
+    addAll(insertAt.coerceIn(0, size), block)
+}

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/state/RowUnitIndex.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/state/RowUnitIndex.kt
@@ -1,0 +1,140 @@
+package ua.wwind.table.state
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Maps row indices (the public index space of the table) to unit indices (the index space of the
+ * backing `LazyColumn`), where a unit is either a single row or a declared group of adjacent rows.
+ *
+ * Memory is O(number of groups): only group bounds and prefix sums are stored, never a per-row
+ * array. With no groups the index is identity and no binary search is performed.
+ */
+@Immutable
+internal class RowUnitIndex private constructor(
+    private val starts: IntArray,
+    private val ends: IntArray,
+    /** `collapsedBefore[i]` = number of rows absorbed by groups left of group `i`; size is groups+1. */
+    private val collapsedBefore: IntArray,
+    val unitCount: Int,
+) {
+    val isIdentity: Boolean get() = starts.isEmpty()
+
+    /** Unit index that renders [rowIndex]. */
+    fun unitOf(rowIndex: Int): Int {
+        if (isIdentity) return rowIndex
+        val group = groupContaining(rowIndex)
+        if (group >= 0) return starts[group] - collapsedBefore[group]
+        return rowIndex - collapsedBefore[groupsFullyBefore(rowIndex)]
+    }
+
+    /** Rows rendered by [unitIndex]; a single-row unit returns `i..i`. */
+    fun rowsOf(unitIndex: Int): IntRange {
+        if (isIdentity) return unitIndex..unitIndex
+        val group = groupAtUnit(unitIndex)
+        if (group >= 0) return starts[group]..ends[group]
+        val row = unitIndex + collapsedBefore[groupsBeforeUnit(unitIndex)]
+        return row..row
+    }
+
+    fun isGroup(unitIndex: Int): Boolean = !isIdentity && groupAtUnit(unitIndex) >= 0
+
+    /** Index of the group containing [row], or -1. */
+    private fun groupContaining(row: Int): Int {
+        val insertion = upperBoundByStart(row)
+        val candidate = insertion - 1
+        return if (candidate >= 0 && row <= ends[candidate]) candidate else -1
+    }
+
+    /** Number of groups that end strictly before [row]. */
+    private fun groupsFullyBefore(row: Int): Int = upperBoundByStart(row)
+
+    /** Number of groups whose `starts` are <= [row]. */
+    private fun upperBoundByStart(row: Int): Int {
+        var low = 0
+        var high = starts.size
+        while (low < high) {
+            val mid = (low + high) ushr 1
+            if (starts[mid] <= row) low = mid + 1 else high = mid
+        }
+        return low
+    }
+
+    /** Unit index at which group [i] starts. */
+    private fun unitStartOf(i: Int): Int = starts[i] - collapsedBefore[i]
+
+    /** Index of the group whose unit index is exactly [unit], or -1. */
+    private fun groupAtUnit(unit: Int): Int {
+        var low = 0
+        var high = starts.size - 1
+        while (low <= high) {
+            val mid = (low + high) ushr 1
+            val midUnit = unitStartOf(mid)
+            when {
+                midUnit == unit -> return mid
+                midUnit < unit -> low = mid + 1
+                else -> high = mid - 1
+            }
+        }
+        return -1
+    }
+
+    /** Number of groups whose unit index is < [unit]. */
+    private fun groupsBeforeUnit(unit: Int): Int {
+        var low = 0
+        var high = starts.size
+        while (low < high) {
+            val mid = (low + high) ushr 1
+            if (unitStartOf(mid) < unit) low = mid + 1 else high = mid
+        }
+        return low
+    }
+
+    internal companion object {
+        fun identity(itemsCount: Int): RowUnitIndex =
+            RowUnitIndex(
+                starts = IntArray(0),
+                ends = IntArray(0),
+                collapsedBefore = IntArray(1),
+                unitCount = itemsCount.coerceAtLeast(0),
+            )
+
+        fun of(itemsCount: Int, groups: List<IntRange>): RowUnitIndex {
+            val size = groups.size
+            val starts = IntArray(size)
+            val ends = IntArray(size)
+            val collapsedBefore = IntArray(size + 1)
+            var previousEnd = -1
+            var collapsed = 0
+            groups.forEachIndexed { i, range ->
+                require(!range.isEmpty()) { "row block ranges must not be empty, got $range" }
+                require(range.first > previousEnd) {
+                    "row block ranges must be sorted and non-overlapping, got $range after row $previousEnd"
+                }
+                require(range.first >= 0 && range.last < itemsCount) {
+                    "row block range $range is out of bounds for $itemsCount rows"
+                }
+                starts[i] = range.first
+                ends[i] = range.last
+                collapsedBefore[i] = collapsed
+                collapsed += range.last - range.first
+                previousEnd = range.last
+            }
+            collapsedBefore[size] = collapsed
+            return RowUnitIndex(starts, ends, collapsedBefore, itemsCount - collapsed)
+        }
+    }
+}
+
+/**
+ * Builds a [RowUnitIndex] for [itemsCount] rows. Returns the identity index when [groups] is null or
+ * empty, so tables without groups keep their existing behavior with no extra work.
+ */
+internal fun buildRowUnitIndex(
+    itemsCount: Int,
+    groups: List<IntRange>?,
+): RowUnitIndex =
+    if (groups.isNullOrEmpty() || itemsCount <= 0) {
+        RowUnitIndex.identity(itemsCount)
+    } else {
+        RowUnitIndex.of(itemsCount, groups)
+    }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/state/TableState.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/state/TableState.kt
@@ -77,6 +77,36 @@ public class TableState<C>
         internal var visibleColumns: List<ColumnSpec<*, C, *>> by mutableStateOf(emptyList())
 
         /**
+         * Row-to-unit mapping for the current data set. Identity unless the consumer passed
+         * `rowBlocks`. Assigned by `Table` during composition, read by scroll/keyboard effects.
+         *
+         * Snapshot state, because the prefetcher reads it inside a `snapshotFlow`, which re-evaluates
+         * only on a tracked read. As a plain field it would be carried along by the `layoutInfo` read
+         * next to it — correct only for as long as something else keeps scrolling.
+         *
+         * `Table` holds the index in `remember`, and [RowUnitIndex] compares by identity, so
+         * re-assigning the same instance each recomposition is a no-op and only a genuine rebuild
+         * notifies.
+         */
+        internal var rowUnits: RowUnitIndex by mutableStateOf(RowUnitIndex.identity(0))
+
+        /**
+         * True while a non-null `rowBlocks` declaration is being ignored because [groupBy] is
+         * active. The two features describe incompatible structures over the same rows, so the
+         * library suppresses blocks instead of rendering both; this flag exists so consumers can
+         * surface that conflict in their own UI rather than have blocks vanish unexplained.
+         */
+        public var rowBlocksSuppressedByGroupBy: Boolean by mutableStateOf(false)
+            internal set
+
+        /**
+         * True while the table derives at least one row block. The column menu reads it to disable
+         * the group-by action: activating `groupBy` would silently suppress visible blocks, and a
+         * disabled item surfaces that instead of letting the feature disappear on a menu click.
+         */
+        internal var rowBlocksNonEmpty: Boolean by mutableStateOf(false)
+
+        /**
          * Current table width computed from visible columns and their widths.
          * Automatically recalculates when columnOrder, columnWidths, or visibleColumns change.
          */
@@ -250,11 +280,21 @@ public class TableState<C>
             }
         }
 
-        /** Toggle or set sorting for a [column]. If [order] is null, cycles ASC -> DESC -> none. */
+        /**
+         * Toggle or set sorting for a [column]. If [order] is null, cycles ASC -> DESC -> none.
+         *
+         * A no-op while row reorder is enabled, mirroring the `initialSort` normalization in
+         * [rememberTableState]: under an active sort the view is invariant to source permutations,
+         * so drag history would be unobservable — the two features cannot both apply.
+         */
         public fun setSort(
             column: C,
             order: SortOrder? = null,
         ) {
+            if (settings.isRowReorderEnabled) {
+                settingsLogger.w { "rowReorderEnabled is incompatible with sorting; setSort is ignored." }
+                return
+            }
             sort =
                 if (order != null) {
                     SortState(column, order)
@@ -544,6 +584,22 @@ public class TableState<C>
             } else {
                 // No more editable columns - try to complete row
                 tryCompleteEditing()
+            }
+        }
+
+        /**
+         * Follows a committed block drag: positional runtime state must keep pointing at the rows
+         * it pointed at before the permutation, or selection and editing silently jump to whichever
+         * rows landed on the old positions.
+         */
+        internal fun remapRowPositions(remap: (Int) -> Int) {
+            selectedIndex = selectedIndex?.let(remap)
+            selectedCell = selectedCell?.let { it.copy(rowIndex = remap(it.rowIndex)) }
+            editingRow = editingRow?.let(remap)
+            if (checkedIndices.isNotEmpty()) {
+                val remapped = checkedIndices.map(remap)
+                checkedIndices.clear()
+                checkedIndices.addAll(remapped)
             }
         }
 

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/state/TableState.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/state/TableState.kt
@@ -69,8 +69,12 @@ public class TableState<C>
 
         /**
          * Current visible columns list. Must be set externally before tableWidth is accessed.
+         *
+         * Snapshot state, because [tableWidth] derives from it: a plain field would be an untracked
+         * read, leaving the derived width frozen at whatever the first composition computed until
+         * some *other* tracked read — a [columnWidths] write — happened to invalidate it.
          */
-        internal var visibleColumns: List<ColumnSpec<*, C, *>> = emptyList()
+        internal var visibleColumns: List<ColumnSpec<*, C, *>> by mutableStateOf(emptyList())
 
         /**
          * Current table width computed from visible columns and their widths.

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/ApplyRowBlockMoveTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/ApplyRowBlockMoveTest.kt
@@ -1,0 +1,204 @@
+package ua.wwind.table
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import ua.wwind.table.state.RowBlocksState
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.fail
+
+private data class Row(val key: Int, val block: String?)
+
+private fun row(
+    key: Int,
+    block: String? = null,
+) = Row(key, block)
+
+private fun MutableList<Row>.applyMove(move: RowBlockMove) = applyRowBlockMove(move, keyOf = { it.key }, blockOf = { it.block })
+
+/** Fails when any non-null block id occupies non-adjacent positions — the P1 invariant. */
+private fun assertBlocksContiguous(rows: List<Row>) {
+    val finished = mutableSetOf<String>()
+    var runId: String? = null
+    for (item in rows) {
+        val id = item.block
+        if (id == runId) continue
+        runId?.let { finished += it }
+        runId = id
+        if (id != null && id in finished) fail("block $id is fragmented in ${rows.map { it.key to it.block }}")
+    }
+}
+
+class ApplyRowBlockMoveTest {
+    // region deterministic lifts
+
+    @Test
+    fun `block move relocates hidden members with the block`() {
+        // Row 3 of block "a" is hidden by the filter: the commit names only rows 1..2, yet the
+        // whole block must travel — leaving row 3 behind would fragment "a" in the source.
+        val source = mutableListOf(row(1, "a"), row(2, "a"), row(3, "a"), row(4, "b"), row(5, "b"), row(6))
+        source.applyMove(RowBlockMove(blockId = "a", movedKeys = listOf(1, 2), afterKey = 5, beforeKey = 6))
+        assertThat(source.map { it.key }).isEqualTo(listOf(4, 5, 1, 2, 3, 6))
+    }
+
+    @Test
+    fun `insertion expands past the hidden tail of the anchor block`() {
+        // View is [1, 2, 5]: rows 3..4 of block "a" hide behind their visible leader. Inserting
+        // right after the anchor would drop row 1 inside the hidden span and split "a".
+        val source = mutableListOf(row(1), row(2, "a"), row(3, "a"), row(4, "a"), row(5))
+        source.applyMove(RowBlockMove(blockId = null, movedKeys = listOf(1), afterKey = 2, beforeKey = 5))
+        assertThat(source.map { it.key }).isEqualTo(listOf(2, 3, 4, 1, 5))
+    }
+
+    @Test
+    fun `hidden block leader travels and stays the leader`() {
+        val source = mutableListOf(row(1, "a"), row(2, "a"), row(3, "a"), row(4, "b"))
+        // The source leader (row 1) is hidden, so movedKeys cannot name it; relocation is by id.
+        source.applyMove(RowBlockMove(blockId = "a", movedKeys = listOf(2, 3), afterKey = 4, beforeKey = null))
+        assertThat(source.map { it.key }).isEqualTo(listOf(4, 1, 2, 3))
+    }
+
+    @Test
+    fun `null after anchor inserts at the start of the source`() {
+        val source = mutableListOf(row(1), row(2), row(3, "b"), row(4, "b"))
+        source.applyMove(RowBlockMove(blockId = "b", movedKeys = listOf(3, 4), afterKey = null, beforeKey = 1))
+        assertThat(source.map { it.key }).isEqualTo(listOf(3, 4, 1, 2))
+    }
+
+    @Test
+    fun `missing after anchor falls back to the before anchor expanding backward`() {
+        // The primary anchor (row 9) was deleted between the commit and the apply. The fallback
+        // anchor is a non-leader member of "a" (its leader hides above it), so the insertion must
+        // walk back to the block start — inserting right before row 3 would split "a".
+        val source = mutableListOf(row(1), row(2, "a"), row(3, "a"), row(4))
+        source.applyMove(RowBlockMove(blockId = null, movedKeys = listOf(4), afterKey = 9, beforeKey = 3))
+        assertThat(source.map { it.key }).isEqualTo(listOf(1, 4, 2, 3))
+    }
+
+    @Test
+    fun `missing after anchor with null before anchor inserts at the end`() {
+        val source = mutableListOf(row(1), row(2), row(3))
+        source.applyMove(RowBlockMove(blockId = null, movedKeys = listOf(1), afterKey = 9, beforeKey = null))
+        assertThat(source.map { it.key }).isEqualTo(listOf(2, 3, 1))
+    }
+
+    @Test
+    fun `move with both anchors missing leaves the list untouched`() {
+        val source = mutableListOf(row(1), row(2), row(3))
+        source.applyMove(RowBlockMove(blockId = null, movedKeys = listOf(1), afterKey = 8, beforeKey = 9))
+        assertThat(source.map { it.key }).isEqualTo(listOf(1, 2, 3))
+    }
+
+    @Test
+    fun `move of a vanished block id leaves the list untouched`() {
+        val source = mutableListOf(row(1), row(2, "a"))
+        source.applyMove(RowBlockMove(blockId = "gone", movedKeys = listOf(9), afterKey = 1, beforeKey = null))
+        assertThat(source.map { it.key }).isEqualTo(listOf(1, 2))
+    }
+
+    @Test
+    fun `standalone move with vanished keys leaves the list untouched`() {
+        val source = mutableListOf(row(1), row(2))
+        source.applyMove(RowBlockMove(blockId = null, movedKeys = listOf(9), afterKey = 1, beforeKey = 2))
+        assertThat(source.map { it.key }).isEqualTo(listOf(1, 2))
+    }
+
+    // endregion
+
+    // region property harness
+
+    /**
+     * End-to-end property proof over random sources, random filters and random gestures: the move
+     * is the REAL commit `RowBlocksState` emits for the gesture, applied to the source the state
+     * never saw — exactly the consumer's situation.
+     */
+    @Test
+    fun `random filtered gestures hold every lift property across 3000 commits`() {
+        val random = Random(20260717)
+        var effective = 0
+        var attempts = 0
+        var blockMovesWithHiddenMembers = 0
+        var blockMovesWithHiddenLeader = 0
+        while (effective < 3000) {
+            check(++attempts <= 30_000) { "degenerate generator: $effective effective gestures in $attempts attempts" }
+            val source = randomSource(random)
+            // 25% of rows hidden: V is an order-preserving filter of S, the in-contract shape.
+            val visibleKeys = source.filter { random.nextInt(4) > 0 }.map { it.key }.toSet()
+            val view = source.filter { it.key in visibleKeys }
+
+            val commits = mutableListOf<RowBlockMove>()
+            val warnings = mutableListOf<String>()
+            val state =
+                RowBlocksState(
+                    config = RowBlocks<Row>(blockOf = { it.block }, onCommit = { commits += it }),
+                    rowKey = { item, _ -> requireNotNull(item).key },
+                    warn = { warnings += it },
+                )
+            state.reconcile(view.size) { view[it] }
+            val unitCount = state.units.unitCount
+            if (unitCount < 2) continue
+            val fromUnit = random.nextInt(unitCount)
+            val toUnit = random.nextInt(unitCount)
+            if (fromUnit == toUnit) continue
+            state.applyUnitMove(fromUnit, toUnit)
+            val move = requireNotNull(state.settle())
+            val permutedView = (0 until state.itemsCount).map { requireNotNull(state.itemAt(it)) }
+            assertThat(warnings).isEqualTo(emptyList<String>())
+
+            val result = source.toMutableList()
+            result.applyMove(move)
+
+            val belongsToMove: (Row) -> Boolean =
+                when (val blockId = move.blockId) {
+                    null -> ({ it.key in move.movedKeys })
+                    else -> ({ it.block == blockId })
+                }
+            // The result is a permutation of the source: nothing lost, nothing duplicated.
+            assertThat(result.sortedBy { it.key }).isEqualTo(source.sortedBy { it.key })
+            // No block — moved or foreign — is ever fragmented.
+            assertBlocksContiguous(result)
+            // Filtering the lifted source reproduces the drag result exactly: the lift is invisible
+            // in the view the user manipulated.
+            assertThat(result.filter { it.key in visibleKeys }).isEqualTo(permutedView)
+            // Rows outside the moved unit keep their relative order, hidden ones included.
+            assertThat(result.filterNot(belongsToMove)).isEqualTo(source.filterNot(belongsToMove))
+            // Moved rows keep their relative order, hidden ones included.
+            assertThat(result.filter(belongsToMove)).isEqualTo(source.filter(belongsToMove))
+            // Applying the same commit twice is a fixpoint — a consumer replaying an event stream
+            // must not drift.
+            val reapplied = result.toMutableList()
+            reapplied.applyMove(move)
+            assertThat(reapplied).isEqualTo(result)
+
+            if (move.blockId != null) {
+                val members = source.filter { it.block == move.blockId }
+                if (members.size > move.movedKeys.size) blockMovesWithHiddenMembers++
+                if (members.first().key !in visibleKeys) blockMovesWithHiddenLeader++
+            }
+            effective++
+        }
+        // The generator must actually exercise the hidden-member semantics, not pass on trivially
+        // visible moves.
+        assertThat(blockMovesWithHiddenMembers).isGreaterThan(100)
+        assertThat(blockMovesWithHiddenLeader).isGreaterThan(50)
+    }
+
+    /** Units of 1..4 rows; roughly half standalone, half blocks with unique ids — in-contract S. */
+    private fun randomSource(random: Random): List<Row> {
+        var key = 1
+        var block = 0
+        return buildList {
+            repeat(random.nextInt(2, 9)) {
+                if (random.nextBoolean()) {
+                    add(row(key++))
+                } else {
+                    val id = "b${block++}"
+                    repeat(random.nextInt(1, 5)) { add(row(key++, id)) }
+                }
+            }
+        }
+    }
+
+    // endregion
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/ApplyRowReorderWithinBlockTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/ApplyRowReorderWithinBlockTest.kt
@@ -1,0 +1,81 @@
+package ua.wwind.table
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+private data class WbRow(val key: Int, val block: String?)
+
+private fun wbRow(
+    key: Int,
+    block: String? = null,
+) = WbRow(key, block)
+
+private fun MutableList<WbRow>.applyWb(move: RowWithinBlockMove) =
+    applyRowReorderWithinBlock(move, keyOf = { it.key }, blockOf = { it.block })
+
+class ApplyRowReorderWithinBlockTest {
+    @Test
+    fun `move a row to the end of its block`() {
+        val source = mutableListOf(wbRow(0, "x"), wbRow(1, "a"), wbRow(2, "a"), wbRow(3, "a"), wbRow(4))
+        // id 1 lands after id 3 (block end)
+        source.applyWb(RowWithinBlockMove(blockId = "a", movedKey = 1, afterKey = 3, beforeKey = null))
+        assertThat(source.map { it.key }).isEqualTo(listOf(0, 2, 3, 1, 4))
+    }
+
+    @Test
+    fun `move a row to the start of its block`() {
+        val source = mutableListOf(wbRow(0, "x"), wbRow(1, "a"), wbRow(2, "a"), wbRow(3, "a"), wbRow(4))
+        // id 3 lands at block start (null after anchor, before = first mate)
+        source.applyWb(RowWithinBlockMove(blockId = "a", movedKey = 3, afterKey = null, beforeKey = 1))
+        assertThat(source.map { it.key }).isEqualTo(listOf(0, 3, 1, 2, 4))
+    }
+
+    @Test
+    fun `hidden block members keep their relative order`() {
+        // Source block "a": 1, 2(hidden), 3. View is [1, 3]. Move id 3 above id 1.
+        val source = mutableListOf(wbRow(0, "x"), wbRow(1, "a"), wbRow(2, "a"), wbRow(3, "a"), wbRow(4))
+        source.applyWb(RowWithinBlockMove(blockId = "a", movedKey = 3, afterKey = null, beforeKey = 1))
+        // id 3 first, then 1, then hidden 2 keeps its position after 1
+        assertThat(source.map { it.key }).isEqualTo(listOf(0, 3, 1, 2, 4))
+    }
+
+    @Test
+    fun `missing after anchor falls back to before anchor`() {
+        val source = mutableListOf(wbRow(1, "a"), wbRow(2, "a"), wbRow(3, "a"))
+        // after anchor (99) is gone; before anchor is id 3 -> land right before it
+        source.applyWb(RowWithinBlockMove(blockId = "a", movedKey = 1, afterKey = 99, beforeKey = 3))
+        assertThat(source.map { it.key }).isEqualTo(listOf(2, 1, 3))
+    }
+
+    @Test
+    fun `both anchors missing leaves the list untouched`() {
+        val source = mutableListOf(wbRow(1, "a"), wbRow(2, "a"), wbRow(3, "a"))
+        source.applyWb(RowWithinBlockMove(blockId = "a", movedKey = 2, afterKey = 88, beforeKey = 99))
+        assertThat(source.map { it.key }).isEqualTo(listOf(1, 2, 3))
+    }
+
+    @Test
+    fun `vanished moved key leaves the list untouched`() {
+        val source = mutableListOf(wbRow(1, "a"), wbRow(2, "a"))
+        source.applyWb(RowWithinBlockMove(blockId = "a", movedKey = 99, afterKey = 1, beforeKey = null))
+        assertThat(source.map { it.key }).isEqualTo(listOf(1, 2))
+    }
+
+    @Test
+    fun `stale block id leaves the list untouched`() {
+        val source = mutableListOf(wbRow(1, "a"), wbRow(2, "a"))
+        source.applyWb(RowWithinBlockMove(blockId = "gone", movedKey = 1, afterKey = 2, beforeKey = null))
+        assertThat(source.map { it.key }).isEqualTo(listOf(1, 2))
+    }
+
+    @Test
+    fun `applying the same move twice is a fixpoint`() {
+        val source = mutableListOf(wbRow(0, "x"), wbRow(1, "a"), wbRow(2, "a"), wbRow(3, "a"), wbRow(4))
+        val move = RowWithinBlockMove(blockId = "a", movedKey = 1, afterKey = 3, beforeKey = null)
+        source.applyWb(move)
+        val once = source.map { it.key }
+        source.applyWb(move)
+        assertThat(source.map { it.key }).isEqualTo(once)
+    }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/ColumnVisibilityTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/ColumnVisibilityTest.kt
@@ -1,0 +1,148 @@
+package ua.wwind.table
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isLessThan
+import kotlinx.collections.immutable.persistentListOf
+import ua.wwind.table.state.TableState
+import ua.wwind.table.state.rememberTableState
+import kotlin.test.Test
+
+/**
+ * Composition-level cover for `ColumnSpec.visible` changing after the first render — the path that
+ * `TableState.tableWidth` derives from, and the one the unit tests can only reach by assigning
+ * `visibleColumns` by hand.
+ *
+ * These also stand in for a recomposition-loop check: `Table` assigns `state.visibleColumns` *during*
+ * composition, and a write that kept invalidating its own readers would never let `waitForIdle`
+ * return, failing here by timeout rather than by assertion.
+ */
+@OptIn(ExperimentalTestApi::class, ExperimentalTableApi::class)
+class ColumnVisibilityTest {
+    private fun columnsWith(showSecond: Boolean) =
+        tableColumns<String, String, Unit> {
+            column("a", valueOf = { it }) {
+                header("A")
+                width(100.dp, 100.dp)
+                resizable(false)
+                cell { item, _ -> Text(item) }
+            }
+            column("b", valueOf = { it }) {
+                header("B")
+                width(100.dp, 100.dp)
+                resizable(false)
+                visible(showSecond)
+                cell { _, _ -> Text("cell-b") }
+            }
+        }
+
+    @Test
+    fun `table width grows when a column becomes visible after the first render`() =
+        runComposeUiTest {
+            // Starts hidden on purpose: the width freezes at whatever the first composition
+            // computed, so a table that opens narrow is the case that breaks. Opening wide and
+            // hiding freezes at the *wider* value, which still fits every cell and hides nothing.
+            var showSecond by mutableStateOf(false)
+            lateinit var state: TableState<String>
+
+            setContent {
+                val columns = remember(showSecond) { columnsWith(showSecond) }
+                state = rememberTableState(columns = persistentListOf("a", "b"))
+                Box(Modifier.size(400.dp)) {
+                    Table(
+                        itemsCount = 1,
+                        itemAt = { "row" },
+                        state = state,
+                        columns = columns,
+                    )
+                }
+            }
+
+            waitForIdle()
+            val divider = state.dimensions.dividerThickness
+            assertThat(state.tableWidth).isEqualTo(100.dp + divider)
+
+            showSecond = true
+            waitForIdle()
+            assertThat(state.tableWidth).isEqualTo(200.dp + divider * 2)
+
+            showSecond = false
+            waitForIdle()
+            assertThat(state.tableWidth).isEqualTo(100.dp + divider)
+        }
+
+    @Test
+    fun `a cell of a column revealed after the first render is on screen`() =
+        runComposeUiTest {
+            var showSecond by mutableStateOf(false)
+
+            setContent {
+                val columns = remember(showSecond) { columnsWith(showSecond) }
+                val state = rememberTableState(columns = persistentListOf("a", "b"))
+                Box(Modifier.size(400.dp)) {
+                    Table(
+                        itemsCount = 1,
+                        itemAt = { "row" },
+                        state = state,
+                        columns = columns,
+                    )
+                }
+            }
+
+            waitForIdle()
+            onNodeWithText("cell-b").assertDoesNotExist()
+
+            // Asserts the *cell*, not the header: the header measures from its own width map and
+            // rendered fine even while the bug was live. It was the row — measured with
+            // `state.tableWidth` — that kept the revealed column outside its bounds and out of
+            // horizontal scroll range.
+            showSecond = true
+            waitForIdle()
+            onNodeWithText("cell-b").assertIsDisplayed()
+        }
+
+    @Test
+    fun `a visibility flip settles instead of recomposing forever`() =
+        runComposeUiTest {
+            var showSecond by mutableStateOf(true)
+            var rootCompositions = 0
+
+            setContent {
+                SideEffect { rootCompositions++ }
+                val columns = remember(showSecond) { columnsWith(showSecond) }
+                val state = rememberTableState(columns = persistentListOf("a", "b"))
+                Box(Modifier.size(400.dp)) {
+                    Table(
+                        itemsCount = 1,
+                        itemAt = { "row" },
+                        state = state,
+                        columns = columns,
+                    )
+                }
+            }
+
+            waitForIdle()
+            val settled = rootCompositions
+
+            showSecond = false
+            waitForIdle()
+
+            // Writing state during composition costs at most one extra pass; anything more means the
+            // write is feeding its own readers.
+            assertThat(rootCompositions - settled).isLessThan(3)
+        }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/RowBlockOrderingTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/RowBlockOrderingTest.kt
@@ -1,0 +1,188 @@
+package ua.wwind.table
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
+import kotlin.random.Random
+import kotlin.test.Test
+
+private data class Entry(val key: Int, val block: String?, val value: Int)
+
+/** The table's unit rule, reimplemented independently: adjacency runs, singletons for null ids. */
+private fun unitsOf(rows: List<Entry>): List<List<Entry>> {
+    val units = mutableListOf<MutableList<Entry>>()
+    var runId: String? = null
+    for (entry in rows) {
+        val id = entry.block
+        if (id != null && id == runId) {
+            units.last() += entry
+        } else {
+            units += mutableListOf(entry)
+            runId = id
+        }
+    }
+    return units
+}
+
+/** Block units are identified by id, standalone units by their single row's key. */
+private fun unitIdentity(unit: List<Entry>): Any = unit.first().block ?: unit.first().key
+
+/** Units of 1..4 rows with values in 0..9, so comparator ties occur constantly. */
+private fun randomEntries(random: Random): List<Entry> {
+    var key = 1
+    var block = 0
+    return buildList {
+        repeat(random.nextInt(1, 9)) {
+            if (random.nextBoolean()) {
+                add(Entry(key++, null, random.nextInt(10)))
+            } else {
+                val id = "b${block++}"
+                repeat(random.nextInt(1, 5)) { add(Entry(key++, id, random.nextInt(10))) }
+            }
+        }
+    }
+}
+
+class RowBlockOrderingTest {
+    private val byValue = compareBy<Entry> { it.value }
+
+    // region sortedWithinRowBlocks
+
+    @Test
+    fun `rows sort within their block and units order by their minimal member`() {
+        val rows =
+            listOf(
+                Entry(1, "b", 5),
+                Entry(2, "b", 2),
+                Entry(3, null, 9),
+                Entry(4, "a", 4),
+                Entry(5, "a", 1),
+            )
+        val sorted = rows.sortedWithinRowBlocks({ it.block }, byValue)
+        assertThat(sorted.map { it.key }).isEqualTo(listOf(5, 4, 2, 1, 3))
+    }
+
+    @Test
+    fun `blocks never fragment under a comparator that interleaves them`() {
+        // A plain sortedBy would render 1(a) 3(b) 4(b) 2(a): both blocks torn into duplicate bands.
+        val rows =
+            listOf(
+                Entry(1, "a", 1),
+                Entry(2, "a", 9),
+                Entry(3, "b", 2),
+                Entry(4, "b", 8),
+            )
+        val sorted = rows.sortedWithinRowBlocks({ it.block }, byValue)
+        assertThat(sorted.map { it.key }).isEqualTo(listOf(1, 2, 3, 4))
+    }
+
+    @Test
+    fun `ties keep their original order within a block and between units`() {
+        val rows =
+            listOf(
+                Entry(1, "a", 3),
+                Entry(2, "a", 3),
+                Entry(3, null, 3),
+                Entry(4, "b", 3),
+            )
+        assertThat(rows.sortedWithinRowBlocks({ it.block }, byValue)).isEqualTo(rows)
+    }
+
+    @Test
+    fun `a list without blocks sorts like a plain stable sort`() {
+        val rows = listOf(Entry(1, null, 5), Entry(2, null, 1), Entry(3, null, 5), Entry(4, null, 0))
+        assertThat(rows.sortedWithinRowBlocks({ it.block }, byValue)).isEqualTo(rows.sortedWith(byValue))
+    }
+
+    @Test
+    fun `empty list sorts to an empty list`() {
+        assertThat(emptyList<Entry>().sortedWithinRowBlocks({ it.block }, byValue)).isEqualTo(emptyList<Entry>())
+    }
+
+    @Test
+    fun `random lists hold every within-block ordering property across 1000 rounds`() {
+        val random = Random(7177)
+        repeat(1000) {
+            val rows = randomEntries(random)
+            val sorted = rows.sortedWithinRowBlocks({ it.block }, byValue)
+
+            // Permutation: nothing lost, nothing duplicated.
+            assertThat(sorted.sortedBy { it.key }).isEqualTo(rows.sortedBy { it.key })
+
+            // Every unit survives whole — a split would surface as an extra run here.
+            val originalUnits = unitsOf(rows)
+            val sortedUnits = unitsOf(sorted)
+            assertThat(sortedUnits.size).isEqualTo(originalUnits.size)
+
+            // Within each unit: sorted by the comparator, ties in original order (stable).
+            val expectedByIdentity = originalUnits.associate { unitIdentity(it) to it.sortedWith(byValue) }
+            for (unit in sortedUnits) {
+                assertThat(unit).isEqualTo(expectedByIdentity.getValue(unitIdentity(unit)))
+            }
+
+            // Between units: minimal members never decrease; equal minimals keep unit order.
+            val originalPosition = originalUnits.withIndex().associate { (i, unit) -> unitIdentity(unit) to i }
+            sortedUnits.zipWithNext().forEach { (left, right) ->
+                val order = byValue.compare(left.first(), right.first())
+                assertThat(order <= 0).isTrue()
+                if (order == 0) {
+                    assertThat(
+                        originalPosition.getValue(unitIdentity(left)) < originalPosition.getValue(unitIdentity(right)),
+                    ).isTrue()
+                }
+            }
+
+            // Re-sorting the result changes nothing: the sort is a fixpoint.
+            assertThat(sorted.sortedWithinRowBlocks({ it.block }, byValue)).isEqualTo(sorted)
+        }
+    }
+
+    // endregion
+
+    // region filteredWholeRowBlocks
+
+    @Test
+    fun `a single matching member keeps its whole block`() {
+        val rows =
+            listOf(
+                Entry(1, "a", 1),
+                Entry(2, "a", 7),
+                Entry(3, null, 1),
+                Entry(4, "b", 1),
+                Entry(5, "b", 2),
+            )
+        val filtered = rows.filteredWholeRowBlocks({ it.block }) { it.value >= 5 }
+        assertThat(filtered.map { it.key }).isEqualTo(listOf(1, 2))
+    }
+
+    @Test
+    fun `standalone rows filter row by row`() {
+        val rows = listOf(Entry(1, null, 5), Entry(2, null, 1), Entry(3, null, 6))
+        val filtered = rows.filteredWholeRowBlocks({ it.block }) { it.value >= 5 }
+        assertThat(filtered.map { it.key }).isEqualTo(listOf(1, 3))
+    }
+
+    @Test
+    fun `random filters keep or drop whole blocks across 1000 rounds`() {
+        val random = Random(41)
+        repeat(1000) {
+            val rows = randomEntries(random)
+            // Thresholds 0..10 over values 0..9: keep-everything and drop-everything both occur.
+            val threshold = random.nextInt(11)
+            val predicate: (Entry) -> Boolean = { it.value >= threshold }
+            val filtered = rows.filteredWholeRowBlocks({ it.block }, predicate)
+
+            // Order-preserving subsequence of the input.
+            val keptKeys = filtered.map { it.key }.toSet()
+            assertThat(filtered).isEqualTo(rows.filter { it.key in keptKeys })
+
+            // Block granularity: any match keeps the whole unit, none drops it whole.
+            for (unit in unitsOf(rows)) {
+                val expected = if (unit.any(predicate)) unit.map { it.key }.toSet() else emptySet()
+                assertThat(unit.filter { it.key in keptKeys }.map { it.key }.toSet()).isEqualTo(expected)
+            }
+        }
+    }
+
+    // endregion
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/RowBlocksPagedTableTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/RowBlocksPagedTableTest.kt
@@ -1,0 +1,376 @@
+package ua.wwind.table
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isLessThan
+import assertk.assertions.isNull
+import kotlinx.collections.immutable.persistentListOf
+import ua.wwind.table.config.TableDefaults
+import ua.wwind.table.config.TableSettings
+import ua.wwind.table.state.rememberTableState
+import kotlin.test.Test
+
+private data class PagedRow(val id: Int, val block: String?) {
+    val name: String get() = "name-$id"
+}
+
+private fun pagedColumns() =
+    tableColumns<PagedRow, String, Unit> {
+        column("handle", valueOf = { it.id }) {
+            header("H")
+            width(48.dp, 48.dp)
+            resizable(false)
+            cell { item, _ ->
+                if (isRowBlockLeader) {
+                    Box(
+                        Modifier
+                            .size(24.dp)
+                            .testTag("handle-${item.id}")
+                            .draggableHandle(),
+                    )
+                } else {
+                    Box(Modifier.size(24.dp).testTag("member-${item.id}"))
+                }
+            }
+        }
+        column("name", valueOf = { it.name }) {
+            header("Name")
+            width(120.dp, 120.dp)
+            resizable(false)
+            cell { item, _ -> Text(item.name) }
+        }
+    }
+
+private val pagedRowKey: (PagedRow?, Int) -> Any = { item, index -> item?.id ?: "ph-$index" }
+
+/**
+ * The paged surface of row blocks, driven through a fake paged source: a fixed [itemsCount] whose
+ * `itemAt` answers null until the "page" holding an index loads. This is exactly what the paging
+ * adapter hands the core table, so the policies proven here — bands over loaded runs, the paged
+ * drop policy, gestures surviving a mid-drag page load — are the adapter's behavior.
+ */
+@OptIn(ExperimentalTestApi::class, ExperimentalTableApi::class)
+class RowBlocksPagedTableTest {
+    @Test
+    fun `bands extend as pages load`() =
+        runComposeUiTest {
+            // Rows 0..3 are one block, but only the first page is in: the band must cover the
+            // loaded fragment and grow when the rest of the block arrives — never claim unloaded
+            // rows whose membership is not yet observable.
+            var loaded by mutableStateOf(mapOf(0 to PagedRow(0, "a"), 1 to PagedRow(1, "a")))
+            setContent {
+                val columns = remember { pagedColumns() }
+                val state = rememberTableState(columns = persistentListOf("handle", "name"))
+                val blocks =
+                    remember {
+                        RowBlocks<PagedRow>(
+                            blockOf = { it.block },
+                            blockHeader = { blockId, rows ->
+                                Text("band-$blockId-${rows.first}-${rows.last}")
+                            },
+                        )
+                    }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = 6,
+                        itemAt = { loaded[it] },
+                        state = state,
+                        columns = columns,
+                        rowKey = pagedRowKey,
+                        rowBlocks = blocks,
+                    )
+                }
+            }
+            waitForIdle()
+            onNodeWithText("band-a-0-1").assertIsDisplayed()
+
+            loaded = loaded +
+                mapOf(
+                    2 to PagedRow(2, "a"),
+                    3 to PagedRow(3, "a"),
+                    4 to PagedRow(4, null),
+                    5 to PagedRow(5, null),
+                )
+            waitForIdle()
+            onNodeWithText("band-a-0-1").assertDoesNotExist()
+            onNodeWithText("band-a-0-3").assertIsDisplayed()
+        }
+
+    @Test
+    fun `drop onto a placeholder cancels and a later drop onto the loaded page commits`() =
+        runComposeUiTest {
+            val moves = mutableListOf<RowBlockMove>()
+            var loaded by mutableStateOf(
+                mapOf(
+                    0 to PagedRow(0, "a"),
+                    1 to PagedRow(1, "a"),
+                    2 to PagedRow(2, null),
+                ),
+            )
+            setContent {
+                val columns = remember { pagedColumns() }
+                val state =
+                    rememberTableState(
+                        columns = persistentListOf("handle", "name"),
+                        settings = TableSettings(rowReorderEnabled = true),
+                        dimensions = TableDefaults.compactDimensions(),
+                    )
+                val blocks =
+                    remember { RowBlocks<PagedRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = 4,
+                        itemAt = { loaded[it] },
+                        state = state,
+                        columns = columns,
+                        rowKey = pagedRowKey,
+                        rowBlocks = blocks,
+                    )
+                }
+            }
+            waitForIdle()
+
+            // Overshoot past the end: the block lands last, directly after the unloaded row 3 —
+            // an anchor whose key does not exist yet. The gesture must snap back and emit nothing.
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(10) { moveBy(Offset(0f, 60f)) }
+                up()
+            }
+            waitForIdle()
+            assertThat(moves).isEqualTo(emptyList<RowBlockMove>())
+            val blockTop = onNodeWithText("name-0").getBoundsInRoot().top
+            val standaloneTop = onNodeWithText("name-2").getBoundsInRoot().top
+            assertThat(blockTop).isLessThan(standaloneTop)
+
+            // The page arrives; the same drop now has a loaded anchor and commits normally.
+            loaded = loaded + mapOf(3 to PagedRow(3, null))
+            waitForIdle()
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(10) { moveBy(Offset(0f, 60f)) }
+                up()
+            }
+            waitForIdle()
+            assertThat(moves.size).isEqualTo(1)
+            val move = moves.single()
+            assertThat(move.blockId).isEqualTo("a")
+            assertThat(move.movedKeys).isEqualTo(listOf<Any>(0, 1))
+            assertThat(move.afterKey).isEqualTo(3)
+            assertThat(move.beforeKey).isNull()
+        }
+
+    @Test
+    fun `embedded refused drop snaps the view back and a later drop onto the loaded page commits`() =
+        runComposeUiTest {
+            // Embedded twist on the paged drop policy: the embedded engine keys its drag offsets
+            // on list equality alone, and a refusal is net-neutral over that list — without a
+            // rebuild signal the view would keep showing the dropped order over a model that
+            // snapped back, until some unrelated list change made the rows visibly jump.
+            val moves = mutableListOf<RowBlockMove>()
+            var loaded by mutableStateOf(
+                mapOf(
+                    0 to PagedRow(0, "a"),
+                    1 to PagedRow(1, "a"),
+                    2 to PagedRow(2, null),
+                ),
+            )
+            setContent {
+                val columns = remember { pagedColumns() }
+                val state =
+                    rememberTableState(
+                        columns = persistentListOf("handle", "name"),
+                        settings = TableSettings(rowReorderEnabled = true),
+                        dimensions = TableDefaults.compactDimensions(),
+                    )
+                val blocks =
+                    remember { RowBlocks<PagedRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = 4,
+                        itemAt = { loaded[it] },
+                        state = state,
+                        columns = columns,
+                        rowKey = pagedRowKey,
+                        rowBlocks = blocks,
+                        embedded = true,
+                    )
+                }
+            }
+            waitForIdle()
+
+            // Overshoot past the end: the block lands after the unloaded row 3, whose key does
+            // not exist yet. Nothing may be emitted — and the VIEW, not just the model, must
+            // show the restored order.
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(10) { moveBy(Offset(0f, 60f)) }
+                up()
+            }
+            waitForIdle()
+            assertThat(moves).isEqualTo(emptyList<RowBlockMove>())
+            val blockTop = onNodeWithText("name-0").getBoundsInRoot().top
+            val standaloneTop = onNodeWithText("name-2").getBoundsInRoot().top
+            assertThat(blockTop).isLessThan(standaloneTop)
+
+            // The page arrives; the same drop now has a loaded anchor, and the engine rebuilt by
+            // the refusal must deliver it as one normal commit.
+            loaded = loaded + mapOf(3 to PagedRow(3, null))
+            waitForIdle()
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(10) { moveBy(Offset(0f, 60f)) }
+                up()
+            }
+            waitForIdle()
+            assertThat(moves.size).isEqualTo(1)
+            val move = moves.single()
+            assertThat(move.blockId).isEqualTo("a")
+            assertThat(move.movedKeys).isEqualTo(listOf<Any>(0, 1))
+            assertThat(move.afterKey).isEqualTo(3)
+            assertThat(move.beforeKey).isNull()
+        }
+
+    @Test
+    fun `drop onto a loaded anchor commits despite a placeholder crossed en route`() =
+        runComposeUiTest {
+            val moves = mutableListOf<RowBlockMove>()
+            val loaded =
+                mapOf(
+                    0 to PagedRow(0, "a"),
+                    1 to PagedRow(1, "a"),
+                    3 to PagedRow(3, null),
+                )
+            setContent {
+                val columns = remember { pagedColumns() }
+                val state =
+                    rememberTableState(
+                        columns = persistentListOf("handle", "name"),
+                        settings = TableSettings(rowReorderEnabled = true),
+                        dimensions = TableDefaults.compactDimensions(),
+                    )
+                val blocks =
+                    remember { RowBlocks<PagedRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = 4,
+                        itemAt = { loaded[it] },
+                        state = state,
+                        columns = columns,
+                        rowKey = pagedRowKey,
+                        rowBlocks = blocks,
+                    )
+                }
+            }
+            waitForIdle()
+
+            // The drag swaps past the placeholder unit at row 2 and lands last, after loaded
+            // row 3: crossing a placeholder is fine, only the landing anchors must be loaded.
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(10) { moveBy(Offset(0f, 60f)) }
+                up()
+            }
+            waitForIdle()
+            assertThat(moves.size).isEqualTo(1)
+            val move = moves.single()
+            assertThat(move.blockId).isEqualTo("a")
+            assertThat(move.movedKeys).isEqualTo(listOf<Any>(0, 1))
+            assertThat(move.afterKey).isEqualTo(3)
+            assertThat(move.beforeKey).isNull()
+        }
+
+    @Test
+    fun `page loading mid gesture keeps the drag alive and the drop commits`() =
+        runComposeUiTest {
+            // The go/no-go check for paged drag: a page arriving under a held gesture replaces
+            // placeholder index-keys with item keys beneath the engine. The dragged unit's own key
+            // is stable, so the drag must survive the neighbour churn and settle into one commit
+            // whose anchors come from the freshly loaded page.
+            val moves = mutableListOf<RowBlockMove>()
+            var loaded by mutableStateOf(
+                mapOf(
+                    0 to PagedRow(0, "a"),
+                    1 to PagedRow(1, "a"),
+                    2 to PagedRow(2, null),
+                ),
+            )
+            setContent {
+                val columns = remember { pagedColumns() }
+                val state =
+                    rememberTableState(
+                        columns = persistentListOf("handle", "name"),
+                        settings = TableSettings(rowReorderEnabled = true),
+                        dimensions = TableDefaults.compactDimensions(),
+                    )
+                val blocks =
+                    remember { RowBlocks<PagedRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = 6,
+                        itemAt = { loaded[it] },
+                        state = state,
+                        columns = columns,
+                        rowKey = pagedRowKey,
+                        rowBlocks = blocks,
+                    )
+                }
+            }
+            waitForIdle()
+
+            // Start the drag and hold it mid-list — no release yet. Steps stay under one row
+            // height (36dp compact): the engine swaps with the item whose CENTER the dragged
+            // rect covers, one per event, so a coarser step can pass two centers and drop a swap
+            // — that would blur what the landing assertion below is allowed to prove.
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(2) { moveBy(Offset(0f, 40f)) }
+            }
+            waitForIdle()
+
+            // The page under the pointer loads: rows 3..5 appear, their lazy keys flip from
+            // placeholder index-keys to item keys.
+            loaded = loaded +
+                mapOf(
+                    3 to PagedRow(3, null),
+                    4 to PagedRow(4, null),
+                    5 to PagedRow(5, null),
+                )
+            waitForIdle()
+
+            // The same gesture continues over the fresh rows to the end of the list. Landing
+            // last requires swaps that can only happen AFTER the load, so the final anchor is
+            // itself the proof that the churn did not kill or corrupt the gesture.
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                repeat(2) { moveBy(Offset(0f, 40f)) }
+                repeat(4) { moveBy(Offset(0f, 10f)) }
+                up()
+            }
+            waitForIdle()
+
+            assertThat(moves.size).isEqualTo(1)
+            val move = moves.single()
+            assertThat(move.blockId).isEqualTo("a")
+            assertThat(move.movedKeys).isEqualTo(listOf<Any>(0, 1))
+            assertThat(move.afterKey).isEqualTo(5)
+            assertThat(move.beforeKey).isNull()
+        }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/RowBlocksPagedTableTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/RowBlocksPagedTableTest.kt
@@ -3,6 +3,7 @@ package ua.wwind.table
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -39,16 +40,12 @@ private fun pagedColumns() =
             width(48.dp, 48.dp)
             resizable(false)
             cell { item, _ ->
-                if (isRowBlockLeader) {
-                    Box(
-                        Modifier
-                            .size(24.dp)
-                            .testTag("handle-${item.id}")
-                            .draggableHandle(),
-                    )
-                } else {
-                    Box(Modifier.size(24.dp).testTag("member-${item.id}"))
-                }
+                Box(
+                    Modifier
+                        .size(24.dp)
+                        .testTag("handle-${item.id}")
+                        .draggableHandle(),
+                )
             }
         }
         column("name", valueOf = { it.name }) {
@@ -56,6 +53,19 @@ private fun pagedColumns() =
             width(120.dp, 120.dp)
             resizable(false)
             cell { item, _ -> Text(item.name) }
+        }
+    }
+
+/** Block header carrying the whole-block drag handle tagged `block-handle-<blockId>`. */
+private val pagedBlockDragHeader: @Composable context(RowBlockHeaderScope) (blockId: Any, rows: IntRange) -> Unit =
+    { blockId, _ ->
+        Box(
+            Modifier
+                .size(24.dp)
+                .testTag("block-handle-$blockId")
+                .draggableHandle(),
+        ) {
+            Text("band-$blockId")
         }
     }
 
@@ -134,7 +144,13 @@ class RowBlocksPagedTableTest {
                         dimensions = TableDefaults.compactDimensions(),
                     )
                 val blocks =
-                    remember { RowBlocks<PagedRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                    remember {
+                        RowBlocks<PagedRow>(
+                            blockOf = { it.block },
+                            onCommit = { moves += it },
+                            blockHeader = pagedBlockDragHeader,
+                        )
+                    }
                 Box(Modifier.size(400.dp, 640.dp)) {
                     Table(
                         itemsCount = 4,
@@ -150,7 +166,7 @@ class RowBlocksPagedTableTest {
 
             // Overshoot past the end: the block lands last, directly after the unloaded row 3 —
             // an anchor whose key does not exist yet. The gesture must snap back and emit nothing.
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
                 down(center)
                 repeat(10) { moveBy(Offset(0f, 60f)) }
                 up()
@@ -164,7 +180,7 @@ class RowBlocksPagedTableTest {
             // The page arrives; the same drop now has a loaded anchor and commits normally.
             loaded = loaded + mapOf(3 to PagedRow(3, null))
             waitForIdle()
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
                 down(center)
                 repeat(10) { moveBy(Offset(0f, 60f)) }
                 up()
@@ -202,7 +218,13 @@ class RowBlocksPagedTableTest {
                         dimensions = TableDefaults.compactDimensions(),
                     )
                 val blocks =
-                    remember { RowBlocks<PagedRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                    remember {
+                        RowBlocks<PagedRow>(
+                            blockOf = { it.block },
+                            onCommit = { moves += it },
+                            blockHeader = pagedBlockDragHeader,
+                        )
+                    }
                 Box(Modifier.size(400.dp, 640.dp)) {
                     Table(
                         itemsCount = 4,
@@ -220,7 +242,7 @@ class RowBlocksPagedTableTest {
             // Overshoot past the end: the block lands after the unloaded row 3, whose key does
             // not exist yet. Nothing may be emitted — and the VIEW, not just the model, must
             // show the restored order.
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
                 down(center)
                 repeat(10) { moveBy(Offset(0f, 60f)) }
                 up()
@@ -235,7 +257,7 @@ class RowBlocksPagedTableTest {
             // the refusal must deliver it as one normal commit.
             loaded = loaded + mapOf(3 to PagedRow(3, null))
             waitForIdle()
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
                 down(center)
                 repeat(10) { moveBy(Offset(0f, 60f)) }
                 up()
@@ -268,7 +290,13 @@ class RowBlocksPagedTableTest {
                         dimensions = TableDefaults.compactDimensions(),
                     )
                 val blocks =
-                    remember { RowBlocks<PagedRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                    remember {
+                        RowBlocks<PagedRow>(
+                            blockOf = { it.block },
+                            onCommit = { moves += it },
+                            blockHeader = pagedBlockDragHeader,
+                        )
+                    }
                 Box(Modifier.size(400.dp, 640.dp)) {
                     Table(
                         itemsCount = 4,
@@ -284,7 +312,7 @@ class RowBlocksPagedTableTest {
 
             // The drag swaps past the placeholder unit at row 2 and lands last, after loaded
             // row 3: crossing a placeholder is fine, only the landing anchors must be loaded.
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
                 down(center)
                 repeat(10) { moveBy(Offset(0f, 60f)) }
                 up()
@@ -322,7 +350,13 @@ class RowBlocksPagedTableTest {
                         dimensions = TableDefaults.compactDimensions(),
                     )
                 val blocks =
-                    remember { RowBlocks<PagedRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                    remember {
+                        RowBlocks<PagedRow>(
+                            blockOf = { it.block },
+                            onCommit = { moves += it },
+                            blockHeader = pagedBlockDragHeader,
+                        )
+                    }
                 Box(Modifier.size(400.dp, 640.dp)) {
                     Table(
                         itemsCount = 6,
@@ -340,7 +374,7 @@ class RowBlocksPagedTableTest {
             // height (36dp compact): the engine swaps with the item whose CENTER the dragged
             // rect covers, one per event, so a coarser step can pass two centers and drop a swap
             // — that would blur what the landing assertion below is allowed to prove.
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
                 down(center)
                 repeat(2) { moveBy(Offset(0f, 40f)) }
             }
@@ -359,7 +393,7 @@ class RowBlocksPagedTableTest {
             // The same gesture continues over the fresh rows to the end of the list. Landing
             // last requires swaps that can only happen AFTER the load, so the final anchor is
             // itself the proof that the churn did not kill or corrupt the gesture.
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
                 repeat(2) { moveBy(Offset(0f, 40f)) }
                 repeat(4) { moveBy(Offset(0f, 10f)) }
                 up()

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/RowBlocksTableTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/RowBlocksTableTest.kt
@@ -55,9 +55,9 @@ private data class BlockRow(val id: Int, val block: String?) {
 }
 
 /**
- * A handle column exercising the public leader flag plus a plain content column. Leaders carry a
- * draggable handle tagged `handle-<id>`; members are tagged `member-<id>` so both outcomes of the
- * flag are observable.
+ * A handle column plus a plain content column. Every row carries a drag handle tagged `handle-<id>`:
+ * a standalone row's handle drives the outer (unit) engine, a block row's handle drives the nested
+ * within-block engine. The whole block is dragged from its header handle (see [blockDragHeader]).
  */
 private fun blockColumns() =
     tableColumns<BlockRow, String, Unit> {
@@ -66,16 +66,12 @@ private fun blockColumns() =
             width(48.dp, 48.dp)
             resizable(false)
             cell { item, _ ->
-                if (isRowBlockLeader) {
-                    Box(
-                        Modifier
-                            .size(24.dp)
-                            .testTag("handle-${item.id}")
-                            .draggableHandle(),
-                    )
-                } else {
-                    Box(Modifier.size(24.dp).testTag("member-${item.id}"))
-                }
+                Box(
+                    Modifier
+                        .size(24.dp)
+                        .testTag("handle-${item.id}")
+                        .draggableHandle(),
+                )
             }
         }
         column("name", valueOf = { it.name }) {
@@ -83,6 +79,22 @@ private fun blockColumns() =
             width(120.dp, 120.dp)
             resizable(false)
             cell { item, _ -> Text(item.name) }
+        }
+    }
+
+/**
+ * A block header carrying the whole-block drag handle tagged `block-handle-<blockId>`, plus a
+ * `band-<blockId>` label. Dragging the handle drags the entire block through the outer engine.
+ */
+private val blockDragHeader: @Composable context(RowBlockHeaderScope) (blockId: Any, rows: IntRange) -> Unit =
+    { blockId, _ ->
+        Box(
+            Modifier
+                .size(24.dp)
+                .testTag("block-handle-$blockId")
+                .draggableHandle(),
+        ) {
+            Text("band-$blockId")
         }
     }
 
@@ -143,10 +155,10 @@ class RowBlocksTableTest {
         }
 
     @Test
-    fun `leader flag marks the first row of every run and standalone rows`() =
+    fun `every row carries a drag handle`() =
         runComposeUiTest {
-            // The same id in non-adjacent runs models a filter that split a block: each visible run
-            // gets its own leader, exactly like the band derivation.
+            // Handles are per-row now — block members included, not just a leader — because a block
+            // row drives the nested within-block engine.
             val items =
                 listOf(
                     BlockRow(0, "a"),
@@ -171,7 +183,7 @@ class RowBlocksTableTest {
             }
             waitForIdle()
             onNodeWithTag("handle-0", useUnmergedTree = true).assertExists()
-            onNodeWithTag("member-1", useUnmergedTree = true).assertExists()
+            onNodeWithTag("handle-1", useUnmergedTree = true).assertExists()
             onNodeWithTag("handle-2", useUnmergedTree = true).assertExists()
             onNodeWithTag("handle-3", useUnmergedTree = true).assertExists()
         }
@@ -245,7 +257,13 @@ class RowBlocksTableTest {
                         dimensions = TableDefaults.compactDimensions(),
                     )
                 val blocks =
-                    remember { RowBlocks<BlockRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                    remember {
+                        RowBlocks<BlockRow>(
+                            blockOf = { it.block },
+                            onCommit = { moves += it },
+                            blockHeader = blockDragHeader,
+                        )
+                    }
                 Box(Modifier.size(400.dp, 640.dp)) {
                     Table(
                         itemsCount = items.size,
@@ -264,9 +282,10 @@ class RowBlocksTableTest {
             }
             waitForIdle()
 
-            // Drag block "a" from the top far past the end of the short list: the overshoot makes
-            // the landing position deterministic (last), however many intermediate swaps fire.
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+            // Drag block "a" by its header handle from the top far past the end of the short list:
+            // the overshoot makes the landing position deterministic (last), however many
+            // intermediate swaps fire.
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
                 down(center)
                 repeat(10) { moveBy(Offset(0f, 60f)) }
                 up()
@@ -306,7 +325,14 @@ class RowBlocksTableTest {
                             TableSettings(rowReorderEnabled = true, editingEnabled = true),
                         dimensions = TableDefaults.compactDimensions(),
                     )
-                val blocks = remember { RowBlocks<BlockRow>(blockOf = { it.block }, onCommit = {}) }
+                val blocks =
+                    remember {
+                        RowBlocks<BlockRow>(
+                            blockOf = { it.block },
+                            onCommit = {},
+                            blockHeader = blockDragHeader,
+                        )
+                    }
                 Box(Modifier.size(400.dp, 640.dp)) {
                     EditableTable(
                         itemsCount = items.size,
@@ -327,7 +353,8 @@ class RowBlocksTableTest {
             waitForIdle()
             assertThat(state.editingRow).isEqualTo(2)
 
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+            // Whole-block drag starts from the header handle; its start hook cancels the edit.
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
                 down(center)
                 moveBy(Offset(0f, 60f))
                 up()
@@ -533,7 +560,13 @@ class RowBlocksTableTest {
                         dimensions = dimensions,
                     )
                 val blocks =
-                    remember { RowBlocks<BlockRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                    remember {
+                        RowBlocks<BlockRow>(
+                            blockOf = { it.block },
+                            onCommit = { moves += it },
+                            blockHeader = blockDragHeader,
+                        )
+                    }
                 Box(Modifier.size(400.dp, 640.dp)) {
                     Table(
                         itemsCount = items.size,
@@ -557,7 +590,7 @@ class RowBlocksTableTest {
             }
             waitForIdle()
 
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
                 down(center)
                 repeat(10) { moveBy(Offset(0f, 60f)) }
                 up()
@@ -599,7 +632,13 @@ class RowBlocksTableTest {
                         dimensions = TableDefaults.compactDimensions(),
                     )
                 val blocks =
-                    remember { RowBlocks<BlockRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                    remember {
+                        RowBlocks<BlockRow>(
+                            blockOf = { it.block },
+                            onCommit = { moves += it },
+                            blockHeader = blockDragHeader,
+                        )
+                    }
                 Box(Modifier.size(400.dp, 640.dp)) {
                     Table(
                         itemsCount = items.size,
@@ -619,9 +658,10 @@ class RowBlocksTableTest {
             }
             waitForIdle()
 
-            // Drag block "a" from the top far past the end of the short list: the overshoot makes
-            // the landing position deterministic (last), whatever the intermediate geometry.
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+            // Drag block "a" by its header handle from the top far past the end of the short list:
+            // the overshoot makes the landing position deterministic (last), whatever the
+            // intermediate geometry.
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
                 down(center)
                 repeat(10) { moveBy(Offset(0f, 60f)) }
                 up()
@@ -673,7 +713,13 @@ class RowBlocksTableTest {
                         dimensions = TableDefaults.compactDimensions(),
                     )
                 val blocks =
-                    remember { RowBlocks<BlockRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                    remember {
+                        RowBlocks<BlockRow>(
+                            blockOf = { it.block },
+                            onCommit = { moves += it },
+                            blockHeader = blockDragHeader,
+                        )
+                    }
                 Box(Modifier.size(400.dp, 640.dp)) {
                     Table(
                         itemsCount = items.size,
@@ -688,8 +734,9 @@ class RowBlocksTableTest {
             }
             waitForIdle()
 
-            // Drag block "a" well past other units and hold it there — no release yet.
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+            // Drag block "a" by its header handle well past other units and hold it there — no
+            // release yet.
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
                 down(center)
                 repeat(10) { moveBy(Offset(0f, 60f)) }
             }
@@ -698,13 +745,13 @@ class RowBlocksTableTest {
             // External update mid-gesture: a new standalone leader on top shifts every unit index.
             items = listOf(BlockRow(9, null)) + items
             waitForIdle()
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput { up() }
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput { up() }
             waitForIdle()
 
             assertThat(moves).isEqualTo(emptyList<RowBlockMove>())
 
             // The dead gesture must not poison the next one.
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
                 down(center)
                 repeat(12) { moveBy(Offset(0f, 60f)) }
                 up()
@@ -893,7 +940,14 @@ class RowBlocksTableTest {
                             TableSettings(rowReorderEnabled = true, editingEnabled = true),
                         dimensions = TableDefaults.compactDimensions(),
                     )
-                val blocks = remember { RowBlocks<BlockRow>(blockOf = { it.block }, onCommit = {}) }
+                val blocks =
+                    remember {
+                        RowBlocks<BlockRow>(
+                            blockOf = { it.block },
+                            onCommit = {},
+                            blockHeader = blockDragHeader,
+                        )
+                    }
                 Box(Modifier.size(400.dp, 640.dp)) {
                     EditableTable(
                         itemsCount = items.size,
@@ -915,7 +969,8 @@ class RowBlocksTableTest {
             waitForIdle()
             assertThat(state.editingRow).isEqualTo(2)
 
-            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+            // Whole-block drag starts from the header handle; its start hook cancels the edit.
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
                 down(center)
                 moveBy(Offset(0f, 60f))
                 up()

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/RowBlocksTableTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/RowBlocksTableTest.kt
@@ -1,0 +1,1006 @@
+package ua.wwind.table
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.getBoundsInRoot
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.width
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isLessThan
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
+import co.touchlab.kermit.platformLogWriter
+import kotlinx.collections.immutable.persistentListOf
+import ua.wwind.table.config.SelectionMode
+import ua.wwind.table.config.TableCustomization
+import ua.wwind.table.config.TableDefaults
+import ua.wwind.table.config.TableRowContext
+import ua.wwind.table.config.TableRowStyle
+import ua.wwind.table.config.TableSettings
+import ua.wwind.table.config.resolveRowBlockContainerColor
+import ua.wwind.table.state.TableState
+import ua.wwind.table.state.rememberTableState
+import kotlin.test.Test
+
+private data class BlockRow(val id: Int, val block: String?) {
+    val name: String get() = "name-$id"
+}
+
+/**
+ * A handle column exercising the public leader flag plus a plain content column. Leaders carry a
+ * draggable handle tagged `handle-<id>`; members are tagged `member-<id>` so both outcomes of the
+ * flag are observable.
+ */
+private fun blockColumns() =
+    tableColumns<BlockRow, String, Unit> {
+        column("handle", valueOf = { it.id }) {
+            header("H")
+            width(48.dp, 48.dp)
+            resizable(false)
+            cell { item, _ ->
+                if (isRowBlockLeader) {
+                    Box(
+                        Modifier
+                            .size(24.dp)
+                            .testTag("handle-${item.id}")
+                            .draggableHandle(),
+                    )
+                } else {
+                    Box(Modifier.size(24.dp).testTag("member-${item.id}"))
+                }
+            }
+        }
+        column("name", valueOf = { it.name }) {
+            header("Name")
+            width(120.dp, 120.dp)
+            resizable(false)
+            cell { item, _ -> Text(item.name) }
+        }
+    }
+
+private val stableRowKey: (BlockRow?, Int) -> Any = { item, index -> item?.id ?: "ph-$index" }
+
+/**
+ * Records the `isInRowBlock` flag handed to row styling per row id. Proves the boolean the
+ * derivation feeds into `resolveRowStyle` — the only channel by which customization can style block
+ * members — carries the real membership, not a constant that would pass every other block test.
+ */
+private class RecordingCustomization(
+    val inBlockById: MutableMap<Int, Boolean>,
+) : TableCustomization<BlockRow, String> {
+    @Composable
+    override fun resolveRowStyle(ctx: TableRowContext<BlockRow, String>): TableRowStyle {
+        inBlockById[ctx.item.id] = ctx.isInRowBlock
+        return TableRowStyle()
+    }
+}
+
+@OptIn(ExperimentalTestApi::class, ExperimentalTableApi::class)
+class RowBlocksTableTest {
+    @Test
+    fun `bands render from blockOf derivation without onCommit`() =
+        runComposeUiTest {
+            val items =
+                listOf(
+                    BlockRow(0, "alpha"),
+                    BlockRow(1, "alpha"),
+                    BlockRow(2, null),
+                    BlockRow(3, "beta"),
+                    BlockRow(4, "beta"),
+                )
+            setContent {
+                val columns = remember { blockColumns() }
+                val state = rememberTableState(columns = persistentListOf("handle", "name"))
+                val blocks =
+                    remember {
+                        RowBlocks<BlockRow>(
+                            blockOf = { it.block },
+                            blockHeader = { blockId, _ -> Text("band-$blockId") },
+                        )
+                    }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                        rowBlocks = blocks,
+                    )
+                }
+            }
+            waitForIdle()
+            onNodeWithText("band-alpha").assertIsDisplayed()
+            onNodeWithText("band-beta").assertIsDisplayed()
+        }
+
+    @Test
+    fun `leader flag marks the first row of every run and standalone rows`() =
+        runComposeUiTest {
+            // The same id in non-adjacent runs models a filter that split a block: each visible run
+            // gets its own leader, exactly like the band derivation.
+            val items =
+                listOf(
+                    BlockRow(0, "a"),
+                    BlockRow(1, "a"),
+                    BlockRow(2, null),
+                    BlockRow(3, "a"),
+                )
+            setContent {
+                val columns = remember { blockColumns() }
+                val state = rememberTableState(columns = persistentListOf("handle", "name"))
+                val blocks = remember { RowBlocks<BlockRow>(blockOf = { it.block }) }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                        rowBlocks = blocks,
+                    )
+                }
+            }
+            waitForIdle()
+            onNodeWithTag("handle-0", useUnmergedTree = true).assertExists()
+            onNodeWithTag("member-1", useUnmergedTree = true).assertExists()
+            onNodeWithTag("handle-2", useUnmergedTree = true).assertExists()
+            onNodeWithTag("handle-3", useUnmergedTree = true).assertExists()
+        }
+
+    @Test
+    fun `isInRowBlock flag reaches customization true for block members false for standalone`() =
+        runComposeUiTest {
+            // The adjacent isRowBlockLeader flag is proven by the handle/member tags, but the
+            // isInRowBlock boolean fed into resolveRowStyle is customization's only handle on block
+            // membership; a regression to constant false/true would leave every other block test
+            // green. Observe it directly through a recording customization.
+            val inBlockById = mutableMapOf<Int, Boolean>()
+            val items =
+                listOf(
+                    BlockRow(0, "alpha"),
+                    BlockRow(1, "alpha"),
+                    BlockRow(2, null),
+                    BlockRow(3, "beta"),
+                    BlockRow(4, "beta"),
+                )
+            setContent {
+                val columns = remember { blockColumns() }
+                val state = rememberTableState(columns = persistentListOf("handle", "name"))
+                val blocks = remember { RowBlocks<BlockRow>(blockOf = { it.block }) }
+                val customization = remember { RecordingCustomization(inBlockById) }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                        customization = customization,
+                        rowBlocks = blocks,
+                    )
+                }
+            }
+            waitForIdle()
+            // Members of the two derived blocks are marked; the standalone row between them is not.
+            // isEqualTo(true/false) also rejects a missing (null) entry, so every row is observed.
+            assertThat(inBlockById[0]).isEqualTo(true)
+            assertThat(inBlockById[1]).isEqualTo(true)
+            assertThat(inBlockById[2]).isEqualTo(false)
+            assertThat(inBlockById[3]).isEqualTo(true)
+            assertThat(inBlockById[4]).isEqualTo(true)
+        }
+
+    @Test
+    fun `drop commits one move and remaps positional state`() =
+        runComposeUiTest {
+            val moves = mutableListOf<RowBlockMove>()
+            val items =
+                listOf(
+                    BlockRow(0, "a"),
+                    BlockRow(1, "a"),
+                    BlockRow(2, null),
+                    BlockRow(3, null),
+                    BlockRow(4, null),
+                )
+            lateinit var state: TableState<String>
+            setContent {
+                val columns = remember { blockColumns() }
+                state =
+                    rememberTableState(
+                        columns = persistentListOf("handle", "name"),
+                        settings =
+                            TableSettings(
+                                rowReorderEnabled = true,
+                                selectionMode = SelectionMode.Single,
+                            ),
+                        dimensions = TableDefaults.compactDimensions(),
+                    )
+                val blocks =
+                    remember { RowBlocks<BlockRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                        rowBlocks = blocks,
+                    )
+                }
+            }
+            waitForIdle()
+            runOnIdle {
+                state.toggleSelect(3)
+                state.selectCell(3, "name")
+            }
+            waitForIdle()
+
+            // Drag block "a" from the top far past the end of the short list: the overshoot makes
+            // the landing position deterministic (last), however many intermediate swaps fire.
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(10) { moveBy(Offset(0f, 60f)) }
+                up()
+            }
+            waitForIdle()
+
+            assertThat(moves.size).isEqualTo(1)
+            val move = moves.single()
+            assertThat(move.blockId).isEqualTo("a")
+            assertThat(move.movedKeys).isEqualTo(listOf<Any>(0, 1))
+            assertThat(move.afterKey).isEqualTo(4)
+            assertThat(move.beforeKey).isNull()
+
+            // id-3 sat at view position 3; the block moved from above it to the end, so it now
+            // renders one unit higher.
+            assertThat(state.selectedIndex).isEqualTo(1)
+            assertThat(state.selectedCell?.rowIndex).isEqualTo(1)
+
+            // The permuted order is held optimistically after the drop: block rows render last.
+            val blockTop = onNodeWithText("name-0").getBoundsInRoot().top
+            val standaloneTop = onNodeWithText("name-4").getBoundsInRoot().top
+            assertThat(blockTop).isGreaterThan(standaloneTop)
+        }
+
+    @Test
+    fun `drag start completes or cancels an active cell edit`() =
+        runComposeUiTest {
+            val cancelled = mutableListOf<Int>()
+            val items = listOf(BlockRow(0, "a"), BlockRow(1, "a"), BlockRow(2, null))
+            lateinit var state: TableState<String>
+            setContent {
+                val columns = remember { blockColumns() }
+                state =
+                    rememberTableState(
+                        columns = persistentListOf("handle", "name"),
+                        settings =
+                            TableSettings(rowReorderEnabled = true, editingEnabled = true),
+                        dimensions = TableDefaults.compactDimensions(),
+                    )
+                val blocks = remember { RowBlocks<BlockRow>(blockOf = { it.block }, onCommit = {}) }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    EditableTable(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        tableData = Unit,
+                        rowKey = stableRowKey,
+                        rowBlocks = blocks,
+                        // Completion is blocked, so the drag must fall back to cancelling.
+                        onRowEditComplete = { false },
+                        onEditCancelled = { cancelled += it },
+                    )
+                }
+            }
+            waitForIdle()
+            runOnIdle { state.startEditing(items[2], 2, "name") }
+            waitForIdle()
+            assertThat(state.editingRow).isEqualTo(2)
+
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                moveBy(Offset(0f, 60f))
+                up()
+            }
+            waitForIdle()
+
+            assertThat(state.editingRow).isNull()
+            assertThat(cancelled).isEqualTo(listOf(2))
+        }
+
+    @Test
+    fun `groupBy suppresses blocks and their commits and is surfaced`() =
+        runComposeUiTest {
+            val moves = mutableListOf<RowBlockMove>()
+            val rowMoves = mutableListOf<Pair<Int, Int>>()
+            val items = listOf(BlockRow(0, "a"), BlockRow(1, "a"), BlockRow(2, null))
+            lateinit var state: TableState<String>
+            setContent {
+                val columns = remember { blockColumns() }
+                state =
+                    rememberTableState(
+                        columns = persistentListOf("handle", "name"),
+                        settings = TableSettings(rowReorderEnabled = true),
+                        dimensions = TableDefaults.compactDimensions(),
+                    )
+                val blocks =
+                    remember {
+                        RowBlocks<BlockRow>(
+                            blockOf = { it.block },
+                            onCommit = { moves += it },
+                            blockHeader = { blockId, _ -> Text("band-$blockId") },
+                        )
+                    }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                        // Superseded for good: suppression must not resurrect the per-row
+                        // fallback, or the same gesture would silently change move semantics.
+                        onRowMove = { from, to -> rowMoves += from to to },
+                        rowBlocks = blocks,
+                    )
+                }
+            }
+            waitForIdle()
+            onNodeWithText("band-a").assertExists()
+            assertThat(state.rowBlocksSuppressedByGroupBy).isFalse()
+
+            runOnIdle { state.groupBy("name") }
+            waitForIdle()
+            assertThat(state.rowBlocksSuppressedByGroupBy).isTrue()
+            onNodeWithText("band-a").assertDoesNotExist()
+
+            // Handles are inert while suppressed: a full drag gesture must commit nothing —
+            // neither a block commit nor a per-row move.
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(5) { moveBy(Offset(0f, 60f)) }
+                up()
+            }
+            waitForIdle()
+            assertThat(moves).isEqualTo(emptyList<RowBlockMove>())
+            assertThat(rowMoves).isEqualTo(emptyList<Pair<Int, Int>>())
+
+            runOnIdle { state.groupBy(null) }
+            waitForIdle()
+            assertThat(state.rowBlocksSuppressedByGroupBy).isFalse()
+            onNodeWithText("band-a").assertExists()
+        }
+
+    @Test
+    fun `column menu group-by item is disabled while blocks are non-empty`() =
+        runComposeUiTest {
+            val items = listOf(BlockRow(0, "a"), BlockRow(1, "a"), BlockRow(2, null))
+            setContent {
+                val columns = remember { blockColumns() }
+                // Reorder stays disabled: the header menu locks entirely under reorder, and the
+                // group-by conflict matters exactly for display-only blocks.
+                val state = rememberTableState(columns = persistentListOf("handle", "name"))
+                val blocks = remember { RowBlocks<BlockRow>(blockOf = { it.block }) }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                        rowBlocks = blocks,
+                    )
+                }
+            }
+            waitForIdle()
+            onNodeWithText("Name").performTouchInput { longClick() }
+            waitForIdle()
+            onNodeWithText("Group by").assertIsNotEnabled()
+        }
+
+    @Test
+    fun `column menu group-by item stays enabled without blocks`() =
+        runComposeUiTest {
+            val items = listOf(BlockRow(0, "a"), BlockRow(1, "a"), BlockRow(2, null))
+            setContent {
+                val columns = remember { blockColumns() }
+                val state = rememberTableState(columns = persistentListOf("handle", "name"))
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                    )
+                }
+            }
+            waitForIdle()
+            onNodeWithText("Name").performTouchInput { longClick() }
+            waitForIdle()
+            onNodeWithText("Group by").assertIsEnabled()
+        }
+
+    @Test
+    fun `unspecified row block color resolves to the theme band color at draw`() =
+        runComposeUiTest {
+            val themed = Color(0xFF123456)
+            var resolvedDefault: Color? = null
+            var resolvedExplicit: Color? = null
+            setContent {
+                MaterialTheme(colorScheme = lightColorScheme(surfaceContainerHighest = themed)) {
+                    resolvedDefault = resolveRowBlockContainerColor(TableDefaults.colors())
+                    resolvedExplicit =
+                        resolveRowBlockContainerColor(
+                            TableDefaults.colors(rowBlockContainerColor = Color.Red),
+                        )
+                }
+            }
+            waitForIdle()
+            assertThat(resolvedDefault).isEqualTo(themed)
+            assertThat(resolvedExplicit).isEqualTo(Color.Red)
+        }
+
+    @Test
+    fun `an items change settles instead of recomposing forever`() =
+        runComposeUiTest {
+            var rootCompositions = 0
+            var items by mutableStateOf(listOf(BlockRow(0, "a"), BlockRow(1, "a"), BlockRow(2, null)))
+            setContent {
+                SideEffect { rootCompositions++ }
+                val columns = remember { blockColumns() }
+                val state = rememberTableState(columns = persistentListOf("handle", "name"))
+                val blocks = remember { RowBlocks<BlockRow>(blockOf = { it.block }) }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { index -> items.getOrNull(index) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                        rowBlocks = blocks,
+                    )
+                }
+            }
+            waitForIdle()
+            val settled = rootCompositions
+
+            items = items + BlockRow(3, "b")
+            waitForIdle()
+
+            // reconcile() writes snapshot state during composition, which costs at most one extra
+            // pass; anything more means the write keeps feeding its own readers.
+            assertThat(rootCompositions - settled).isLessThan(4)
+        }
+
+    @Test
+    fun `drag hooks land on a recreated TableState`() =
+        runComposeUiTest {
+            // rememberTableState swaps instances when dimensions change, while the reorder engine
+            // keeps its per-item scopes alive across the swap. The commit side effects must reach
+            // the live state, not the one captured when the scope was first built.
+            val moves = mutableListOf<RowBlockMove>()
+            val items =
+                listOf(
+                    BlockRow(0, "a"),
+                    BlockRow(1, "a"),
+                    BlockRow(2, null),
+                    BlockRow(3, null),
+                    BlockRow(4, null),
+                )
+            var dimensions by mutableStateOf(TableDefaults.compactDimensions())
+            lateinit var state: TableState<String>
+            setContent {
+                val columns = remember { blockColumns() }
+                state =
+                    rememberTableState(
+                        columns = persistentListOf("handle", "name"),
+                        settings =
+                            TableSettings(
+                                rowReorderEnabled = true,
+                                selectionMode = SelectionMode.Single,
+                            ),
+                        dimensions = dimensions,
+                    )
+                val blocks =
+                    remember { RowBlocks<BlockRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                        rowBlocks = blocks,
+                    )
+                }
+            }
+            waitForIdle()
+            val firstState = state
+
+            dimensions = TableDefaults.standardDimensions()
+            waitForIdle()
+            assertThat(state !== firstState).isTrue()
+            runOnIdle {
+                state.toggleSelect(3)
+                state.selectCell(3, "name")
+            }
+            waitForIdle()
+
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(10) { moveBy(Offset(0f, 60f)) }
+                up()
+            }
+            waitForIdle()
+
+            assertThat(moves.size).isEqualTo(1)
+            // id-3 sat at view position 3; the two-row block moved from above it to the end, so it
+            // renders one unit higher — on the LIVE state.
+            assertThat(state.selectedIndex).isEqualTo(1)
+            assertThat(state.selectedCell?.rowIndex).isEqualTo(1)
+        }
+
+    @Test
+    fun `embedded drop commits one move and remaps positional state`() =
+        runComposeUiTest {
+            // The embedded engine reports the gesture's net result once, at drop — the commit and
+            // its side effects must match the lazy path's exactly-one-event contract.
+            val moves = mutableListOf<RowBlockMove>()
+            val items =
+                listOf(
+                    BlockRow(0, "a"),
+                    BlockRow(1, "a"),
+                    BlockRow(2, null),
+                    BlockRow(3, null),
+                    BlockRow(4, null),
+                )
+            lateinit var state: TableState<String>
+            setContent {
+                val columns = remember { blockColumns() }
+                state =
+                    rememberTableState(
+                        columns = persistentListOf("handle", "name"),
+                        settings =
+                            TableSettings(
+                                rowReorderEnabled = true,
+                                selectionMode = SelectionMode.Single,
+                            ),
+                        dimensions = TableDefaults.compactDimensions(),
+                    )
+                val blocks =
+                    remember { RowBlocks<BlockRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                        rowBlocks = blocks,
+                        embedded = true,
+                    )
+                }
+            }
+            waitForIdle()
+            runOnIdle {
+                state.toggleSelect(3)
+                state.selectCell(3, "name")
+            }
+            waitForIdle()
+
+            // Drag block "a" from the top far past the end of the short list: the overshoot makes
+            // the landing position deterministic (last), whatever the intermediate geometry.
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(10) { moveBy(Offset(0f, 60f)) }
+                up()
+            }
+            waitForIdle()
+
+            assertThat(moves.size).isEqualTo(1)
+            val move = moves.single()
+            assertThat(move.blockId).isEqualTo("a")
+            assertThat(move.movedKeys).isEqualTo(listOf<Any>(0, 1))
+            assertThat(move.afterKey).isEqualTo(4)
+            assertThat(move.beforeKey).isNull()
+
+            // id-3 sat at view position 3; the block moved from above it to the end, so it now
+            // renders one unit higher.
+            assertThat(state.selectedIndex).isEqualTo(1)
+            assertThat(state.selectedCell?.rowIndex).isEqualTo(1)
+
+            // The permuted order is held optimistically after the drop: block rows render last.
+            val blockTop = onNodeWithText("name-0").getBoundsInRoot().top
+            val standaloneTop = onNodeWithText("name-4").getBoundsInRoot().top
+            assertThat(blockTop).isGreaterThan(standaloneTop)
+        }
+
+    @Test
+    fun `embedded upstream change mid-gesture cancels the drag and commits nothing`() =
+        runComposeUiTest {
+            // Changing the rendered list mid-drag rebuilds the embedded engine, and the OLD
+            // engine's disposal still delivers the dead gesture's settle — with unit indices
+            // computed against the old geometry. Applying them to the new list would commit a
+            // move the user never made (regression for the stale-settle phantom commit); the
+            // documented policy is to cancel, and the next gesture must work unimpeded.
+            val moves = mutableListOf<RowBlockMove>()
+            var items by mutableStateOf(
+                listOf(
+                    BlockRow(0, "a"),
+                    BlockRow(1, "a"),
+                    BlockRow(2, null),
+                    BlockRow(3, null),
+                    BlockRow(4, null),
+                ),
+            )
+            setContent {
+                val columns = remember { blockColumns() }
+                val state =
+                    rememberTableState(
+                        columns = persistentListOf("handle", "name"),
+                        settings = TableSettings(rowReorderEnabled = true),
+                        dimensions = TableDefaults.compactDimensions(),
+                    )
+                val blocks =
+                    remember { RowBlocks<BlockRow>(blockOf = { it.block }, onCommit = { moves += it }) }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                        rowBlocks = blocks,
+                        embedded = true,
+                    )
+                }
+            }
+            waitForIdle()
+
+            // Drag block "a" well past other units and hold it there — no release yet.
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(10) { moveBy(Offset(0f, 60f)) }
+            }
+            waitForIdle()
+
+            // External update mid-gesture: a new standalone leader on top shifts every unit index.
+            items = listOf(BlockRow(9, null)) + items
+            waitForIdle()
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput { up() }
+            waitForIdle()
+
+            assertThat(moves).isEqualTo(emptyList<RowBlockMove>())
+
+            // The dead gesture must not poison the next one.
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(12) { moveBy(Offset(0f, 60f)) }
+                up()
+            }
+            waitForIdle()
+
+            assertThat(moves.size).isEqualTo(1)
+            val move = moves.single()
+            assertThat(move.blockId).isEqualTo("a")
+            assertThat(move.movedKeys).isEqualTo(listOf<Any>(0, 1))
+            assertThat(move.afterKey).isEqualTo(4)
+            assertThat(move.beforeKey).isNull()
+        }
+
+    @Test
+    fun `embedded reorder without blocks still delivers per-row moves`() =
+        runComposeUiTest {
+            // Regression guard for the pre-blocks embedded contract: no blocks means per-row
+            // onRowMove semantics, one (from, to) pair per completed gesture.
+            val moves = mutableListOf<Pair<Int, Int>>()
+            val items =
+                listOf(
+                    BlockRow(0, null),
+                    BlockRow(1, null),
+                    BlockRow(2, null),
+                    BlockRow(3, null),
+                )
+            setContent {
+                val columns = remember { blockColumns() }
+                val state =
+                    rememberTableState(
+                        columns = persistentListOf("handle", "name"),
+                        settings = TableSettings(rowReorderEnabled = true),
+                        dimensions = TableDefaults.compactDimensions(),
+                    )
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                        onRowMove = { from, to -> moves += from to to },
+                        embedded = true,
+                    )
+                }
+            }
+            waitForIdle()
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(10) { moveBy(Offset(0f, 60f)) }
+                up()
+            }
+            waitForIdle()
+            assertThat(moves).isEqualTo(listOf(0 to 3))
+        }
+
+    @Test
+    fun `embedded same-count list change mid-gesture drops the stale settle`() =
+        runComposeUiTest {
+            // itemsCount is unchanged and the itemAt lambda captures the state delegate, so both
+            // keep one identity across the change: only the snapshot's CONTENT can tell the settle
+            // guard the engine laid out a different list. Regression for the memoized stale
+            // snapshot that compared the old list against itself and let a phantom move through.
+            val moves = mutableListOf<Pair<Int, Int>>()
+            var items by mutableStateOf(
+                listOf(
+                    BlockRow(0, null),
+                    BlockRow(1, null),
+                    BlockRow(2, null),
+                    BlockRow(3, null),
+                ),
+            )
+            setContent {
+                val columns = remember { blockColumns() }
+                val state =
+                    rememberTableState(
+                        columns = persistentListOf("handle", "name"),
+                        settings = TableSettings(rowReorderEnabled = true),
+                        dimensions = TableDefaults.compactDimensions(),
+                    )
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                        onRowMove = { from, to -> moves += from to to },
+                        embedded = true,
+                    )
+                }
+            }
+            waitForIdle()
+
+            // Drag row 0 well past other rows and hold it there — no release yet.
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(10) { moveBy(Offset(0f, 60f)) }
+            }
+            waitForIdle()
+
+            // External update mid-gesture that keeps the size: replace a row the gesture never
+            // touched, so the dragged handle survives while the rendered list changes.
+            items = items.dropLast(1) + BlockRow(7, null)
+            waitForIdle()
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput { up() }
+            waitForIdle()
+
+            assertThat(moves).isEqualTo(emptyList<Pair<Int, Int>>())
+
+            // The dead gesture must not poison the next one.
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(10) { moveBy(Offset(0f, 60f)) }
+                up()
+            }
+            waitForIdle()
+            assertThat(moves).isEqualTo(listOf(0 to 3))
+        }
+
+    @Test
+    fun `embedded reorder without blocks renders cleanly after an applied in-place move`() =
+        runComposeUiTest {
+            // The applied move changes neither itemsCount nor the itemAt identity, so only the
+            // snapshot's content can rebuild the engine state; a stale snapshot would keep the
+            // settled drag offsets forever and render every row doubly displaced — once by the
+            // leftover offsets, once by the reordered data.
+            var items by mutableStateOf(
+                listOf(
+                    BlockRow(0, null),
+                    BlockRow(1, null),
+                    BlockRow(2, null),
+                    BlockRow(3, null),
+                ),
+            )
+            setContent {
+                val columns = remember { blockColumns() }
+                val state =
+                    rememberTableState(
+                        columns = persistentListOf("handle", "name"),
+                        settings = TableSettings(rowReorderEnabled = true),
+                        dimensions = TableDefaults.compactDimensions(),
+                    )
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                        onRowMove = { from, to ->
+                            items = items.toMutableList().also { it.add(to, it.removeAt(from)) }
+                        },
+                        embedded = true,
+                    )
+                }
+            }
+            waitForIdle()
+
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(10) { moveBy(Offset(0f, 60f)) }
+                up()
+            }
+            waitForIdle()
+
+            assertThat(items.map { it.id }).isEqualTo(listOf(1, 2, 3, 0))
+            // The rendered vertical order follows the applied list, with no leftover offsets.
+            val tops = items.map { onNodeWithText(it.name).getBoundsInRoot().top }
+            assertThat(tops).isEqualTo(tops.sorted())
+        }
+
+    @Test
+    fun `embedded drag start completes or cancels an active cell edit`() =
+        runComposeUiTest {
+            val cancelled = mutableListOf<Int>()
+            val items = listOf(BlockRow(0, "a"), BlockRow(1, "a"), BlockRow(2, null))
+            lateinit var state: TableState<String>
+            setContent {
+                val columns = remember { blockColumns() }
+                state =
+                    rememberTableState(
+                        columns = persistentListOf("handle", "name"),
+                        settings =
+                            TableSettings(rowReorderEnabled = true, editingEnabled = true),
+                        dimensions = TableDefaults.compactDimensions(),
+                    )
+                val blocks = remember { RowBlocks<BlockRow>(blockOf = { it.block }, onCommit = {}) }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    EditableTable(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        tableData = Unit,
+                        rowKey = stableRowKey,
+                        rowBlocks = blocks,
+                        embedded = true,
+                        // Completion is blocked, so the drag must fall back to cancelling.
+                        onRowEditComplete = { false },
+                        onEditCancelled = { cancelled += it },
+                    )
+                }
+            }
+            waitForIdle()
+            runOnIdle { state.startEditing(items[2], 2, "name") }
+            waitForIdle()
+            assertThat(state.editingRow).isEqualTo(2)
+
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                moveBy(Offset(0f, 60f))
+                up()
+            }
+            waitForIdle()
+
+            assertThat(state.editingRow).isNull()
+            assertThat(cancelled).isEqualTo(listOf(2))
+        }
+
+    @Test
+    fun `embedded band header renders with non-zero width`() =
+        runComposeUiTest {
+            // The embedded path attaches no horizontal scroll node, so viewportSize reports 0;
+            // the band must fall back to the table width (regression for the 0-px band defect).
+            val items = listOf(BlockRow(0, "a"), BlockRow(1, "a"), BlockRow(2, null))
+            setContent {
+                val columns = remember { blockColumns() }
+                val state = rememberTableState(columns = persistentListOf("handle", "name"))
+                val blocks =
+                    remember {
+                        RowBlocks<BlockRow>(
+                            blockOf = { it.block },
+                            blockHeader = { blockId, _ -> Text("band-$blockId") },
+                        )
+                    }
+                Box(Modifier.size(400.dp, 640.dp)) {
+                    Table(
+                        itemsCount = items.size,
+                        itemAt = { items.getOrNull(it) },
+                        state = state,
+                        columns = columns,
+                        rowKey = stableRowKey,
+                        rowBlocks = blocks,
+                        embedded = true,
+                    )
+                }
+            }
+            waitForIdle()
+            val band = onNodeWithText("band-a").getBoundsInRoot()
+            assertThat(band.width).isGreaterThan(0.dp)
+        }
+
+    @Test
+    fun `default positional row key with blocks logs a single warning`() =
+        runComposeUiTest {
+            val warnings = mutableListOf<String>()
+            val writer =
+                object : LogWriter() {
+                    override fun log(
+                        severity: Severity,
+                        message: String,
+                        tag: String,
+                        throwable: Throwable?,
+                    ) {
+                        if (severity == Severity.Warn) warnings += message
+                    }
+                }
+            Logger.addLogWriter(writer)
+            try {
+                val items = listOf(BlockRow(0, "a"), BlockRow(1, "a"))
+                var tick by mutableStateOf(0)
+                setContent {
+                    val columns = remember { blockColumns() }
+                    val state = rememberTableState(columns = persistentListOf("handle", "name"))
+                    val blocks = remember { RowBlocks<BlockRow>(blockOf = { it.block }) }
+                    Text("tick-$tick")
+                    Box(Modifier.size(400.dp, 640.dp)) {
+                        Table(
+                            itemsCount = items.size,
+                            itemAt = { items.getOrNull(it) },
+                            state = state,
+                            columns = columns,
+                            // rowKey deliberately omitted: the default positional key cannot
+                            // anchor a RowBlockMove, which is exactly what must warn.
+                            rowBlocks = blocks,
+                        )
+                    }
+                }
+                waitForIdle()
+                tick = 1
+                waitForIdle()
+                assertThat(warnings.count { it.contains("stable rowKey") }).isEqualTo(1)
+            } finally {
+                Logger.setLogWriters(platformLogWriter())
+            }
+        }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/state/MoveRowGroupTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/state/MoveRowGroupTest.kt
@@ -1,0 +1,77 @@
+package ua.wwind.table.state
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class MoveRowGroupTest {
+    @Test
+    fun `move block down lands after the target`() {
+        val list = (0..9).toMutableList()
+        list.moveRowGroup(from = 2..4, to = 7..8)
+        assertThat(list).isEqualTo(listOf(0, 1, 5, 6, 7, 8, 2, 3, 4, 9))
+    }
+
+    @Test
+    fun `move block down past a single row`() {
+        val list = (0..6).toMutableList()
+        list.moveRowGroup(from = 2..4, to = 5..5)
+        assertThat(list).isEqualTo(listOf(0, 1, 5, 2, 3, 4, 6))
+    }
+
+    @Test
+    fun `move block up lands before the target`() {
+        val list = (0..9).toMutableList()
+        list.moveRowGroup(from = 5..6, to = 2..2)
+        assertThat(list).isEqualTo(listOf(0, 1, 5, 6, 2, 3, 4, 7, 8, 9))
+    }
+
+    @Test
+    fun `move single row behaves like remove and insert`() {
+        val list = (0..4).toMutableList()
+        list.moveRowGroup(from = 0..0, to = 3..3)
+        assertThat(list).isEqualTo(listOf(1, 2, 3, 0, 4))
+    }
+
+    @Test
+    fun `move to the same position is a no-op`() {
+        val list = (0..4).toMutableList()
+        list.moveRowGroup(from = 1..2, to = 1..2)
+        assertThat(list).isEqualTo(listOf(0, 1, 2, 3, 4))
+    }
+
+    @Test
+    fun `out of bounds move is rejected`() {
+        val list = (0..4).toMutableList()
+        assertFailsWith<IllegalArgumentException> { list.moveRowGroup(from = 3..7, to = 0..0) }
+    }
+
+    @Test
+    fun `out of bounds target is rejected`() {
+        val list = (0..4).toMutableList()
+        assertFailsWith<IllegalArgumentException> { list.moveRowGroup(from = 0..0, to = 3..7) }
+    }
+
+    @Test
+    fun `empty range is rejected`() {
+        val list = (0..4).toMutableList()
+        assertFailsWith<IllegalArgumentException> { list.moveRowGroup(from = 3..2, to = 0..0) }
+        assertFailsWith<IllegalArgumentException> { list.moveRowGroup(from = 0..0, to = 3..2) }
+    }
+
+    // A swap between overlapping ranges has no meaning: the "target" partially IS the moved block.
+    // Reaching this is a unit-derivation bug, and it must fail loudly instead of corrupting order.
+    @Test
+    fun `overlapping ranges are rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            (0..9).toMutableList().moveRowGroup(from = 1..3, to = 2..4)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            (0..9).toMutableList().moveRowGroup(from = 2..4, to = 1..3)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            (0..9).toMutableList().moveRowGroup(from = 1..2, to = 1..3)
+        }
+    }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/state/RowBlocksGestureRemapTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/state/RowBlocksGestureRemapTest.kt
@@ -1,0 +1,104 @@
+package ua.wwind.table.state
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import ua.wwind.table.RowBlocks
+import kotlin.test.Test
+
+private data class RemapItem(val id: Int, val block: String?)
+
+/**
+ * The commit-side companion of `settle()`: the remap is what carries positional runtime state
+ * (selection, editing, cached heights) across a drop, so it must mirror the permutation exactly
+ * and be read before settling forgets the pre-gesture order.
+ */
+class RowBlocksGestureRemapTest {
+    private val items =
+        listOf(
+            RemapItem(0, "a"),
+            RemapItem(1, "a"),
+            RemapItem(2, "b"),
+            RemapItem(3, "b"),
+            RemapItem(4, null),
+        )
+
+    private fun state(): RowBlocksState<RemapItem> =
+        RowBlocksState(
+            config = RowBlocks<RemapItem>(blockOf = { it.block }),
+            rowKey = { item, _ -> requireNotNull(item).id },
+            warn = {},
+        ).also { s -> s.reconcile(items.size) { items[it] } }
+
+    @Test
+    fun `remap follows rows across a block move and passes stale positions through`() {
+        val s = state()
+        s.applyUnitMove(fromUnit = 0, toUnit = 1)
+        // view is now [2, 3, 0, 1, 4]
+        val remap = requireNotNull(s.gestureRemap())
+        assertThat(remap(0)).isEqualTo(2)
+        assertThat(remap(1)).isEqualTo(3)
+        assertThat(remap(2)).isEqualTo(0)
+        assertThat(remap(3)).isEqualTo(1)
+        assertThat(remap(4)).isEqualTo(4)
+        // Selection kept across older data updates may point anywhere; it must pass through.
+        assertThat(remap(99)).isEqualTo(99)
+        assertThat(remap(-1)).isEqualTo(-1)
+    }
+
+    @Test
+    fun `remap positions whose content changed are exactly the shifted ones`() {
+        val s = state()
+        s.applyUnitMove(fromUnit = 0, toUnit = 1)
+        val remap = requireNotNull(s.gestureRemap())
+        // Height-cache clearing iterates this predicate; position 4 stayed put and must be spared.
+        val shifted = (0 until s.itemsCount).filter { remap(it) != it }
+        assertThat(shifted).isEqualTo(listOf(0, 1, 2, 3))
+    }
+
+    @Test
+    fun `remap is null without a gesture and after settle`() {
+        val s = state()
+        assertThat(s.gestureRemap()).isNull()
+        s.applyUnitMove(fromUnit = 0, toUnit = 1)
+        s.settle()
+        assertThat(s.gestureRemap()).isNull()
+    }
+
+    @Test
+    fun `remap is null when the gesture returned to its origin`() {
+        val s = state()
+        s.applyUnitMove(fromUnit = 0, toUnit = 1)
+        s.applyUnitMove(fromUnit = 1, toUnit = 0)
+        assertThat(s.gestureRemap()).isNull()
+    }
+
+    @Test
+    fun `blockIdAt reports ids in view order and null out of range`() {
+        val s = state()
+        assertThat(s.blockIdAt(0)).isEqualTo("a")
+        assertThat(s.blockIdAt(4)).isNull()
+        assertThat(s.blockIdAt(5)).isNull()
+        s.applyUnitMove(fromUnit = 0, toUnit = 1)
+        assertThat(s.blockIdAt(0)).isEqualTo("b")
+    }
+
+    @Test
+    fun `itemAt answers out-of-range probes with a placeholder`() {
+        val s = state()
+        assertThat(s.itemAt(items.size)).isNull()
+        assertThat(s.itemAt(-1)).isNull()
+    }
+
+    @Test
+    fun `upstreamIndexOf answers out-of-range probes with the raw index`() {
+        val s = state()
+        // The raw index is what a table without blocks would hand the consumer's rowKey; stale
+        // probes must degrade to that, not throw, exactly like itemAt and blockIdAt.
+        assertThat(s.upstreamIndexOf(items.size)).isEqualTo(items.size)
+        assertThat(s.upstreamIndexOf(-1)).isEqualTo(-1)
+        s.applyUnitMove(fromUnit = 0, toUnit = 1)
+        // view is now [2, 3, 0, 1, 4]
+        assertThat(s.upstreamIndexOf(0)).isEqualTo(2)
+    }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/state/RowBlocksPagingPolicyTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/state/RowBlocksPagingPolicyTest.kt
@@ -1,0 +1,191 @@
+package ua.wwind.table.state
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import ua.wwind.table.RowBlockMove
+import ua.wwind.table.RowBlocks
+import kotlin.test.Test
+
+private data class PagedItem(val id: Int, val block: String?)
+
+/**
+ * Paged sources render placeholders (null items) for rows whose page has not arrived. Two policies
+ * hang off that fact: a placeholder fill-in mid-gesture must NOT cancel the drag (holding the drag
+ * is what loads the page whose rows will anchor the drop), and a drop whose landing neighbour is
+ * still a placeholder must snap back without emitting — a key that does not exist yet cannot
+ * anchor a move.
+ */
+private class PagedHarness(
+    items: List<PagedItem?>,
+) {
+    val commits = mutableListOf<RowBlockMove>()
+    val warnings = mutableListOf<String>()
+    val state =
+        RowBlocksState(
+            config = RowBlocks<PagedItem>(blockOf = { it.block }, onCommit = { commits += it }),
+            rowKey = { item, index -> item?.id ?: "ph-$index" },
+            warn = { warnings += it },
+        )
+
+    init {
+        reconcile(items)
+    }
+
+    fun reconcile(items: List<PagedItem?>) = state.reconcile(items.size) { items[it] }
+
+    /** Item ids in the rendered (permuted) order; null marks a placeholder. */
+    fun viewIds(): List<Int?> = (0 until state.itemsCount).map { state.itemAt(it)?.id }
+}
+
+class RowBlocksPagingPolicyTest {
+    // region reconcile: placeholder fill-in vs real change
+
+    @Test
+    fun `placeholder fill-in mid gesture keeps the gesture and the drop commits`() {
+        val h =
+            PagedHarness(
+                listOf(PagedItem(0, "a"), PagedItem(1, "a"), null, null, PagedItem(4, null)),
+            )
+        // Units: block a (rows 0..1), two placeholders, one standalone.
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        assertThat(h.viewIds()).isEqualTo(listOf(null, 0, 1, null, 4))
+        assertThat(h.state.isDragActive).isTrue()
+
+        // The held drag renders the placeholders, their page arrives: nothing moved, so the
+        // permutation — and the gesture — must survive.
+        h.reconcile(
+            listOf(PagedItem(0, "a"), PagedItem(1, "a"), PagedItem(2, null), PagedItem(3, null), PagedItem(4, null)),
+        )
+        assertThat(h.state.isDragActive).isTrue()
+        assertThat(h.viewIds()).isEqualTo(listOf(2, 0, 1, 3, 4))
+
+        // The gesture continues over the freshly loaded rows and drops on loaded anchors.
+        h.state.applyUnitMove(fromUnit = 1, toUnit = 2)
+        val move = requireNotNull(h.state.settle())
+        assertThat(h.commits).isEqualTo(listOf(move))
+        assertThat(move.blockId).isEqualTo("a")
+        assertThat(move.movedKeys).isEqualTo(listOf<Any>(0, 1))
+        assertThat(move.afterKey).isEqualTo(3)
+        assertThat(move.beforeKey).isEqualTo(4)
+    }
+
+    @Test
+    fun `eviction mid gesture cancels like any other change`() {
+        val h =
+            PagedHarness(
+                listOf(PagedItem(0, "a"), PagedItem(1, "a"), PagedItem(2, null), PagedItem(3, null)),
+            )
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        // A loaded row turning back into a placeholder loses its key and block membership under
+        // the engine — the reverse of a fill-in is not gesture-safe.
+        h.reconcile(listOf(PagedItem(0, "a"), PagedItem(1, "a"), null, PagedItem(3, null)))
+        assertThat(h.state.isDragActive).isFalse()
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 1, null, 3))
+        assertThat(h.state.settle()).isNull()
+        assertThat(h.commits.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `placeholder fill-in outside a gesture keeps the optimistic hold`() {
+        val h =
+            PagedHarness(
+                listOf(PagedItem(0, "a"), PagedItem(1, "a"), null, PagedItem(3, null)),
+            )
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 2)
+        requireNotNull(h.state.settle())
+        assertThat(h.viewIds()).isEqualTo(listOf(null, 3, 0, 1))
+        // The consumer has not applied the move yet when the page arrives; positions are
+        // untouched by a fill-in, so the permuted view must hold exactly like an unchanged list.
+        h.reconcile(listOf(PagedItem(0, "a"), PagedItem(1, "a"), PagedItem(2, null), PagedItem(3, null)))
+        assertThat(h.viewIds()).isEqualTo(listOf(2, 3, 0, 1))
+        assertThat(h.commits.size).isEqualTo(1)
+    }
+
+    // endregion
+
+    // region settle: paged drop policy
+
+    @Test
+    fun `drop with loaded anchors commits despite placeholders elsewhere`() {
+        val h =
+            PagedHarness(
+                listOf(PagedItem(0, "a"), PagedItem(1, "a"), null, PagedItem(3, null)),
+            )
+        // The drag crosses the placeholder unit and lands last: both anchors resolve (the row
+        // above is loaded, there is no row below), so the placeholder en route is irrelevant.
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 2)
+        val move = requireNotNull(h.state.settle())
+        assertThat(move.movedKeys).isEqualTo(listOf<Any>(0, 1))
+        assertThat(move.afterKey).isEqualTo(3)
+        assertThat(move.beforeKey).isNull()
+        assertThat(h.viewIds()).isEqualTo(listOf(null, 3, 0, 1))
+    }
+
+    @Test
+    fun `drop onto an unloaded after anchor snaps back and emits nothing`() {
+        val h =
+            PagedHarness(
+                listOf(PagedItem(0, "a"), PagedItem(1, "a"), PagedItem(2, null), null),
+            )
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 2)
+        assertThat(h.viewIds()).isEqualTo(listOf(2, null, 0, 1))
+        // The row the block would sit after is a placeholder: no key exists to anchor the move.
+        assertThat(h.state.settle()).isNull()
+        assertThat(h.commits.size).isEqualTo(0)
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 1, 2, null))
+        assertThat(h.state.isDragActive).isFalse()
+        // The refusal must be observable: the embedded engine rebuilds off this count, and a
+        // count that stays put would strand its drag offsets on the dropped order.
+        assertThat(h.state.refusedDropCount).isEqualTo(1)
+
+        // The snapped-back state is clean: a next gesture onto loaded anchors commits normally.
+        h.state.applyUnitMove(fromUnit = 1, toUnit = 0)
+        val move = requireNotNull(h.state.settle())
+        assertThat(move.blockId).isNull()
+        assertThat(move.movedKeys).isEqualTo(listOf<Any>(2))
+        assertThat(move.afterKey).isNull()
+        assertThat(move.beforeKey).isEqualTo(0)
+        // A committed drop is not a refusal — the count must not bump.
+        assertThat(h.state.refusedDropCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `drop onto an unloaded before anchor snaps back and emits nothing`() {
+        val h =
+            PagedHarness(
+                listOf(PagedItem(0, null), null, PagedItem(2, "a"), PagedItem(3, "a")),
+            )
+        h.state.applyUnitMove(fromUnit = 2, toUnit = 1)
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 2, 3, null))
+        // The row the block would sit before is a placeholder: the redundant anchor must be as
+        // real as the primary one, or a consumer falling back to it would misplace the block.
+        assertThat(h.state.settle()).isNull()
+        assertThat(h.commits.size).isEqualTo(0)
+        assertThat(h.viewIds()).isEqualTo(listOf(0, null, 2, 3))
+    }
+
+    @Test
+    fun `page load merging into the dragged block widens the committed extent`() {
+        val h =
+            PagedHarness(
+                listOf(PagedItem(0, "a"), PagedItem(1, "a"), null, PagedItem(3, null)),
+            )
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        assertThat(h.viewIds()).isEqualTo(listOf(null, 0, 1, 3))
+        // The placeholder above the dragged fragment loads as a member of the SAME block: the
+        // runs merge, and the merged unit is what the user visibly drops. Reporting the stale
+        // two-row extent would anchor the move on a row inside its own block.
+        h.reconcile(listOf(PagedItem(0, "a"), PagedItem(1, "a"), PagedItem(2, "a"), PagedItem(3, null)))
+        assertThat(h.viewIds()).isEqualTo(listOf(2, 0, 1, 3))
+        val move = requireNotNull(h.state.settle())
+        assertThat(move.blockId).isEqualTo("a")
+        assertThat(move.movedKeys).isEqualTo(listOf<Any>(2, 0, 1))
+        assertThat(move.afterKey).isNull()
+        assertThat(move.beforeKey).isEqualTo(3)
+    }
+
+    // endregion
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/state/RowBlocksStateTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/state/RowBlocksStateTest.kt
@@ -1,0 +1,334 @@
+package ua.wwind.table.state
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import ua.wwind.table.RowBlockMove
+import ua.wwind.table.RowBlocks
+import kotlin.test.Test
+
+private data class Item(val id: Int, val block: String?)
+
+/**
+ * The rendered fixture, in view order:
+ *
+ * ```
+ * row 0..1  block "a"   (unit 0)
+ * row 2..4  block "b"   (unit 1)
+ * row 5     standalone  (unit 2)
+ * row 6     block "c"   (unit 3)
+ * ```
+ */
+private val fixture =
+    listOf(
+        Item(0, "a"),
+        Item(1, "a"),
+        Item(2, "b"),
+        Item(3, "b"),
+        Item(4, "b"),
+        Item(5, null),
+        Item(6, "c"),
+    )
+
+private class Harness(
+    items: List<Item> = fixture,
+) {
+    val commits = mutableListOf<RowBlockMove>()
+    val warnings = mutableListOf<String>()
+    val state =
+        RowBlocksState(
+            config = RowBlocks<Item>(blockOf = { it.block }, onCommit = { commits += it }),
+            rowKey = { item, _ -> requireNotNull(item).id },
+            warn = { warnings += it },
+        )
+
+    init {
+        state.reconcile(items.size) { items[it] }
+    }
+
+    fun reconcile(items: List<Item>) = state.reconcile(items.size) { items[it] }
+
+    /** Item ids in the rendered (permuted) order — the observable result of every move. */
+    fun viewIds(): List<Int> = (0 until state.itemsCount).map { requireNotNull(state.itemAt(it)).id }
+}
+
+class RowBlocksStateTest {
+    // region derivation
+
+    @Test
+    fun `runs derive from blockOf over the rendered order`() {
+        val h = Harness()
+        assertThat(h.state.runs.map { it.id }).isEqualTo(listOf<Any>("a", "b", "c"))
+        assertThat(h.state.runs.map { it.rows }).isEqualTo(listOf(0..1, 2..4, 6..6))
+        assertThat(h.state.units.unitCount).isEqualTo(4)
+        assertThat(h.state.units.isGroup(2)).isFalse()
+        assertThat(h.state.units.isGroup(3)).isTrue()
+    }
+
+    @Test
+    fun `rows with null id never form runs`() {
+        val h = Harness(listOf(Item(0, null), Item(1, null), Item(2, null)))
+        assertThat(h.state.runs).isEqualTo(emptyList<RowBlockRun>())
+        assertThat(h.state.units.unitCount).isEqualTo(3)
+    }
+
+    @Test
+    fun `placeholder rows break runs without a fragmentation warning`() {
+        val items = listOf(Item(0, "a"), Item(1, "a"), Item(2, "a"))
+        val h = Harness()
+        // A not-yet-loaded row cannot prove block membership, so it must split the band — but the
+        // upstream order is not accused: the placeholder may be an unloaded member of the block.
+        h.state.reconcile(3) { index -> if (index == 1) null else items[index] }
+        assertThat(h.state.itemAt(1)).isNull()
+        assertThat(h.state.runs.map { it.rows }).isEqualTo(listOf(0..0, 2..2))
+        assertThat(h.warnings).isEqualTo(emptyList<String>())
+    }
+
+    @Test
+    fun `fragmented id warns once naming the id`() {
+        val h = Harness(listOf(Item(0, "block-7"), Item(1, "block-7"), Item(2, null), Item(3, "block-7")))
+        assertThat(h.state.runs.map { it.rows }).isEqualTo(listOf(0..1, 3..3))
+        assertThat(h.state.runs.map { it.rows }).isEqualTo(listOf(0..1, 3..3))
+        assertThat(h.warnings.size).isEqualTo(1)
+        assertThat(h.warnings.single().contains("block-7")).isTrue()
+    }
+
+    @Test
+    fun `placeholder gap does not mask real fragmentation`() {
+        val items = listOf(Item(0, "a"), Item(1, "a"), Item(2, "b"), Item(3, "a"))
+        val h = Harness()
+        // The gap between the runs of "a" holds a LOADED foreign row, so this is real upstream
+        // fragmentation; the extra placeholder must not launder it into a paging state.
+        h.state.reconcile(4) { index -> if (index == 1) null else items[index] }
+        assertThat(h.warnings.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `fragmented id does not warn again after upstream change`() {
+        val h = Harness(listOf(Item(0, "a"), Item(1, null), Item(2, "a")))
+        h.state.runs
+        h.reconcile(listOf(Item(0, "a"), Item(1, null), Item(2, "a"), Item(3, "b")))
+        h.state.runs
+        assertThat(h.warnings.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `distinct adjacent ids do not warn`() {
+        val h = Harness(listOf(Item(0, "a"), Item(1, "b")))
+        assertThat(h.state.runs.map { it.id }).isEqualTo(listOf<Any>("a", "b"))
+        assertThat(h.warnings).isEqualTo(emptyList<String>())
+    }
+
+    // endregion
+
+    // region applyUnitMove
+
+    @Test
+    fun `move block down lands after the target unit`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        assertThat(h.viewIds()).isEqualTo(listOf(2, 3, 4, 0, 1, 5, 6))
+    }
+
+    @Test
+    fun `move block up lands before the target unit`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 3, toUnit = 1)
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 1, 6, 2, 3, 4, 5))
+    }
+
+    @Test
+    fun `move block to the first unit`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 1, toUnit = 0)
+        assertThat(h.viewIds()).isEqualTo(listOf(2, 3, 4, 0, 1, 5, 6))
+    }
+
+    @Test
+    fun `move block to the last unit`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 3)
+        assertThat(h.viewIds()).isEqualTo(listOf(2, 3, 4, 5, 6, 0, 1))
+    }
+
+    @Test
+    fun `same unit move is a no-op and settles silently`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 1, toUnit = 1)
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 1, 2, 3, 4, 5, 6))
+        assertThat(h.state.settle()).isNull()
+        assertThat(h.commits.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `adjacent blocks swap rederives runs`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        assertThat(h.state.runs.map { it.id }).isEqualTo(listOf<Any>("b", "a", "c"))
+        assertThat(h.state.runs.map { it.rows }).isEqualTo(listOf(0..2, 3..4, 6..6))
+    }
+
+    @Test
+    fun `out of bounds unit move is dropped without starting a gesture`() {
+        val h = Harness()
+        // The engine can deliver a swap computed against a layout one frame older than the list
+        // (async consumer pipelines); it must be ignored, never crash the drag.
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 4)
+        h.state.applyUnitMove(fromUnit = -1, toUnit = 0)
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 1, 2, 3, 4, 5, 6))
+        assertThat(h.state.isDragActive).isFalse()
+        assertThat(h.state.settle()).isNull()
+        assertThat(h.commits.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `stale move arriving after a mid-gesture reconcile is dropped`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 3)
+        // The list shrinks under the gesture: unit indices from the old layout no longer exist.
+        h.reconcile(fixture.take(2))
+        h.state.applyUnitMove(fromUnit = 3, toUnit = 2)
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 1))
+        assertThat(h.state.isDragActive).isFalse()
+        assertThat(h.state.settle()).isNull()
+        assertThat(h.commits.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `moves after a mid-gesture reconcile are swallowed until settle`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        h.reconcile(fixture.dropLast(1))
+        // In bounds over the new list, but the gesture was cancelled: applying it would commit a
+        // move the user never made.
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 1, 2, 3, 4, 5))
+        assertThat(h.state.isDragActive).isFalse()
+        assertThat(h.state.settle()).isNull()
+        assertThat(h.commits.size).isEqualTo(0)
+        // The pointer went up: the latch releases and the next gesture is live again.
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        assertThat(h.viewIds()).isEqualTo(listOf(2, 3, 4, 0, 1, 5))
+        requireNotNull(h.state.settle())
+        assertThat(h.commits.size).isEqualTo(1)
+    }
+
+    // endregion
+
+    // region settle
+
+    @Test
+    fun `settle after a downward move anchors past the whole target block`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        val move = requireNotNull(h.state.settle())
+        assertThat(h.commits).isEqualTo(listOf(move))
+        assertThat(move.blockId).isEqualTo("a")
+        assertThat(move.movedKeys).isEqualTo(listOf<Any>(0, 1))
+        // Regression for the v1 "collapsed to" defect: landing after block "b" must anchor on its
+        // LAST row, not its leader — anchoring on the leader would drop the block inside "b".
+        assertThat(move.afterKey).isEqualTo(4)
+        assertThat(move.beforeKey).isEqualTo(5)
+    }
+
+    @Test
+    fun `settle after an upward move anchors before the target leader`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 3, toUnit = 1)
+        val move = requireNotNull(h.state.settle())
+        assertThat(move.blockId).isEqualTo("c")
+        assertThat(move.movedKeys).isEqualTo(listOf<Any>(6))
+        assertThat(move.afterKey).isEqualTo(1)
+        assertThat(move.beforeKey).isEqualTo(2)
+    }
+
+    @Test
+    fun `multi swap gesture emits exactly one event`() {
+        val h = Harness()
+        // Drag block "a" from the top all the way to the end: three engine swaps, one commit.
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        h.state.applyUnitMove(fromUnit = 1, toUnit = 2)
+        h.state.applyUnitMove(fromUnit = 2, toUnit = 3)
+        val move = requireNotNull(h.state.settle())
+        assertThat(h.commits.size).isEqualTo(1)
+        assertThat(h.viewIds()).isEqualTo(listOf(2, 3, 4, 5, 6, 0, 1))
+        assertThat(move.movedKeys).isEqualTo(listOf<Any>(0, 1))
+        assertThat(move.afterKey).isEqualTo(6)
+        assertThat(move.beforeKey).isNull()
+    }
+
+    @Test
+    fun `standalone row move commits null block id and edge anchor`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 2, toUnit = 0)
+        val move = requireNotNull(h.state.settle())
+        assertThat(move.blockId).isNull()
+        assertThat(move.movedKeys).isEqualTo(listOf<Any>(5))
+        assertThat(move.afterKey).isNull()
+        assertThat(move.beforeKey).isEqualTo(0)
+    }
+
+    @Test
+    fun `settle without a gesture emits nothing`() {
+        val h = Harness()
+        assertThat(h.state.settle()).isNull()
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        h.state.settle()
+        assertThat(h.state.settle()).isNull()
+        assertThat(h.commits.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `gesture returning to origin emits nothing`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        h.state.applyUnitMove(fromUnit = 1, toUnit = 0)
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 1, 2, 3, 4, 5, 6))
+        assertThat(h.state.settle()).isNull()
+        assertThat(h.commits.size).isEqualTo(0)
+    }
+
+    // endregion
+
+    // region reconcile
+
+    @Test
+    fun `external change mid gesture cancels the gesture`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        assertThat(h.state.isDragActive).isTrue()
+        h.reconcile(fixture.dropLast(1))
+        assertThat(h.state.isDragActive).isFalse()
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 1, 2, 3, 4, 5))
+        assertThat(h.state.settle()).isNull()
+        assertThat(h.commits.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `reconcile with unchanged items keeps the optimistic order`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        h.state.settle()
+        // The consumer has not applied the move yet: the permuted view must hold, no snap-back.
+        h.reconcile(fixture)
+        assertThat(h.viewIds()).isEqualTo(listOf(2, 3, 4, 0, 1, 5, 6))
+        assertThat(h.commits.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `reconcile with the applied move resets to identity without visual change`() {
+        val h = Harness()
+        h.state.applyUnitMove(fromUnit = 0, toUnit = 1)
+        h.state.settle()
+        val applied = h.viewIds().map { id -> fixture.first { it.id == id } }
+        h.reconcile(applied)
+        assertThat(h.viewIds()).isEqualTo(listOf(2, 3, 4, 0, 1, 5, 6))
+        assertThat(h.state.upstreamIndexOf(0)).isEqualTo(0)
+        assertThat(h.state.settle()).isNull()
+        assertThat(h.commits.size).isEqualTo(1)
+    }
+
+    // endregion
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/state/RowBlocksWithinBlockTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/state/RowBlocksWithinBlockTest.kt
@@ -1,0 +1,139 @@
+package ua.wwind.table.state
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import ua.wwind.table.RowBlocks
+import ua.wwind.table.RowWithinBlockMove
+import kotlin.test.Test
+
+private data class WbItem(val id: Int, val block: String?)
+
+// row 0..1 block "a" (unit 0) | row 2..4 block "b" (unit 1) | row 5 standalone (unit 2) | row 6 block "c" (unit 3)
+private val wbFixture =
+    listOf(
+        WbItem(0, "a"),
+        WbItem(1, "a"),
+        WbItem(2, "b"),
+        WbItem(3, "b"),
+        WbItem(4, "b"),
+        WbItem(5, null),
+        WbItem(6, "c"),
+    )
+
+private class WbHarness(
+    items: List<WbItem> = wbFixture,
+) {
+    val within = mutableListOf<RowWithinBlockMove>()
+    val state =
+        RowBlocksState(
+            config = RowBlocks<WbItem>(blockOf = { it.block }, onRowReorderWithinBlock = { within += it }),
+            rowKey = { item, _ -> requireNotNull(item).id },
+        )
+
+    init {
+        state.reconcile(items.size) { items[it] }
+    }
+
+    fun reconcile(items: List<WbItem>) = state.reconcile(items.size) { items[it] }
+
+    fun viewIds(): List<Int> = (0 until state.itemsCount).map { requireNotNull(state.itemAt(it)).id }
+}
+
+class RowBlocksWithinBlockTest {
+    @Test
+    fun `move a row down within its block permutes only inside the block`() {
+        val h = WbHarness()
+        h.state.applyRowMoveWithinBlock(fromView = 2, toView = 4) // id 2 to the end of block "b"
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 1, 3, 4, 2, 5, 6))
+    }
+
+    @Test
+    fun `move a row up within its block`() {
+        val h = WbHarness()
+        h.state.applyRowMoveWithinBlock(fromView = 4, toView = 2) // id 4 to the start of block "b"
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 1, 4, 2, 3, 5, 6))
+    }
+
+    @Test
+    fun `a move crossing a block boundary is dropped`() {
+        val h = WbHarness()
+        h.state.applyRowMoveWithinBlock(fromView = 2, toView = 6) // block "b" -> block "c"
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 1, 2, 3, 4, 5, 6))
+        assertThat(h.state.isDragActive).isFalse()
+    }
+
+    @Test
+    fun `a move on a standalone unit is dropped`() {
+        val h = WbHarness()
+        h.state.applyRowMoveWithinBlock(fromView = 5, toView = 5)
+        assertThat(h.state.isDragActive).isFalse()
+    }
+
+    @Test
+    fun `settle after a down move anchors on the block-mate and the block edge`() {
+        val h = WbHarness()
+        h.state.applyRowMoveWithinBlock(fromView = 2, toView = 4)
+        val move = requireNotNull(h.state.settleWithinBlock())
+        assertThat(move.blockId).isEqualTo("b")
+        assertThat(move.movedKey).isEqualTo(2)
+        assertThat(move.afterKey).isEqualTo(4) // now the last visible row of block "b"
+        assertThat(move.beforeKey).isNull() // block end
+        assertThat(h.within).isEqualTo(listOf(move))
+    }
+
+    @Test
+    fun `settle after an up move to the block start has a null after anchor`() {
+        val h = WbHarness()
+        h.state.applyRowMoveWithinBlock(fromView = 4, toView = 2)
+        val move = requireNotNull(h.state.settleWithinBlock())
+        assertThat(move.movedKey).isEqualTo(4)
+        assertThat(move.afterKey).isNull() // block start
+        assertThat(move.beforeKey).isEqualTo(2) // first block-mate below it
+    }
+
+    @Test
+    fun `multi swap within a block emits exactly one event`() {
+        val h = WbHarness()
+        h.state.applyRowMoveWithinBlock(fromView = 2, toView = 3)
+        h.state.applyRowMoveWithinBlock(fromView = 3, toView = 4)
+        val move = requireNotNull(h.state.settleWithinBlock())
+        assertThat(h.within.size).isEqualTo(1)
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 1, 3, 4, 2, 5, 6))
+        assertThat(move.movedKey).isEqualTo(2)
+    }
+
+    @Test
+    fun `settle returning to origin emits nothing`() {
+        val h = WbHarness()
+        h.state.applyRowMoveWithinBlock(fromView = 2, toView = 3)
+        h.state.applyRowMoveWithinBlock(fromView = 3, toView = 2)
+        assertThat(h.viewIds()).isEqualTo(listOf(0, 1, 2, 3, 4, 5, 6))
+        assertThat(h.state.settleWithinBlock()).isNull()
+        assertThat(h.within.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `external change mid gesture cancels the within-block gesture`() {
+        val h = WbHarness()
+        h.state.applyRowMoveWithinBlock(fromView = 2, toView = 4)
+        h.reconcile(wbFixture.dropLast(1))
+        assertThat(h.state.isDragActive).isFalse()
+        assertThat(h.state.settleWithinBlock()).isNull()
+        assertThat(h.within.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `placeholder landing neighbour refuses the drop and snaps back`() {
+        // Block "b" = rows 2..4; hide row 3 (id 3) as a placeholder. Dragging id 2 to sit after the
+        // placeholder cannot anchor: refuse, snap back, emit nothing.
+        val h = WbHarness()
+        h.state.reconcile(wbFixture.size) { index -> if (index == 3) null else wbFixture[index] }
+        h.state.applyRowMoveWithinBlock(fromView = 2, toView = 3)
+        assertThat(h.state.settleWithinBlock()).isNull()
+        assertThat(h.within.size).isEqualTo(0)
+        assertThat((0 until h.state.itemsCount).map { h.state.itemAt(it)?.id })
+            .isEqualTo(listOf(0, 1, 2, null, 4, 5, 6))
+    }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/state/RowUnitIndexTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/state/RowUnitIndexTest.kt
@@ -1,0 +1,152 @@
+package ua.wwind.table.state
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class RowUnitIndexTest {
+    @Test
+    fun `no groups is identity`() {
+        val index = buildRowUnitIndex(itemsCount = 10, groups = null)
+        assertThat(index.unitCount).isEqualTo(10)
+        repeat(10) { row ->
+            assertThat(index.unitOf(row)).isEqualTo(row)
+            assertThat(index.rowsOf(row)).isEqualTo(row..row)
+            assertThat(index.isGroup(row)).isFalse()
+        }
+    }
+
+    @Test
+    fun `empty group list is identity`() {
+        val index = buildRowUnitIndex(itemsCount = 3, groups = emptyList())
+        assertThat(index.unitCount).isEqualTo(3)
+        assertThat(index.unitOf(2)).isEqualTo(2)
+    }
+
+    @Test
+    fun `single group in the middle collapses its rows`() {
+        // rows: 0 1 [2 3 4] 5 6 7 8 9  ->  units: 0 1 2 3 4 5 6 7
+        val index = buildRowUnitIndex(itemsCount = 10, groups = listOf(2..4))
+        assertThat(index.unitCount).isEqualTo(8)
+        assertThat(index.unitOf(0)).isEqualTo(0)
+        assertThat(index.unitOf(1)).isEqualTo(1)
+        assertThat(index.unitOf(2)).isEqualTo(2)
+        assertThat(index.unitOf(3)).isEqualTo(2)
+        assertThat(index.unitOf(4)).isEqualTo(2)
+        assertThat(index.unitOf(5)).isEqualTo(3)
+        assertThat(index.unitOf(9)).isEqualTo(7)
+        assertThat(index.rowsOf(2)).isEqualTo(2..4)
+        assertThat(index.rowsOf(3)).isEqualTo(5..5)
+        assertThat(index.rowsOf(7)).isEqualTo(9..9)
+        assertThat(index.isGroup(2)).isTrue()
+        assertThat(index.isGroup(3)).isFalse()
+    }
+
+    @Test
+    fun `group at the start`() {
+        val index = buildRowUnitIndex(itemsCount = 5, groups = listOf(0..1))
+        assertThat(index.unitCount).isEqualTo(4)
+        assertThat(index.unitOf(0)).isEqualTo(0)
+        assertThat(index.unitOf(1)).isEqualTo(0)
+        assertThat(index.unitOf(2)).isEqualTo(1)
+        assertThat(index.rowsOf(0)).isEqualTo(0..1)
+    }
+
+    @Test
+    fun `group at the end`() {
+        val index = buildRowUnitIndex(itemsCount = 5, groups = listOf(3..4))
+        assertThat(index.unitCount).isEqualTo(4)
+        assertThat(index.unitOf(4)).isEqualTo(3)
+        assertThat(index.rowsOf(3)).isEqualTo(3..4)
+    }
+
+    @Test
+    fun `adjacent groups stay separate units`() {
+        // rows: [0 1] [2 3] 4  ->  units: 0 1 2
+        val index = buildRowUnitIndex(itemsCount = 5, groups = listOf(0..1, 2..3))
+        assertThat(index.unitCount).isEqualTo(3)
+        assertThat(index.unitOf(1)).isEqualTo(0)
+        assertThat(index.unitOf(2)).isEqualTo(1)
+        assertThat(index.unitOf(4)).isEqualTo(2)
+        assertThat(index.rowsOf(0)).isEqualTo(0..1)
+        assertThat(index.rowsOf(1)).isEqualTo(2..3)
+        assertThat(index.rowsOf(2)).isEqualTo(4..4)
+    }
+
+    @Test
+    fun `single row group is still a group`() {
+        val index = buildRowUnitIndex(itemsCount = 3, groups = listOf(1..1))
+        assertThat(index.unitCount).isEqualTo(3)
+        assertThat(index.isGroup(1)).isTrue()
+        assertThat(index.rowsOf(1)).isEqualTo(1..1)
+    }
+
+    @Test
+    fun `round trip holds for every row`() {
+        val index = buildRowUnitIndex(itemsCount = 20, groups = listOf(2..4, 7..7, 15..18))
+        repeat(20) { row ->
+            val unit = index.unitOf(row)
+            assertThat(index.rowsOf(unit).contains(row)).isTrue()
+        }
+    }
+
+    @Test
+    fun `every unit maps back to a distinct row range covering all rows`() {
+        val index = buildRowUnitIndex(itemsCount = 12, groups = listOf(1..3, 8..9))
+        val covered = (0 until index.unitCount).flatMap { index.rowsOf(it) }
+        assertThat(covered).isEqualTo((0 until 12).toList())
+    }
+
+    // The footer is an extra lazy item at `unitCount`, past every unit the index describes. Callers
+    // that read `layoutInfo` can hand that index straight back, so both accessors must answer for it
+    // rather than throw or claim a group.
+    @Test
+    fun `footer unit index reports no group and the row past the end`() {
+        val identity = buildRowUnitIndex(itemsCount = 10, groups = null)
+        assertThat(identity.isGroup(identity.unitCount)).isFalse()
+        assertThat(identity.rowsOf(identity.unitCount)).isEqualTo(10..10)
+
+        val grouped = buildRowUnitIndex(itemsCount = 10, groups = listOf(2..4))
+        assertThat(grouped.unitCount).isEqualTo(8)
+        assertThat(grouped.isGroup(grouped.unitCount)).isFalse()
+        assertThat(grouped.rowsOf(grouped.unitCount)).isEqualTo(10..10)
+    }
+
+    @Test
+    fun `no items is identity with no units`() {
+        val index = buildRowUnitIndex(itemsCount = 0, groups = listOf(0..0))
+        assertThat(index.unitCount).isEqualTo(0)
+        assertThat(index.isGroup(0)).isFalse()
+    }
+
+    @Test
+    fun `overlapping groups are rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            buildRowUnitIndex(itemsCount = 10, groups = listOf(2..4, 4..6))
+        }
+    }
+
+    @Test
+    fun `unsorted groups are rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            buildRowUnitIndex(itemsCount = 10, groups = listOf(5..6, 1..2))
+        }
+    }
+
+    @Test
+    fun `out of bounds group is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            buildRowUnitIndex(itemsCount = 5, groups = listOf(3..7))
+        }
+    }
+
+    @Test
+    fun `empty range is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            buildRowUnitIndex(itemsCount = 5, groups = listOf(3..2))
+        }
+    }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/state/TableStateRemapTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/state/TableStateRemapTest.kt
@@ -1,0 +1,48 @@
+package ua.wwind.table.state
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import ua.wwind.table.config.SelectionMode
+import ua.wwind.table.config.TableDefaults
+import ua.wwind.table.config.TableSettings
+import kotlin.test.Test
+
+/** All positional runtime state must move through one remap, or the pieces drift apart at commit. */
+class TableStateRemapTest {
+    @Test
+    fun `remapRowPositions moves selection editing and checks together`() {
+        val state =
+            TableState(
+                initialColumns = listOf("a"),
+                initialSort = null,
+                initialOrder = listOf("a"),
+                initialWidths = emptyMap(),
+                settings =
+                    TableSettings(
+                        selectionMode = SelectionMode.Multiple,
+                        editingEnabled = true,
+                    ),
+                dimensions = TableDefaults.standardDimensions(),
+            )
+        state.startEditing(item = Any(), rowIndex = 2, column = "a")
+        state.toggleSelect(3)
+        state.selectCell(3, "a")
+        state.toggleCheck(1)
+        state.toggleCheck(4)
+
+        state.remapRowPositions { position ->
+            when (position) {
+                3 -> 1
+                2 -> 0
+                1 -> 3
+                4 -> 2
+                else -> position
+            }
+        }
+
+        assertThat(state.selectedIndex).isEqualTo(1)
+        assertThat(state.selectedCell).isEqualTo(TableState.SelectedCell(1, "a"))
+        assertThat(state.editingRow).isEqualTo(0)
+        assertThat(state.checkedIndices.toList()).isEqualTo(listOf(3, 2))
+    }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/state/TableStateSortLockTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/state/TableStateSortLockTest.kt
@@ -1,0 +1,46 @@
+package ua.wwind.table.state
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import ua.wwind.table.config.TableDefaults
+import ua.wwind.table.config.TableSettings
+import ua.wwind.table.data.SortOrder
+import kotlin.test.Test
+
+/**
+ * The consistency half of the reorder interaction lock: `initialSort` was already normalized away
+ * in `rememberTableState`, but a runtime `setSort` used to slip through — under an active sort the
+ * view is invariant to source permutations, so a committed drag would be unobservable.
+ */
+class TableStateSortLockTest {
+    private fun stateWith(settings: TableSettings) =
+        TableState(
+            initialColumns = listOf("a", "b"),
+            initialSort = null,
+            initialOrder = listOf("a", "b"),
+            initialWidths = emptyMap(),
+            settings = settings,
+            dimensions = TableDefaults.standardDimensions(),
+        )
+
+    @Test
+    fun `setSort is a no-op while row reorder is enabled`() {
+        val state = stateWith(TableSettings(rowReorderEnabled = true))
+        state.setSort("a")
+        assertThat(state.sort).isNull()
+        state.setSort("b", SortOrder.DESCENDING)
+        assertThat(state.sort).isNull()
+    }
+
+    @Test
+    fun `setSort applies when row reorder is disabled`() {
+        val state = stateWith(TableSettings())
+        state.setSort("a")
+        assertThat(state.sort).isEqualTo(SortState("a", SortOrder.ASCENDING))
+        state.setSort("a")
+        assertThat(state.sort).isEqualTo(SortState("a", SortOrder.DESCENDING))
+        state.setSort("a")
+        assertThat(state.sort).isNull()
+    }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/state/TableWidthTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/state/TableWidthTest.kt
@@ -1,0 +1,76 @@
+package ua.wwind.table.state
+
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import ua.wwind.table.ColumnSpec
+import ua.wwind.table.config.TableDefaults
+import ua.wwind.table.config.TableSettings
+import kotlin.test.Test
+
+private fun spec(key: String): ColumnSpec<Any, String, Unit> =
+    ColumnSpec(
+        key = key,
+        header = {},
+        cell = { _, _ -> },
+        valueOf = { null },
+    )
+
+/**
+ * [TableState.tableWidth] is a `derivedStateOf` over [TableState.visibleColumns]. Snapshot state
+ * only invalidates a derived value when a *tracked* read changes, so `visibleColumns` has to be
+ * snapshot state itself: as a plain field its writes are invisible and the width freezes at
+ * whatever the first composition computed.
+ *
+ * That freeze is not cosmetic. Rows are measured with `Modifier.width(state.tableWidth)` and the
+ * horizontal scroll range follows it, so a stale width leaves newly shown columns off screen and
+ * unreachable — while the header, which measures from its own width map, lays them out. The result
+ * is a header that no longer lines up with the rows beneath it.
+ */
+class TableWidthTest {
+    private fun newState(): TableState<String> =
+        TableState(
+            initialColumns = listOf("a", "b"),
+            initialSort = null,
+            initialOrder = listOf("a", "b"),
+            initialWidths = mapOf("a" to 100.dp, "b" to 100.dp),
+            settings = TableSettings(),
+            dimensions = TableDefaults.standardDimensions(),
+        )
+
+    @Test
+    fun `tableWidth follows a column being hidden`() {
+        val state = newState()
+        val divider = state.dimensions.dividerThickness
+
+        state.visibleColumns = listOf(spec("a"), spec("b"))
+        assertThat(state.tableWidth).isEqualTo(200.dp + divider * 2)
+
+        state.visibleColumns = listOf(spec("a"))
+        assertThat(state.tableWidth).isEqualTo(100.dp + divider)
+    }
+
+    @Test
+    fun `tableWidth follows a column being shown again`() {
+        val state = newState()
+        val divider = state.dimensions.dividerThickness
+
+        state.visibleColumns = listOf(spec("a"))
+        assertThat(state.tableWidth).isEqualTo(100.dp + divider)
+
+        state.visibleColumns = listOf(spec("a"), spec("b"))
+        assertThat(state.tableWidth).isEqualTo(200.dp + divider * 2)
+    }
+
+    @Test
+    fun `tableWidth follows a column width change`() {
+        val state = newState()
+        val divider = state.dimensions.dividerThickness
+
+        state.visibleColumns = listOf(spec("a"))
+        assertThat(state.tableWidth).isEqualTo(100.dp + divider)
+
+        state.columnWidths["a"] = 150.dp
+        assertThat(state.tableWidth).isEqualTo(150.dp + divider)
+    }
+}

--- a/table-paging/src/commonMain/kotlin/ua/wwind/table/paging/Table.kt
+++ b/table-paging/src/commonMain/kotlin/ua/wwind/table/paging/Table.kt
@@ -7,16 +7,19 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
+import co.touchlab.kermit.Logger
 import kotlinx.collections.immutable.ImmutableList
 import ua.wwind.paging.core.PagingData
 import ua.wwind.paging.core.getOrNull
 import ua.wwind.table.ColumnSpec
 import ua.wwind.table.ExperimentalTableApi
+import ua.wwind.table.RowBlocks
 import ua.wwind.table.Table
 import ua.wwind.table.component.TableHeaderDefaults
 import ua.wwind.table.component.TableHeaderIcons
@@ -27,6 +30,33 @@ import ua.wwind.table.config.TableDefaults
 import ua.wwind.table.state.TableState
 import ua.wwind.table.strings.DefaultStrings
 import ua.wwind.table.strings.StringProvider
+
+/**
+ * Shared default for `rowKey` across both paged entry points. The core table warns when a block
+ * table runs on the default positional key, but it can only recognize its OWN default instance —
+ * internal to another module — so the adapter must recognize its default and warn itself.
+ */
+private val DefaultPagedRowKey: (Any?, Int) -> Any = { _, index -> index }
+
+/**
+ * Mirrors the core table's rowKey guard on the paged surface: `RowBlockMove` anchors are row keys,
+ * and a positional key cannot survive the move it describes — see [DefaultPagedRowKey] for why the
+ * core guard cannot fire here.
+ */
+@Composable
+private fun WarnOnDefaultRowKeyWithBlocks(
+    rowBlocks: RowBlocks<*>?,
+    rowKey: Any,
+) {
+    LaunchedEffect(rowBlocks, rowKey) {
+        if (rowBlocks != null && rowKey === DefaultPagedRowKey) {
+            Logger.w {
+                "rowBlocks requires a stable rowKey: RowBlockMove anchors are row keys, " +
+                    "and the default positional key cannot survive a move"
+            }
+        }
+    }
+}
 
 /**
  * Composable data table with paging support.
@@ -51,6 +81,13 @@ import ua.wwind.table.strings.StringProvider
  * @param rowKey stable key for rows; defaults to index
  * @param onRowClick row primary action handler
  * @param onRowLongClick optional long-press handler
+ * @param rowBlocks row blocks declared by identity ([RowBlocks.blockOf]); requires a stable
+ * [rowKey]. Bands derive over loaded adjacent runs, so a placeholder breaks a band and a partially
+ * loaded block extends as its pages arrive. Without [RowBlocks.onCommit] blocks are display-only;
+ * with it a drop commits only when its landing neighbours are loaded — against a placeholder the
+ * gesture snaps back and nothing is emitted. Apply commits in your data layer by
+ * `RowBlockMove.blockId`: a paged consumer holds no materialized list for `applyRowBlockMove`,
+ * and the data layer is what knows full block membership, including rows never loaded here.
  * @param contextMenu optional context menu host, invoked with item and absolute position
  * @param customization styling hooks for rows and cells
  * @param colors container/content colors
@@ -71,9 +108,10 @@ public fun <T : Any, C, E> Table(
     tableData: E,
     modifier: Modifier = Modifier,
     placeholderRow: (@Composable () -> Unit)? = null,
-    rowKey: (item: T?, index: Int) -> Any = { _, i -> i },
+    rowKey: (item: T?, index: Int) -> Any = DefaultPagedRowKey,
     onRowClick: ((T) -> Unit)? = null,
     onRowLongClick: ((T) -> Unit)? = null,
+    rowBlocks: RowBlocks<T>? = null,
     contextMenu: (@Composable (item: T, pos: Offset, dismiss: () -> Unit) -> Unit)? = null,
     customization: TableCustomization<T, C> = DefaultTableCustomization(),
     colors: TableColors = TableDefaults.colors(),
@@ -84,6 +122,7 @@ public fun <T : Any, C, E> Table(
     shape: Shape = RoundedCornerShape(4.dp),
     border: BorderStroke? = null,
 ) {
+    WarnOnDefaultRowKeyWithBlocks(rowBlocks, rowKey)
     val itemsCount = remember(items) { items?.data?.size ?: 0 }
     val itemAt = remember(items) { { index: Int -> items?.data?.get(index)?.getOrNull() } }
 
@@ -98,6 +137,7 @@ public fun <T : Any, C, E> Table(
         rowKey = rowKey,
         onRowClick = onRowClick,
         onRowLongClick = onRowLongClick,
+        rowBlocks = rowBlocks,
         contextMenu = contextMenu,
         customization = customization,
         colors = colors,
@@ -131,6 +171,13 @@ public fun <T : Any, C, E> Table(
  * @param rowKey stable key for rows; defaults to index
  * @param onRowClick row primary action handler
  * @param onRowLongClick optional long-press handler
+ * @param rowBlocks row blocks declared by identity ([RowBlocks.blockOf]); requires a stable
+ * [rowKey]. Bands derive over loaded adjacent runs, so a placeholder breaks a band and a partially
+ * loaded block extends as its pages arrive. Without [RowBlocks.onCommit] blocks are display-only;
+ * with it a drop commits only when its landing neighbours are loaded — against a placeholder the
+ * gesture snaps back and nothing is emitted. Apply commits in your data layer by
+ * `RowBlockMove.blockId`: a paged consumer holds no materialized list for `applyRowBlockMove`,
+ * and the data layer is what knows full block membership, including rows never loaded here.
  * @param contextMenu optional context menu host, invoked with item and absolute position
  * @param customization styling hooks for rows and cells
  * @param colors container/content colors
@@ -150,9 +197,10 @@ public fun <T : Any, C> Table(
     columns: ImmutableList<ColumnSpec<T, C, Unit>>,
     modifier: Modifier = Modifier,
     placeholderRow: (@Composable () -> Unit)? = null,
-    rowKey: (item: T?, index: Int) -> Any = { _, i -> i },
+    rowKey: (item: T?, index: Int) -> Any = DefaultPagedRowKey,
     onRowClick: ((T) -> Unit)? = null,
     onRowLongClick: ((T) -> Unit)? = null,
+    rowBlocks: RowBlocks<T>? = null,
     contextMenu: (@Composable (item: T, pos: Offset, dismiss: () -> Unit) -> Unit)? = null,
     customization: TableCustomization<T, C> = DefaultTableCustomization(),
     colors: TableColors = TableDefaults.colors(),
@@ -163,6 +211,7 @@ public fun <T : Any, C> Table(
     shape: Shape = RoundedCornerShape(4.dp),
     border: BorderStroke? = null,
 ) {
+    WarnOnDefaultRowKeyWithBlocks(rowBlocks, rowKey)
     val itemsCount = remember(items) { items?.data?.size ?: 0 }
     val itemAt = remember(items) { { index: Int -> items?.data?.get(index)?.getOrNull() } }
 
@@ -176,6 +225,7 @@ public fun <T : Any, C> Table(
         rowKey = rowKey,
         onRowClick = onRowClick,
         onRowLongClick = onRowLongClick,
+        rowBlocks = rowBlocks,
         contextMenu = contextMenu,
         customization = customization,
         colors = colors,

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/SampleApp.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/SampleApp.kt
@@ -10,9 +10,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DragIndicator
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.HorizontalDivider
@@ -44,6 +46,7 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import ua.wwind.table.ExperimentalTableApi
 import ua.wwind.table.RowBlocks
+import ua.wwind.table.draggableHandle
 import ua.wwind.table.config.RowHeightMode
 import ua.wwind.table.config.SelectionMode
 import ua.wwind.table.config.TableDefaults
@@ -117,11 +120,14 @@ fun SampleApp(modifier: Modifier = Modifier) {
             )
         }
 
+    // Mirrors the row-handle column in createTableColumns.
+    val handleColumnWidth = if (tableConfig.useCompactMode) 36.dp else 48.dp
+
     // Declared by identity, so nothing here depends on the displayed list: the table derives block
     // extents itself from the snapshot it renders. One instance per toggle flip — RowBlocks
     // compares by identity, and a fresh instance each recomposition would defeat skipping.
     val rowBlocks =
-        remember(tableConfig.enableRowBlocks) {
+        remember(tableConfig.enableRowBlocks, handleColumnWidth) {
             if (!tableConfig.enableRowBlocks) {
                 null
             } else {
@@ -130,24 +136,41 @@ fun SampleApp(modifier: Modifier = Modifier) {
                     // Exactly one event per completed gesture; the lift to the master list is one
                     // applyRowBlockMove call in the ViewModel.
                     onCommit = { move -> viewModel.onEvent(SampleUiEvent.BlockMove(move)) },
-                    // Names the block in the band above it — where the group chip used to sit
-                    // inside the Name cell. The id IS the name, so tapping it edits the id.
+                    // Reordering a row within its block: one applyRowReorderWithinBlock call.
+                    onRowReorderWithinBlock = { move ->
+                        viewModel.onEvent(SampleUiEvent.RowWithinBlockMove(move))
+                    },
+                    // The band above the block: a drag handle that moves the whole block, the group
+                    // name (tap to rename), and an edit affordance.
                     blockHeader = { blockId, _ ->
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(6.dp),
-                            // clickable before padding: the padding is inside the touch target,
-                            // not dead space around it.
-                            modifier =
-                                Modifier
-                                    .clickable {
-                                        viewModel.setRenamingGroup(blockId.toString())
-                                    }.padding(horizontal = 12.dp, vertical = 6.dp),
+                            modifier = Modifier.padding(vertical = 6.dp),
                         ) {
+                            // Same width as the row-handle column, so every drag handle in the table
+                            // lines up in one vertical run.
+                            Box(
+                                contentAlignment = Alignment.Center,
+                                modifier = Modifier.width(handleColumnWidth),
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.DragIndicator,
+                                    contentDescription = "Drag group $blockId",
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(18.dp).draggableHandle(),
+                                )
+                            }
                             Text(
                                 text = blockId.toString(),
                                 style = MaterialTheme.typography.labelLarge,
                                 color = MaterialTheme.colorScheme.onSurface,
+                                // clickable inside the label so the handle drag and the rename tap
+                                // do not fight over the same node.
+                                modifier =
+                                    Modifier.clickable {
+                                        viewModel.setRenamingGroup(blockId.toString())
+                                    },
                             )
                             Icon(
                                 imageVector = Icons.Default.Edit,
@@ -294,6 +317,14 @@ fun SampleApp(modifier: Modifier = Modifier) {
                                     onMovementBlockMove = { person, move ->
                                         viewModel.onEvent(
                                             SampleUiEvent.MovementBlockMove(
+                                                personId = person.id,
+                                                move = move,
+                                            ),
+                                        )
+                                    },
+                                    onMovementRowWithinBlockMove = { person, move ->
+                                        viewModel.onEvent(
+                                            SampleUiEvent.MovementRowWithinBlockMove(
                                                 personId = person.id,
                                                 move = move,
                                             ),

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/SampleApp.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/SampleApp.kt
@@ -1,19 +1,27 @@
 package ua.wwind.table.sample.app
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -35,6 +43,7 @@ import io.github.fletchmckee.liquid.rememberLiquidState
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import ua.wwind.table.ExperimentalTableApi
+import ua.wwind.table.RowBlocks
 import ua.wwind.table.config.RowHeightMode
 import ua.wwind.table.config.SelectionMode
 import ua.wwind.table.config.TableDefaults
@@ -43,6 +52,7 @@ import ua.wwind.table.filter.data.TableFilterState
 import ua.wwind.table.format.rememberCustomization
 import ua.wwind.table.sample.app.components.AppToolbar
 import ua.wwind.table.sample.app.components.ConditionalFormattingDialog
+import ua.wwind.table.sample.app.components.GroupRenameDialog
 import ua.wwind.table.sample.app.components.MainTable
 import ua.wwind.table.sample.app.components.SampleTableConfig
 import ua.wwind.table.sample.app.components.SelectionActionBar
@@ -89,16 +99,66 @@ fun SampleApp(modifier: Modifier = Modifier) {
 
     // Collect state from ViewModel
     val tableData by viewModel.tableData.collectAsState()
+    val sortWithinBlocks by viewModel.sortWithinBlocks.collectAsState()
 
     // Create columns with callbacks
     val columns =
-        remember(tableConfig.useCompactMode, tableConfig.enableRowReorder) {
+        remember(
+            tableConfig.useCompactMode,
+            tableConfig.enableRowReorder,
+            tableConfig.hiddenColumns,
+        ) {
             createTableColumns(
                 onToggleMovementExpanded = viewModel::toggleMovementExpanded,
                 onEvent = viewModel::onEvent,
                 useCompactMode = tableConfig.useCompactMode,
                 enableRowReorder = tableConfig.enableRowReorder,
+                hiddenColumns = tableConfig.hiddenColumns,
             )
+        }
+
+    // Declared by identity, so nothing here depends on the displayed list: the table derives block
+    // extents itself from the snapshot it renders. One instance per toggle flip — RowBlocks
+    // compares by identity, and a fresh instance each recomposition would defeat skipping.
+    val rowBlocks =
+        remember(tableConfig.enableRowBlocks) {
+            if (!tableConfig.enableRowBlocks) {
+                null
+            } else {
+                RowBlocks<Person>(
+                    blockOf = { it.groupId },
+                    // Exactly one event per completed gesture; the lift to the master list is one
+                    // applyRowBlockMove call in the ViewModel.
+                    onCommit = { move -> viewModel.onEvent(SampleUiEvent.BlockMove(move)) },
+                    // Names the block in the band above it — where the group chip used to sit
+                    // inside the Name cell. The id IS the name, so tapping it edits the id.
+                    blockHeader = { blockId, _ ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            // clickable before padding: the padding is inside the touch target,
+                            // not dead space around it.
+                            modifier =
+                                Modifier
+                                    .clickable {
+                                        viewModel.setRenamingGroup(blockId.toString())
+                                    }.padding(horizontal = 12.dp, vertical = 6.dp),
+                        ) {
+                            Text(
+                                text = blockId.toString(),
+                                style = MaterialTheme.typography.labelLarge,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                            Icon(
+                                imageVector = Icons.Default.Edit,
+                                contentDescription = "Rename group $blockId",
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        }
+                    },
+                )
+            }
         }
 
     // Build customization based on rules + matching logic
@@ -132,9 +192,11 @@ fun SampleApp(modifier: Modifier = Modifier) {
     // Liquid glass effect state for SelectionActionBar
     val liquidState = rememberLiquidState()
 
-    // Toggle visibility of SELECTION column by adjusting width based on selection mode
+    // The SELECTION column carries the checkbox in selection mode and the drag handle outside it,
+    // so it must stay open for either one; collapsing it on selection mode alone took the handle
+    // with it. Width is the only visibility control the column has.
     val selectionColumnWidth =
-        if (tableData.selectionModeEnabled) {
+        if (tableData.selectionModeEnabled || tableConfig.enableRowReorder) {
             if (tableConfig.useCompactMode) 36.dp else 48.dp
         } else {
             0.dp
@@ -167,6 +229,8 @@ fun SampleApp(modifier: Modifier = Modifier) {
                                 onConfigChange = { tableConfig = it },
                                 enableSelectionMode = tableData.selectionModeEnabled,
                                 onEnableSelectionModeChange = { viewModel.setSelectionMode(it) },
+                                sortWithinBlocks = sortWithinBlocks,
+                                onSortWithinBlocksChange = { viewModel.setSortWithinBlocks(it) },
                                 onConditionalFormattingClick = {
                                     viewModel.toggleFormatDialog(true)
                                     scope.launch { drawerState.close() }
@@ -223,6 +287,18 @@ fun SampleApp(modifier: Modifier = Modifier) {
                                             )
                                         }
                                     },
+                                    // Non-null blocks take over the drag inside the table, so the
+                                    // plain single-row swap demo (onRowMove) still applies only
+                                    // while blocks are off.
+                                    rowBlocks = rowBlocks,
+                                    onMovementBlockMove = { person, move ->
+                                        viewModel.onEvent(
+                                            SampleUiEvent.MovementBlockMove(
+                                                personId = person.id,
+                                                move = move,
+                                            ),
+                                        )
+                                    },
                                     onMovementRowMove = { person, from, to ->
                                         viewModel.onEvent(
                                             SampleUiEvent.MovementRowMove(
@@ -267,6 +343,22 @@ fun SampleApp(modifier: Modifier = Modifier) {
                                     viewModel.onEvent(SampleUiEvent.ClearSelection)
                                 },
                                 liquidState = liquidState,
+                                // Gated on the blocks toggle: with blocks off `rowBlocks` is null,
+                                // so grouping would change nothing visible and look broken.
+                                canGroup =
+                                    tableConfig.enableRowBlocks &&
+                                        tableData.selectedIds.size >= 2,
+                                onGroupClick = {
+                                    viewModel.onEvent(SampleUiEvent.GroupSelected)
+                                },
+                                canUngroup =
+                                    tableConfig.enableRowBlocks &&
+                                        tableData.displayedPeople.any {
+                                            it.id in tableData.selectedIds && it.groupId != null
+                                        },
+                                onUngroupClick = {
+                                    viewModel.onEvent(SampleUiEvent.UngroupSelected)
+                                },
                                 modifier =
                                     Modifier
                                         .align(Alignment.BottomCenter)
@@ -284,6 +376,27 @@ fun SampleApp(modifier: Modifier = Modifier) {
             onRulesChanged = viewModel::updateRules,
             buildFormatFilterData = viewModel::buildFormatFilterData,
             onDismissRequest = { viewModel.toggleFormatDialog(false) },
+        )
+
+        // The master list, NOT `tableData.displayedPeople`: that one is filtered, so a name held by
+        // a hidden row would look free and the rename would silently bail out in the ViewModel.
+        // Group identity lives in the unfiltered list, which is exactly what RenameGroup rewrites.
+        val allPeople by viewModel.people.collectAsState()
+        val renamingGroupId = viewModel.renamingGroupId
+        GroupRenameDialog(
+            groupId = renamingGroupId,
+            // Its own name is excluded, or the dialog would call the group's current id taken.
+            takenGroupIds =
+                remember(allPeople, renamingGroupId) {
+                    allPeople.mapNotNull { it.groupId }.toSet() - setOfNotNull(renamingGroupId)
+                },
+            onRename = { newGroupId ->
+                val groupId = renamingGroupId ?: return@GroupRenameDialog
+                viewModel.onEvent(
+                    SampleUiEvent.RenameGroup(groupId = groupId, newGroupId = newGroupId),
+                )
+            },
+            onDismissRequest = { viewModel.setRenamingGroup(null) },
         )
     }
 }

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/GroupRenameDialog.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/GroupRenameDialog.kt
@@ -1,0 +1,80 @@
+package ua.wwind.table.sample.app.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+/**
+ * Renames a row group. The group id doubles as its name in this sample, so the dialog edits the id
+ * itself and every row carrying it is rewritten.
+ *
+ * Because the id IS the identity, names must stay unique: two groups sharing one id are one logical
+ * group that renames together yet only merges visually when adjacent. The dialog is the gate that
+ * keeps them apart.
+ *
+ * @param groupId Id of the group being renamed; null keeps the dialog closed.
+ * @param takenGroupIds Ids already in use by OTHER groups - [groupId] itself must be excluded by the
+ *   caller, or the dialog would reject the name the group already has as taken.
+ * @param onRename Callback with the new id, invoked only for a non-blank, unused change.
+ * @param onDismissRequest Callback to close the dialog.
+ */
+@Composable
+fun GroupRenameDialog(
+    groupId: String?,
+    takenGroupIds: Set<String>,
+    onRename: (String) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    if (groupId == null) return
+
+    // Keyed on the group so reopening the dialog - or switching to another group without closing -
+    // refills the field instead of showing the previous target's id.
+    var newGroupId by remember(groupId) { mutableStateOf(groupId) }
+    // Trimmed is what gets saved, so it is also what gets validated: a name is judged exactly as it
+    // would be stored. Comparison is case-sensitive to match block identity, which is decided
+    // with `==` over `blockOf` values - "alice" really is a free name next to "Alice".
+    val trimmed = newGroupId.trim()
+    val errorMessage =
+        when {
+            trimmed.isEmpty() -> "Name cannot be empty"
+            trimmed in takenGroupIds -> "Name is already in use"
+            else -> null
+        }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text("Rename group") },
+        text = {
+            OutlinedTextField(
+                value = newGroupId,
+                onValueChange = { newGroupId = it },
+                label = { Text("Group name") },
+                singleLine = true,
+                isError = errorMessage != null,
+                supportingText = errorMessage?.let { message -> { Text(message) } },
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onRename(trimmed)
+                    onDismissRequest()
+                },
+                enabled = errorMessage == null && trimmed != groupId,
+            ) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text("Cancel")
+            }
+        },
+    )
+}

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/MainTable.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/MainTable.kt
@@ -31,6 +31,7 @@ import ua.wwind.table.ColumnSpec
 import ua.wwind.table.EditableTable
 import ua.wwind.table.ExperimentalTableApi
 import ua.wwind.table.RowBlockMove
+import ua.wwind.table.RowWithinBlockMove
 import ua.wwind.table.RowBlocks
 import ua.wwind.table.config.TableCustomization
 import ua.wwind.table.filter.data.TableFilterState
@@ -54,6 +55,7 @@ fun MainTable(
     onRowMove: (fromIndex: Int, toIndex: Int) -> Unit,
     onMovementRowMove: (person: Person, fromIndex: Int, toIndex: Int) -> Unit,
     onMovementBlockMove: (person: Person, move: RowBlockMove) -> Unit,
+    onMovementRowWithinBlockMove: (person: Person, move: RowWithinBlockMove) -> Unit,
     onRowEditStart: (Person, Int) -> Unit,
     onRowEditComplete: (Int) -> Boolean,
     onEditCancelled: (Int) -> Unit,
@@ -131,6 +133,9 @@ fun MainTable(
                         },
                         onBlockMove = { move ->
                             onMovementBlockMove(person, move)
+                        },
+                        onRowWithinBlockMove = { move ->
+                            onMovementRowWithinBlockMove(person, move)
                         },
                     )
                 }

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/MainTable.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/MainTable.kt
@@ -30,6 +30,8 @@ import kotlinx.coroutines.delay
 import ua.wwind.table.ColumnSpec
 import ua.wwind.table.EditableTable
 import ua.wwind.table.ExperimentalTableApi
+import ua.wwind.table.RowBlockMove
+import ua.wwind.table.RowBlocks
 import ua.wwind.table.config.TableCustomization
 import ua.wwind.table.filter.data.TableFilterState
 import ua.wwind.table.sample.column.PersonColumn
@@ -51,9 +53,11 @@ fun MainTable(
     onSortChanged: (SortState<PersonColumn>?) -> Unit,
     onRowMove: (fromIndex: Int, toIndex: Int) -> Unit,
     onMovementRowMove: (person: Person, fromIndex: Int, toIndex: Int) -> Unit,
+    onMovementBlockMove: (person: Person, move: RowBlockMove) -> Unit,
     onRowEditStart: (Person, Int) -> Unit,
     onRowEditComplete: (Int) -> Boolean,
     onEditCancelled: (Int) -> Unit,
+    rowBlocks: RowBlocks<Person>? = null,
     useCompactMode: Boolean = false,
     enableRowReorder: Boolean = false,
     modifier: Modifier = Modifier,
@@ -120,12 +124,18 @@ fun MainTable(
                         person = person,
                         useCompactMode = useCompactMode,
                         enableRowReorder = enableRowReorder,
+                        // The embedded year-blocks demo follows the same toggle as the main table.
+                        enableRowBlocks = rowBlocks != null,
                         onRowMove = { from, to ->
                             onMovementRowMove(person, from, to)
+                        },
+                        onBlockMove = { move ->
+                            onMovementBlockMove(person, move)
                         },
                     )
                 }
             },
+            rowBlocks = rowBlocks,
             onRowMove = onRowMove,
             onRowEditStart = onRowEditStart,
             onRowEditComplete = onRowEditComplete,

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/PersonMovementsSection.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/PersonMovementsSection.kt
@@ -7,11 +7,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.toImmutableList
 import ua.wwind.table.ExperimentalTableApi
+import ua.wwind.table.RowBlockMove
+import ua.wwind.table.RowBlocks
 import ua.wwind.table.Table
 import ua.wwind.table.config.RowHeightMode
 import ua.wwind.table.config.SelectionMode
@@ -19,7 +22,9 @@ import ua.wwind.table.config.TableDefaults
 import ua.wwind.table.config.TableSettings
 import ua.wwind.table.sample.column.createMovementColumns
 import ua.wwind.table.sample.model.Person
+import ua.wwind.table.sample.model.PersonMovement
 import ua.wwind.table.sample.model.PersonMovementColumn
+import ua.wwind.table.sample.model.movementBlockId
 import ua.wwind.table.state.rememberTableState
 import ua.wwind.table.strings.DefaultStrings
 
@@ -29,7 +34,9 @@ fun PersonMovementsSection(
     person: Person,
     useCompactMode: Boolean = false,
     enableRowReorder: Boolean = false,
+    enableRowBlocks: Boolean = false,
     onRowMove: (fromIndex: Int, toIndex: Int) -> Unit = { _, _ -> },
+    onBlockMove: (RowBlockMove) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val columns =
@@ -58,6 +65,32 @@ fun PersonMovementsSection(
             dimensions = TableDefaults.compactDimensions(),
         )
 
+    // The block declaration must stay one instance (identity equality) while the commit callback
+    // tracks recompositions — each pass captures the current person — so the remembered config
+    // reads the callback through rememberUpdatedState instead of being rebuilt around it.
+    val currentOnBlockMove = rememberUpdatedState(onBlockMove)
+    // Embedded blocks demo: adjacent same-year movements band and drag as one unit, driving the
+    // no-LazyColumn path of the managed drag.
+    val movementBlocks =
+        remember(enableRowBlocks) {
+            if (!enableRowBlocks) {
+                null
+            } else {
+                RowBlocks<PersonMovement>(
+                    blockOf = { it.movementBlockId },
+                    onCommit = { move -> currentOnBlockMove.value(move) },
+                    blockHeader = { blockId, _ ->
+                        Text(
+                            text = "Year $blockId",
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                        )
+                    },
+                )
+            }
+        }
+
     Column(
         modifier = modifier.padding(top = 8.dp, bottom = 8.dp).padding(horizontal = 16.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -79,6 +112,7 @@ fun PersonMovementsSection(
             modifier = Modifier.padding(top = 8.dp),
             embedded = true,
             onRowMove = onRowMove,
+            rowBlocks = movementBlocks,
         )
     }
 }

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/PersonMovementsSection.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/PersonMovementsSection.kt
@@ -1,13 +1,21 @@
 package ua.wwind.table.sample.app.components
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DragIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -15,6 +23,8 @@ import kotlinx.collections.immutable.toImmutableList
 import ua.wwind.table.ExperimentalTableApi
 import ua.wwind.table.RowBlockMove
 import ua.wwind.table.RowBlocks
+import ua.wwind.table.RowWithinBlockMove
+import ua.wwind.table.draggableHandle
 import ua.wwind.table.Table
 import ua.wwind.table.config.RowHeightMode
 import ua.wwind.table.config.SelectionMode
@@ -37,6 +47,7 @@ fun PersonMovementsSection(
     enableRowBlocks: Boolean = false,
     onRowMove: (fromIndex: Int, toIndex: Int) -> Unit = { _, _ -> },
     onBlockMove: (RowBlockMove) -> Unit = {},
+    onRowWithinBlockMove: (RowWithinBlockMove) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val columns =
@@ -69,23 +80,45 @@ fun PersonMovementsSection(
     // tracks recompositions — each pass captures the current person — so the remembered config
     // reads the callback through rememberUpdatedState instead of being rebuilt around it.
     val currentOnBlockMove = rememberUpdatedState(onBlockMove)
-    // Embedded blocks demo: adjacent same-year movements band and drag as one unit, driving the
-    // no-LazyColumn path of the managed drag.
+    val currentOnRowWithinBlockMove = rememberUpdatedState(onRowWithinBlockMove)
+    // Mirrors the reorder column in createMovementColumns.
+    val handleColumnWidth = if (useCompactMode) 36.dp else 48.dp
+    // Embedded blocks demo: adjacent same-year movements band and drag as one unit (from the header
+    // handle), while each row reorders within its year block — driving the no-LazyColumn path of the
+    // managed drag and its nested within-block column.
     val movementBlocks =
-        remember(enableRowBlocks) {
+        remember(enableRowBlocks, handleColumnWidth) {
             if (!enableRowBlocks) {
                 null
             } else {
                 RowBlocks<PersonMovement>(
                     blockOf = { it.movementBlockId },
                     onCommit = { move -> currentOnBlockMove.value(move) },
+                    onRowReorderWithinBlock = { move -> currentOnRowWithinBlockMove.value(move) },
                     blockHeader = { blockId, _ ->
-                        Text(
-                            text = "Year $blockId",
-                            style = MaterialTheme.typography.labelLarge,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-                        )
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            modifier = Modifier.padding(vertical = 6.dp),
+                        ) {
+                            // Same width as the row-handle column, so the handles line up.
+                            Box(
+                                contentAlignment = Alignment.Center,
+                                modifier = Modifier.width(handleColumnWidth),
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.DragIndicator,
+                                    contentDescription = "Drag year $blockId",
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(18.dp).draggableHandle(),
+                                )
+                            }
+                            Text(
+                                text = "Year $blockId",
+                                style = MaterialTheme.typography.labelLarge,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
                     },
                 )
             }

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/SampleTableConfig.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/SampleTableConfig.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import ua.wwind.table.config.PinnedSide
 import ua.wwind.table.platform.getPlatform
 import ua.wwind.table.platform.isMobile
+import ua.wwind.table.sample.column.PersonColumn
 
 /**
  * Configuration data class for sample table settings.
@@ -15,6 +16,7 @@ data class SampleTableConfig(
     val showFastFilters: Boolean = true,
     val enableDragToScroll: Boolean = getPlatform().isMobile(),
     val enableRowReorder: Boolean = false,
+    val enableRowBlocks: Boolean = false,
     val pinnedColumnsCount: Int = 0,
     val pinnedColumnsSide: PinnedSide = PinnedSide.Left,
     val enableEditing: Boolean = false,
@@ -25,4 +27,6 @@ data class SampleTableConfig(
     val showRowDividers: Boolean = true,
     val showHeaderDivider: Boolean = true,
     val showFastFiltersDivider: Boolean = true,
+    /** Columns hidden via the sidebar toggle; specs rebuild with `visible = false` for these. */
+    val hiddenColumns: Set<PersonColumn> = emptySet(),
 )

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/SelectionActionBar.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/SelectionActionBar.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -37,6 +39,10 @@ import io.github.fletchmckee.liquid.liquid
  * @param onClearSelection Callback when clear selection button is clicked
  * @param liquidState State for the Liquid Glass effect (must be shared with liquefiable content)
  * @param modifier Modifier for the composable
+ * @param canGroup Whether the selection can be pulled together into a group
+ * @param onGroupClick Callback when the group button is clicked
+ * @param canUngroup Whether the selection contains at least one grouped row
+ * @param onUngroupClick Callback when the ungroup button is clicked
  */
 @Composable
 fun SelectionActionBar(
@@ -45,6 +51,10 @@ fun SelectionActionBar(
     onClearSelection: () -> Unit,
     liquidState: LiquidState,
     modifier: Modifier = Modifier,
+    canGroup: Boolean = false,
+    onGroupClick: () -> Unit = {},
+    canUngroup: Boolean = false,
+    onUngroupClick: () -> Unit = {},
 ) {
     AnimatedVisibility(
         visible = selectedCount > 0,
@@ -81,6 +91,44 @@ fun SelectionActionBar(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(modifier = Modifier.width(8.dp))
+                if (canGroup) {
+                    Button(
+                        onClick = onGroupClick,
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor =
+                                    MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.9f),
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                            ),
+                        shape = RoundedCornerShape(16.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Link,
+                            contentDescription = null,
+                            modifier = Modifier.padding(end = 8.dp),
+                        )
+                        Text("Group")
+                    }
+                }
+                if (canUngroup) {
+                    Button(
+                        onClick = onUngroupClick,
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor =
+                                    MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.9f),
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                            ),
+                        shape = RoundedCornerShape(16.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.LinkOff,
+                            contentDescription = null,
+                            modifier = Modifier.padding(end = 8.dp),
+                        )
+                        Text("Ungroup")
+                    }
+                }
                 Button(
                     onClick = onDeleteClick,
                     colors =

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/SettingsSidebar.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/app/components/SettingsSidebar.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import ua.wwind.table.config.PinnedSide
+import ua.wwind.table.sample.column.PersonColumn
 
 /**
  * Settings sidebar that displays all table configuration options. Designed to be used as drawer
@@ -48,6 +49,8 @@ fun SettingsSidebar(
     onConfigChange: (SampleTableConfig) -> Unit,
     enableSelectionMode: Boolean,
     onEnableSelectionModeChange: (Boolean) -> Unit,
+    sortWithinBlocks: Boolean,
+    onSortWithinBlocksChange: (Boolean) -> Unit,
     onConditionalFormattingClick: () -> Unit,
     onRecalculateAutoWidthsClick: () -> Unit,
     onClose: () -> Unit,
@@ -153,6 +156,20 @@ fun SettingsSidebar(
                     )
                     Spacer(modifier = Modifier.height(12.dp))
                     SettingSwitch(
+                        label = "Row blocks",
+                        checked = config.enableRowBlocks,
+                        onCheckedChange = { onConfigChange(config.copy(enableRowBlocks = it)) },
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    // A free sort fragments blocks into duplicate bands; this routes the active
+                    // sort through sortedWithinRowBlocks, which keeps every block whole.
+                    SettingSwitch(
+                        label = "Sort within blocks",
+                        checked = sortWithinBlocks,
+                        onCheckedChange = onSortWithinBlocksChange,
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    SettingSwitch(
                         label = "Cell editing",
                         checked = config.enableEditing,
                         onCheckedChange = { onConfigChange(config.copy(enableEditing = it)) },
@@ -239,6 +256,33 @@ fun SettingsSidebar(
                         onClick = onRecalculateAutoWidthsClick,
                         modifier = Modifier.fillMaxWidth(),
                     ) { Text("Fit columns") }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    // Column visibility: rebuilds the ColumnSpec list with `visible = false` for
+                    // unchecked columns. Utility columns (selection, expand) stay out of the list —
+                    // their visibility is driven by selection/reorder modes, not by the user.
+                    Text(
+                        text = "Visible columns",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    hideablePersonColumns.forEach { column ->
+                        Spacer(modifier = Modifier.height(12.dp))
+                        SettingSwitch(
+                            label = columnLabel(column),
+                            checked = column !in config.hiddenColumns,
+                            onCheckedChange = { visible ->
+                                val hidden =
+                                    if (visible) {
+                                        config.hiddenColumns - column
+                                    } else {
+                                        config.hiddenColumns + column
+                                    }
+                                onConfigChange(config.copy(hiddenColumns = hidden))
+                            },
+                        )
+                    }
                 }
 
                 // Advanced Section
@@ -252,6 +296,19 @@ fun SettingsSidebar(
         }
     }
 }
+
+/** Data columns the user may hide; utility columns are excluded on purpose. */
+private val hideablePersonColumns =
+    PersonColumn.entries.filterNot {
+        it == PersonColumn.SELECTION || it == PersonColumn.EXPAND
+    }
+
+/** "HIRE_DATE" -> "Hire date": enum names are already the labels, just not dressed for UI. */
+private fun columnLabel(column: PersonColumn): String =
+    column.name
+        .lowercase()
+        .replace('_', ' ')
+        .replaceFirstChar { it.titlecase() }
 
 /** A switch control for settings with label. */
 @Composable

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/column/TableColumns.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/column/TableColumns.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.format
 import ua.wwind.table.ColumnSpec
@@ -43,6 +44,7 @@ import ua.wwind.table.component.TableCellTextField
 import ua.wwind.table.component.TableCellTextFieldWithTooltipError
 import ua.wwind.table.draggableHandle
 import ua.wwind.table.editableTableColumns
+import ua.wwind.table.isRowBlockLeader
 import ua.wwind.table.sample.config.CellPadding
 import ua.wwind.table.sample.filter.createSalaryRangeFilter
 import ua.wwind.table.sample.filter.filterTypes
@@ -61,8 +63,9 @@ fun createTableColumns(
     onEvent: (SampleUiEvent) -> Unit,
     useCompactMode: Boolean = false,
     enableRowReorder: Boolean = false,
-): ImmutableList<ColumnSpec<Person, PersonColumn, PersonTableData>> =
-    editableTableColumns {
+    hiddenColumns: Set<PersonColumn> = emptySet(),
+): ImmutableList<ColumnSpec<Person, PersonColumn, PersonTableData>> {
+    val specs: ImmutableList<ColumnSpec<Person, PersonColumn, PersonTableData>> = editableTableColumns {
         val cellPadding = if (useCompactMode) CellPadding.compact else CellPadding.standard
         val checkboxSize = if (useCompactMode) 36.dp else 48.dp
 
@@ -85,15 +88,20 @@ fun createTableColumns(
                         )
                     }
                 } else if (enableRowReorder) {
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier = Modifier.fillMaxSize().draggableHandle(),
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Reorder,
-                            contentDescription = "Drag to reorder",
-                            modifier = Modifier.size(24.dp),
-                        )
+                    // The table already knows its unit boundaries: leaders (first visible row of
+                    // a block, every standalone row) carry the handle. Replaces the v1 O(n)
+                    // per-cell leader search over the displayed list.
+                    if (isRowBlockLeader) {
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier.fillMaxSize().draggableHandle(),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Reorder,
+                                contentDescription = "Drag to reorder",
+                                modifier = Modifier.size(24.dp),
+                            )
+                        }
                     }
                 }
             }
@@ -152,7 +160,11 @@ fun createTableColumns(
             autoWidth(500.dp)
             sortable()
             filterTypes[PersonColumn.NAME]?.let { filter(it) }
-            cell { item, _ -> Text(item.name, modifier = Modifier.padding(cellPadding)) }
+            cell { item, _ ->
+                // Group metadata belongs in the block's header band, not in a row cell — see
+                // the `blockHeader` slot of the `RowBlocks` built in SampleApp.
+                Text(item.name, modifier = Modifier.padding(cellPadding))
+            }
 
             // Editing configuration - table will manage when to show this
             editCell { person, tableData, onComplete ->
@@ -465,6 +477,15 @@ fun createTableColumns(
         }
     }
 
+    // Visibility is a ColumnSpec property, so the sidebar toggle rebuilds the spec list instead of
+    // mutating table state — exercising ColumnSpec.visible end to end.
+    return if (hiddenColumns.isEmpty()) {
+        specs
+    } else {
+        specs.map { spec -> spec.copy(visible = spec.key !in hiddenColumns) }.toImmutableList()
+    }
+}
+
 fun createMovementColumns(
     useCompactMode: Boolean = false,
     enableRowReorder: Boolean = false,
@@ -478,7 +499,9 @@ fun createMovementColumns(
             width(reorderSize, reorderSize)
             resizable(false)
             cell { _, _ ->
-                if (enableRowReorder) {
+                // Same leader rule as the main table: with year blocks on, only the first row of
+                // a block carries the handle; without blocks every row is its own drag unit.
+                if (enableRowReorder && isRowBlockLeader) {
                     Box(
                         contentAlignment = Alignment.Center,
                         modifier = Modifier.fillMaxSize().draggableHandle(),

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/column/TableColumns.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/column/TableColumns.kt
@@ -44,7 +44,6 @@ import ua.wwind.table.component.TableCellTextField
 import ua.wwind.table.component.TableCellTextFieldWithTooltipError
 import ua.wwind.table.draggableHandle
 import ua.wwind.table.editableTableColumns
-import ua.wwind.table.isRowBlockLeader
 import ua.wwind.table.sample.config.CellPadding
 import ua.wwind.table.sample.filter.createSalaryRangeFilter
 import ua.wwind.table.sample.filter.filterTypes
@@ -88,20 +87,17 @@ fun createTableColumns(
                         )
                     }
                 } else if (enableRowReorder) {
-                    // The table already knows its unit boundaries: leaders (first visible row of
-                    // a block, every standalone row) carry the handle. Replaces the v1 O(n)
-                    // per-cell leader search over the displayed list.
-                    if (isRowBlockLeader) {
-                        Box(
-                            contentAlignment = Alignment.Center,
-                            modifier = Modifier.fillMaxSize().draggableHandle(),
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Reorder,
-                                contentDescription = "Drag to reorder",
-                                modifier = Modifier.size(24.dp),
-                            )
-                        }
+                    // Every row carries a handle: a standalone row reorders among units, a block row
+                    // reorders within its block. The whole block is dragged from its header handle.
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier.fillMaxSize().draggableHandle(),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Reorder,
+                            contentDescription = "Drag to reorder",
+                            modifier = Modifier.size(24.dp),
+                        )
                     }
                 }
             }
@@ -499,9 +495,9 @@ fun createMovementColumns(
             width(reorderSize, reorderSize)
             resizable(false)
             cell { _, _ ->
-                // Same leader rule as the main table: with year blocks on, only the first row of
-                // a block carries the handle; without blocks every row is its own drag unit.
-                if (enableRowReorder && isRowBlockLeader) {
+                // Same model as the main table: every row carries a handle. A block row reorders
+                // within its block; the whole block moves from its header handle.
+                if (enableRowReorder) {
                     Box(
                         contentAlignment = Alignment.Center,
                         modifier = Modifier.fillMaxSize().draggableHandle(),

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/data/DemoData.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/data/DemoData.kt
@@ -33,6 +33,7 @@ fun createDemoData(): List<Person> =
             salary = 68000,
             rating = 4,
             hireDate = LocalDate(2018, 7, 20),
+            groupId = "team-alpha",
         ),
         Person(
             name = "Carol",
@@ -47,6 +48,7 @@ fun createDemoData(): List<Person> =
             salary = 82000,
             rating = 5,
             hireDate = LocalDate(2020, 1, 10),
+            groupId = "team-alpha",
         ),
         Person(
             name = "Dave",
@@ -61,6 +63,7 @@ fun createDemoData(): List<Person> =
             salary = 95000,
             rating = 4,
             hireDate = LocalDate(2015, 9, 5),
+            groupId = "team-alpha",
         ),
         Person(
             name = "Eve",
@@ -103,6 +106,7 @@ fun createDemoData(): List<Person> =
             salary = 72000,
             rating = 4,
             hireDate = LocalDate(2021, 2, 14),
+            groupId = "team-beta",
         ),
         Person(
             name = "Henry",
@@ -117,6 +121,7 @@ fun createDemoData(): List<Person> =
             salary = 79000,
             rating = 3,
             hireDate = LocalDate(2019, 11, 8),
+            groupId = "team-beta",
         ),
         Person(
             name = "Ivy",

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/model/Person.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/model/Person.kt
@@ -20,6 +20,8 @@ data class Person(
     val salary: Int,
     val rating: Int,
     val hireDate: LocalDate,
+    /** Demo grouping: adjacent people sharing a non-null id drag as one unit. */
+    val groupId: String? = null,
     /** Multiline notes to demonstrate dynamic row height in table. */
     val notes: String =
         when {

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/model/PersonMovement.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/model/PersonMovement.kt
@@ -9,6 +9,13 @@ data class PersonMovement(
     val toPosition: Position,
 )
 
+/**
+ * Block identity for the embedded movements demo: adjacent same-year movements render and drag as
+ * one unit. Declared once so the table's `blockOf` and the ViewModel's lift stay the same rule —
+ * they MUST agree, or a committed move would relocate a different set of rows than was dragged.
+ */
+val PersonMovement.movementBlockId: Int get() = date.year
+
 /** Columns for the embedded movements table. */
 enum class PersonMovementColumn {
     REORDER,

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/util/PersonSorter.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/util/PersonSorter.kt
@@ -10,89 +10,44 @@ import ua.wwind.table.state.SortState
  */
 object PersonSorter {
     /**
-     * Apply sorting to a list of persons based on the sort state.
+     * The ordering rule as a comparator rather than a sorted list, because the within-blocks sort
+     * demo feeds it to `sortedWithinRowBlocks` while the free-sort path plain-sorts with it.
+     * Returns null when [sort] is absent or the column has no ordering.
      */
-    fun sortPeople(
-        people: List<Person>,
-        sort: SortState<PersonColumn>?,
-    ): List<Person> {
-        if (sort == null) {
-            return people
-        }
+    fun comparatorFor(sort: SortState<PersonColumn>?): Comparator<Person>? {
+        if (sort == null) return null
 
-        val sortedList =
+        val comparator: Comparator<Person> =
             when (sort.column) {
-                PersonColumn.NAME -> {
-                    people.sortedBy { it.name.lowercase() }
-                }
-
-                PersonColumn.AGE -> {
-                    people.sortedBy { it.age }
-                }
-
-                PersonColumn.ACTIVE -> {
-                    people.sortedBy { it.active }
-                }
-
-                PersonColumn.ID -> {
-                    people.sortedBy { it.id }
-                }
-
-                PersonColumn.EMAIL -> {
-                    people.sortedBy { it.email.orEmpty().lowercase() }
-                }
-
-                PersonColumn.CITY -> {
-                    people.sortedBy { it.city.lowercase() }
-                }
-
-                PersonColumn.COUNTRY -> {
-                    people.sortedBy { it.country.lowercase() }
-                }
-
-                PersonColumn.DEPARTMENT -> {
-                    people.sortedBy { it.department.lowercase() }
-                }
-
-                PersonColumn.POSITION -> {
-                    people.sortedBy { it.position.name }
-                }
-
-                PersonColumn.SALARY -> {
-                    people.sortedBy { it.salary }
-                }
-
-                PersonColumn.RATING -> {
-                    people.sortedBy { it.rating }
-                }
-
-                PersonColumn.HIRE_DATE -> {
-                    people.sortedBy { it.hireDate }
-                }
-
-                PersonColumn.NOTES -> {
-                    people.sortedBy { it.notes.lowercase() }
-                }
-
-                PersonColumn.AGE_GROUP -> {
-                    people.sortedBy {
+                PersonColumn.NAME -> compareBy { it.name.lowercase() }
+                PersonColumn.AGE -> compareBy { it.age }
+                PersonColumn.ACTIVE -> compareBy { it.active }
+                PersonColumn.ID -> compareBy { it.id }
+                PersonColumn.EMAIL -> compareBy { it.email.orEmpty().lowercase() }
+                PersonColumn.CITY -> compareBy { it.city.lowercase() }
+                PersonColumn.COUNTRY -> compareBy { it.country.lowercase() }
+                PersonColumn.DEPARTMENT -> compareBy { it.department.lowercase() }
+                PersonColumn.POSITION -> compareBy { it.position.name }
+                PersonColumn.SALARY -> compareBy { it.salary }
+                PersonColumn.RATING -> compareBy { it.rating }
+                PersonColumn.HIRE_DATE -> compareBy { it.hireDate }
+                PersonColumn.NOTES -> compareBy { it.notes.lowercase() }
+                PersonColumn.AGE_GROUP ->
+                    compareBy {
                         when {
                             it.age < 25 -> 0
                             it.age < 35 -> 1
                             else -> 2
                         }
                     }
-                }
 
-                else -> {
-                    people
-                }
+                else -> return null
             }
 
         return if (sort.order == SortOrder.DESCENDING) {
-            sortedList.asReversed()
+            comparator.reversed()
         } else {
-            sortedList
+            comparator
         }
     }
 }

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/viewmodel/SampleUiEvent.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/viewmodel/SampleUiEvent.kt
@@ -1,5 +1,6 @@
 package ua.wwind.table.sample.viewmodel
 
+import ua.wwind.table.RowBlockMove
 import ua.wwind.table.sample.model.Person
 import ua.wwind.table.sample.model.Position
 
@@ -53,6 +54,18 @@ sealed class SampleUiEvent {
     /** Delete all selected persons */
     data object DeleteSelected : SampleUiEvent()
 
+    /** Pull the selected rows together and give them a shared group id. */
+    data object GroupSelected : SampleUiEvent()
+
+    /** Move the selected rows out of their groups, dropping them just below the block they left. */
+    data object UngroupSelected : SampleUiEvent()
+
+    /** Rename a group: every row carrying [groupId] gets [newGroupId] instead. */
+    data class RenameGroup(
+        val groupId: String,
+        val newGroupId: String,
+    ) : SampleUiEvent()
+
     /** Clear all selections */
     data object ClearSelection : SampleUiEvent()
 
@@ -60,6 +73,17 @@ sealed class SampleUiEvent {
     data class RowMove(
         val fromPersonId: Int,
         val toPersonId: Int,
+    ) : SampleUiEvent()
+
+    /** Apply a completed block-drag gesture to the master people list. */
+    data class BlockMove(
+        val move: RowBlockMove,
+    ) : SampleUiEvent()
+
+    /** Apply a completed block-drag gesture inside one person's embedded movements table. */
+    data class MovementBlockMove(
+        val personId: Int,
+        val move: RowBlockMove,
     ) : SampleUiEvent()
 
     /** Reorder embedded movement rows for a specific person by movement indices. */

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/viewmodel/SampleUiEvent.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/viewmodel/SampleUiEvent.kt
@@ -80,10 +80,21 @@ sealed class SampleUiEvent {
         val move: RowBlockMove,
     ) : SampleUiEvent()
 
+    /** Apply a completed within-block row-reorder gesture to the master people list. */
+    data class RowWithinBlockMove(
+        val move: ua.wwind.table.RowWithinBlockMove,
+    ) : SampleUiEvent()
+
     /** Apply a completed block-drag gesture inside one person's embedded movements table. */
     data class MovementBlockMove(
         val personId: Int,
         val move: RowBlockMove,
+    ) : SampleUiEvent()
+
+    /** Apply a within-block row-reorder inside one person's embedded movements table. */
+    data class MovementRowWithinBlockMove(
+        val personId: Int,
+        val move: ua.wwind.table.RowWithinBlockMove,
     ) : SampleUiEvent()
 
     /** Reorder embedded movement rows for a specific person by movement indices. */

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/viewmodel/SampleViewModel.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/viewmodel/SampleViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import ua.wwind.table.ExperimentalTableApi
 import ua.wwind.table.applyRowBlockMove
+import ua.wwind.table.applyRowReorderWithinBlock
 import ua.wwind.table.filter.data.TableFilterState
 import ua.wwind.table.format.FormatFilterData
 import ua.wwind.table.format.data.TableFormatRule
@@ -73,12 +74,9 @@ class SampleViewModel : ViewModel() {
             val comparator = PersonSorter.comparatorFor(sort)
             when {
                 comparator == null -> filtered
-                // A persistent render-time projection — the shape sortedWithinRowBlocks' KDoc
-                // forbids with drag enabled, because a live projection re-pins unit order after
-                // every committed move, making the move invisible. It is safe here ONLY because
-                // every move handler in onEvent clears currentSort once a move commits, which
-                // turns this branch back into the identity. Copying this projection without
-                // that sort-clear reintroduces the invisible-move bug.
+                // A live projection re-pins unit order after every committed move, hiding it. Safe
+                // ONLY because every move handler clears currentSort on commit — copy this without
+                // that clear and moves become invisible.
                 withinBlocks -> filtered.sortedWithinRowBlocks({ it.groupId }, comparator)
                 else -> filtered.sortedWith(comparator)
             }
@@ -363,14 +361,9 @@ class SampleViewModel : ViewModel() {
                     val anchor = currentPeople.indexOfFirst { it.id in ids }
                     if (anchor < 0) return@update currentPeople
 
-                    // The id IS the name, so the block is named after its leader - the topmost
-                    // selected row - and group ids are kept unique: a duplicate would make two
-                    // blocks one identity, renamed together yet still separate drag units unless
-                    // adjacent. A leader's name can collide, so it is suffixed until free.
-                    // Only rows staying OUTSIDE the new block can hold a name against it; the
-                    // selected ones are all about to take the new id, which is what lets two whole
-                    // groups merge back under the leader's plain name.
-                    // Derived from `currentPeople` alone, so a retried CAS attempt is harmless.
+                    // The id IS the name and must stay unique: a duplicate would fuse two blocks
+                    // into one identity. Only rows staying OUTSIDE the new block can hold a name
+                    // against it, which is what lets two whole groups merge under the leader's name.
                     val takenGroupIds =
                         currentPeople.filterNot { it.id in ids }.mapNotNull { it.groupId }.toSet()
                     val groupId = uniqueGroupId(currentPeople[anchor].name, takenGroupIds)
@@ -381,14 +374,10 @@ class SampleViewModel : ViewModel() {
                         currentPeople.filter { it.id in ids }.map { it.copy(groupId = groupId) }
                     val rest = currentPeople.filterNot { it.id in ids }
 
-                    // The anchor is the FIRST selected index, so every row before it is unselected
-                    // and survives in `rest` - the insertion point is still the anchor after the
-                    // removal. Do not "fix" this by shifting it. Removing the selected rows is safe
-                    // on its own: it can only bring same-id rows closer, never split a run.
-                    // Never cut another group in half: if the insertion point lands between two rows
-                    // of the same group, push it past that group's last row. Splitting a run would
-                    // leave two blocks sharing one id - one logical group torn in two, which renames
-                    // together but drags apart.
+                    // The anchor is the FIRST selected index, so rows before it survive in `rest` and
+                    // it still points at the right slot after the removal — do not "fix" it by
+                    // shifting. Push past a group it would cut: a split run leaves two blocks sharing
+                    // one id.
                     var insertAt = anchor.coerceAtMost(rest.size)
                     while (
                         insertAt > 0 && insertAt < rest.size &&
@@ -418,12 +407,9 @@ class SampleViewModel : ViewModel() {
                         currentPeople.filter { it.id in ids }.mapNotNull { it.groupId }.toSet()
                     if (touchedGroupIds.isEmpty()) return@update currentPeople
 
-                    // A row leaving a group must leave the block as well. Blocks form only over
-                    // ADJACENT rows, so merely clearing the id of a row in the middle of the run
-                    // tears the block into two halves that BOTH keep the group's id - one name, two
-                    // drag units, exactly the duplicate the uniqueness invariant forbids. Dropping
-                    // the leavers just past the group's last row keeps the rows that stay
-                    // contiguous, so the group survives whole under its own id.
+                    // Clearing the id of a row mid-run would tear the block into two halves that both
+                    // keep the group's id. Dropping leavers past the group's last row keeps the rows
+                    // that stay contiguous.
                     val lastIndexOfGroup =
                         touchedGroupIds.associateWith { groupId ->
                             currentPeople.indexOfLast { it.groupId == groupId }
@@ -440,10 +426,8 @@ class SampleViewModel : ViewModel() {
                             } else {
                                 add(person)
                             }
-                            // Flushed once the run is over, so the leavers land right under what is
-                            // left of the block - and back in their own place when the whole group
-                            // left and there is no block any more. Relative order is preserved
-                            // because they were collected in list order.
+                            // Flushed once the run is over, so leavers land under what is left of the
+                            // block, keeping their relative order.
                             if (groupId != null && lastIndexOfGroup[groupId] == index) {
                                 leavers.remove(groupId)?.let { addAll(it) }
                             }
@@ -458,18 +442,13 @@ class SampleViewModel : ViewModel() {
 
             is SampleUiEvent.RenameGroup -> {
                 val newGroupId = event.newGroupId
-                // A blank id still groups - block derivation only skips nulls - so it would not
-                // ungroup the block, just leave it with a nameless band. Checked ahead of the uniqueness
-                // guard below, which would only catch the SECOND blank name, not the first.
-                // A no-op rename would rewrite every row for nothing.
+                // A blank id still groups (derivation only skips nulls), so it would leave a nameless
+                // band rather than ungroup.
                 if (newGroupId.isBlank() || newGroupId == event.groupId) return
                 // Rows keep their position: renaming must never reorder, so no sort reset either.
                 _people.update { currentPeople ->
-                    // The id IS the name, so a taken name would fuse two groups into one identity:
-                    // both would rename together yet stay separate drag units unless adjacent.
-                    // The dialog already refuses taken names; this is the last line of defence, and
-                    // it bails out rather than half-applying. Any row already carrying `newGroupId`
-                    // is outside the renamed group - the equal-id case returned above.
+                    // Last line of defence behind the dialog: a taken name would fuse two groups into
+                    // one identity, so bail out rather than half-apply.
                     if (currentPeople.any { it.groupId == newGroupId }) return@update currentPeople
                     currentPeople.map {
                         if (it.groupId == event.groupId) it.copy(groupId = newGroupId) else it
@@ -510,10 +489,7 @@ class SampleViewModel : ViewModel() {
             is SampleUiEvent.BlockMove -> {
                 var moved = false
                 _people.update { currentPeople ->
-                    // The whole lift from the rendered view to the master list is the library
-                    // helper: it relocates every member of the dragged block — including rows a
-                    // filter hides — and never splits another block. keyOf mirrors the table's
-                    // rowKey, because the move's anchors are row keys.
+                    // keyOf must mirror the table's rowKey — the move's anchors are row keys.
                     val updated = currentPeople.toMutableList()
                     updated.applyRowBlockMove(
                         move = event.move,
@@ -525,10 +501,28 @@ class SampleViewModel : ViewModel() {
                     updated
                 }
                 if (moved) {
-                    // Load-bearing, not tidiness: displayedPeople keeps sortedWithinRowBlocks as
-                    // a live projection, which its KDoc allows only if drag history dissolves it.
-                    // This clear is that dissolution — without it the projection re-pins unit
-                    // order on the next emission and the move just committed becomes invisible.
+                    // Load-bearing, not tidiness: without this clear the live sort projection
+                    // re-pins unit order and the committed move becomes invisible.
+                    currentSort.value = null
+                }
+            }
+
+            is SampleUiEvent.RowWithinBlockMove -> {
+                var moved = false
+                _people.update { currentPeople ->
+                    // keyOf must mirror the table's rowKey — the move's anchors are row keys.
+                    val updated = currentPeople.toMutableList()
+                    updated.applyRowReorderWithinBlock(
+                        move = event.move,
+                        keyOf = { it.id.toString() },
+                        blockOf = { it.groupId },
+                    )
+                    moved = updated != currentPeople
+                    updated
+                }
+                if (moved) {
+                    // Same dissolution as BlockMove: drop the live within-block sort projection so
+                    // the order just committed is not re-pinned on the next emission.
                     currentSort.value = null
                 }
             }
@@ -543,6 +537,26 @@ class SampleViewModel : ViewModel() {
                     movements.applyRowBlockMove(
                         move = event.move,
                         // Mirrors the embedded table's rowKey and blockOf — see movementBlockId.
+                        keyOf = { it.date },
+                        blockOf = { it.movementBlockId },
+                    )
+                    if (movements == person.movements) return@update currentPeople
+
+                    currentPeople.toMutableList().apply {
+                        this[personIndex] = person.copy(movements = movements)
+                    }
+                }
+            }
+
+            is SampleUiEvent.MovementRowWithinBlockMove -> {
+                _people.update { currentPeople ->
+                    val personIndex = currentPeople.indexOfFirst { it.id == event.personId }
+                    if (personIndex < 0) return@update currentPeople
+
+                    val person = currentPeople[personIndex]
+                    val movements = person.movements.toMutableList()
+                    movements.applyRowReorderWithinBlock(
+                        move = event.move,
                         keyOf = { it.date },
                         blockOf = { it.movementBlockId },
                     )
@@ -584,9 +598,8 @@ class SampleViewModel : ViewModel() {
     }
 
     /**
-     * First free name in the sequence [base], "[base] 2", "[base] 3"... Deterministic on purpose:
-     * the id doubles as the label, so a random or timestamped suffix would be unique but unreadable.
-     * Comparison is exact, matching the block identity rule (`blockOf` values compare with `==`).
+     * First free name in the sequence [base], "[base] 2", "[base] 3"… Deterministic on purpose: the
+     * id doubles as the label, so a random suffix would be unique but unreadable.
      */
     private fun uniqueGroupId(
         base: String,

--- a/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/viewmodel/SampleViewModel.kt
+++ b/table-sample/src/commonMain/kotlin/ua/wwind/table/sample/viewmodel/SampleViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import ua.wwind.table.ExperimentalTableApi
+import ua.wwind.table.applyRowBlockMove
 import ua.wwind.table.filter.data.TableFilterState
 import ua.wwind.table.format.FormatFilterData
 import ua.wwind.table.format.data.TableFormatRule
@@ -23,11 +24,13 @@ import ua.wwind.table.sample.filter.filterTypes
 import ua.wwind.table.sample.model.Person
 import ua.wwind.table.sample.model.PersonEditState
 import ua.wwind.table.sample.model.PersonTableData
+import ua.wwind.table.sample.model.movementBlockId
 import ua.wwind.table.sample.util.DefaultFormatRulesProvider
 import ua.wwind.table.sample.util.PersonFilterMatcher
 import ua.wwind.table.sample.util.PersonFilterStateFactory
 import ua.wwind.table.sample.util.PersonSorter
 import ua.wwind.table.sample.util.PersonValidator
+import ua.wwind.table.sortedWithinRowBlocks
 import ua.wwind.table.state.SortState
 
 @OptIn(ExperimentalTableApi::class)
@@ -43,13 +46,23 @@ class SampleViewModel : ViewModel() {
     // Current sort state
     private val currentSort = MutableStateFlow<SortState<PersonColumn>?>(null)
 
+    // Within-blocks sort demo: a free sort fragments blocks into duplicate bands, so this toggle
+    // routes the active sort through sortedWithinRowBlocks, which keeps every block whole.
+    private val _sortWithinBlocks = MutableStateFlow(false)
+    val sortWithinBlocks: StateFlow<Boolean> = _sortWithinBlocks.asStateFlow()
+
     // Selection state
     private val selectedIds = MutableStateFlow<Set<Int>>(emptySet())
     private val selectionModeEnabled = MutableStateFlow(false)
 
-    // Filtered and sorted people - derived from combining three StateFlows
+    // Filtered and sorted people - derived from combining the source list with view settings
     private val displayedPeople: StateFlow<List<Person>> =
-        combine(_people, currentFilters, currentSort) { peopleList, filters, sort ->
+        combine(
+            _people,
+            currentFilters,
+            currentSort,
+            _sortWithinBlocks,
+        ) { peopleList, filters, sort, withinBlocks ->
             // Apply filtering
             val filtered =
                 peopleList.filter { person ->
@@ -57,7 +70,18 @@ class SampleViewModel : ViewModel() {
                 }
 
             // Apply sorting
-            PersonSorter.sortPeople(filtered, sort)
+            val comparator = PersonSorter.comparatorFor(sort)
+            when {
+                comparator == null -> filtered
+                // A persistent render-time projection — the shape sortedWithinRowBlocks' KDoc
+                // forbids with drag enabled, because a live projection re-pins unit order after
+                // every committed move, making the move invisible. It is safe here ONLY because
+                // every move handler in onEvent clears currentSort once a move commits, which
+                // turns this branch back into the identity. Copying this projection without
+                // that sort-clear reintroduces the invisible-move bug.
+                withinBlocks -> filtered.sortedWithinRowBlocks({ it.groupId }, comparator)
+                else -> filtered.sortedWith(comparator)
+            }
         }.stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
@@ -85,6 +109,11 @@ class SampleViewModel : ViewModel() {
 
     // Dialog visibility
     var showFormatDialog by mutableStateOf(false)
+        private set
+
+    // Group whose name is being edited; null while the rename dialog is closed. The id doubles as
+    // the dialog's payload, so there is no "open but no target" state to get wrong.
+    var renamingGroupId by mutableStateOf<String?>(null)
         private set
 
     // Editing state as StateFlow for reactive composition
@@ -115,6 +144,11 @@ class SampleViewModel : ViewModel() {
     /** Toggle dialog visibility */
     fun toggleFormatDialog(show: Boolean) {
         showFormatDialog = show
+    }
+
+    /** Open the rename dialog for [groupId], or close it when null. */
+    fun setRenamingGroup(groupId: String?) {
+        renamingGroupId = groupId
     }
 
     /** Update formatting rules */
@@ -164,6 +198,11 @@ class SampleViewModel : ViewModel() {
     /** Update sort state - triggers automatic recalculation via StateFlow combination */
     fun updateSort(sort: SortState<PersonColumn>?) {
         currentSort.value = sort
+    }
+
+    /** Route the active sort through `sortedWithinRowBlocks` instead of a free (fragmenting) sort. */
+    fun setSortWithinBlocks(enabled: Boolean) {
+        _sortWithinBlocks.value = enabled
     }
 
     /** Toggle selection mode on or off */
@@ -316,6 +355,128 @@ class SampleViewModel : ViewModel() {
                 selectedIds.value = emptySet()
             }
 
+            is SampleUiEvent.GroupSelected -> {
+                val ids = selectedIds.value
+                if (ids.size < 2) return
+                var grouped = false
+                _people.update { currentPeople ->
+                    val anchor = currentPeople.indexOfFirst { it.id in ids }
+                    if (anchor < 0) return@update currentPeople
+
+                    // The id IS the name, so the block is named after its leader - the topmost
+                    // selected row - and group ids are kept unique: a duplicate would make two
+                    // blocks one identity, renamed together yet still separate drag units unless
+                    // adjacent. A leader's name can collide, so it is suffixed until free.
+                    // Only rows staying OUTSIDE the new block can hold a name against it; the
+                    // selected ones are all about to take the new id, which is what lets two whole
+                    // groups merge back under the leader's plain name.
+                    // Derived from `currentPeople` alone, so a retried CAS attempt is harmless.
+                    val takenGroupIds =
+                        currentPeople.filterNot { it.id in ids }.mapNotNull { it.groupId }.toSet()
+                    val groupId = uniqueGroupId(currentPeople[anchor].name, takenGroupIds)
+
+                    // A drag unit must be contiguous: blocks form over ADJACENT rows with equal
+                    // blockOf ids, so the rows are pulled together first and only then share an id.
+                    val block =
+                        currentPeople.filter { it.id in ids }.map { it.copy(groupId = groupId) }
+                    val rest = currentPeople.filterNot { it.id in ids }
+
+                    // The anchor is the FIRST selected index, so every row before it is unselected
+                    // and survives in `rest` - the insertion point is still the anchor after the
+                    // removal. Do not "fix" this by shifting it. Removing the selected rows is safe
+                    // on its own: it can only bring same-id rows closer, never split a run.
+                    // Never cut another group in half: if the insertion point lands between two rows
+                    // of the same group, push it past that group's last row. Splitting a run would
+                    // leave two blocks sharing one id - one logical group torn in two, which renames
+                    // together but drags apart.
+                    var insertAt = anchor.coerceAtMost(rest.size)
+                    while (
+                        insertAt > 0 && insertAt < rest.size &&
+                        rest[insertAt - 1].groupId != null &&
+                        rest[insertAt - 1].groupId == rest[insertAt].groupId
+                    ) {
+                        insertAt++
+                    }
+
+                    grouped = true
+                    rest.toMutableList().apply { addAll(insertAt, block) }
+                }
+                if (grouped) {
+                    // Grouping reorders rows, so a stale sort would fight the new order.
+                    currentSort.value = null
+                }
+            }
+
+            is SampleUiEvent.UngroupSelected -> {
+                val ids = selectedIds.value
+                if (ids.isEmpty()) return
+                var ungrouped = false
+                _people.update { currentPeople ->
+                    // Only a row that is IN a group can leave one: a selected row without a group
+                    // keeps both its null id and its place.
+                    val touchedGroupIds =
+                        currentPeople.filter { it.id in ids }.mapNotNull { it.groupId }.toSet()
+                    if (touchedGroupIds.isEmpty()) return@update currentPeople
+
+                    // A row leaving a group must leave the block as well. Blocks form only over
+                    // ADJACENT rows, so merely clearing the id of a row in the middle of the run
+                    // tears the block into two halves that BOTH keep the group's id - one name, two
+                    // drag units, exactly the duplicate the uniqueness invariant forbids. Dropping
+                    // the leavers just past the group's last row keeps the rows that stay
+                    // contiguous, so the group survives whole under its own id.
+                    val lastIndexOfGroup =
+                        touchedGroupIds.associateWith { groupId ->
+                            currentPeople.indexOfLast { it.groupId == groupId }
+                        }
+                    val leavers = mutableMapOf<String, MutableList<Person>>()
+
+                    ungrouped = true
+                    buildList {
+                        currentPeople.forEachIndexed { index, person ->
+                            val groupId = person.groupId
+                            if (groupId != null && person.id in ids) {
+                                leavers.getOrPut(groupId) { mutableListOf() } +=
+                                    person.copy(groupId = null)
+                            } else {
+                                add(person)
+                            }
+                            // Flushed once the run is over, so the leavers land right under what is
+                            // left of the block - and back in their own place when the whole group
+                            // left and there is no block any more. Relative order is preserved
+                            // because they were collected in list order.
+                            if (groupId != null && lastIndexOfGroup[groupId] == index) {
+                                leavers.remove(groupId)?.let { addAll(it) }
+                            }
+                        }
+                    }
+                }
+                if (ungrouped) {
+                    // Ungrouping reorders rows, so a stale sort would fight the new order.
+                    currentSort.value = null
+                }
+            }
+
+            is SampleUiEvent.RenameGroup -> {
+                val newGroupId = event.newGroupId
+                // A blank id still groups - block derivation only skips nulls - so it would not
+                // ungroup the block, just leave it with a nameless band. Checked ahead of the uniqueness
+                // guard below, which would only catch the SECOND blank name, not the first.
+                // A no-op rename would rewrite every row for nothing.
+                if (newGroupId.isBlank() || newGroupId == event.groupId) return
+                // Rows keep their position: renaming must never reorder, so no sort reset either.
+                _people.update { currentPeople ->
+                    // The id IS the name, so a taken name would fuse two groups into one identity:
+                    // both would rename together yet stay separate drag units unless adjacent.
+                    // The dialog already refuses taken names; this is the last line of defence, and
+                    // it bails out rather than half-applying. Any row already carrying `newGroupId`
+                    // is outside the renamed group - the equal-id case returned above.
+                    if (currentPeople.any { it.groupId == newGroupId }) return@update currentPeople
+                    currentPeople.map {
+                        if (it.groupId == event.groupId) it.copy(groupId = newGroupId) else it
+                    }
+                }
+            }
+
             is SampleUiEvent.ClearSelection -> {
                 selectedIds.value = emptySet()
             }
@@ -339,7 +500,57 @@ class SampleViewModel : ViewModel() {
                     }
                 }
                 if (moved) {
+                    // Same invariant as BlockMove below: an active sort is a live projection over
+                    // the source, and any projection re-pins row order — the swap would commit to
+                    // the source yet never show. Clearing the sort keeps the reorder visible.
                     currentSort.value = null
+                }
+            }
+
+            is SampleUiEvent.BlockMove -> {
+                var moved = false
+                _people.update { currentPeople ->
+                    // The whole lift from the rendered view to the master list is the library
+                    // helper: it relocates every member of the dragged block — including rows a
+                    // filter hides — and never splits another block. keyOf mirrors the table's
+                    // rowKey, because the move's anchors are row keys.
+                    val updated = currentPeople.toMutableList()
+                    updated.applyRowBlockMove(
+                        move = event.move,
+                        keyOf = { it.id.toString() },
+                        blockOf = { it.groupId },
+                    )
+                    // applyRowBlockMove leaves the list untouched when no anchor resolves.
+                    moved = updated != currentPeople
+                    updated
+                }
+                if (moved) {
+                    // Load-bearing, not tidiness: displayedPeople keeps sortedWithinRowBlocks as
+                    // a live projection, which its KDoc allows only if drag history dissolves it.
+                    // This clear is that dissolution — without it the projection re-pins unit
+                    // order on the next emission and the move just committed becomes invisible.
+                    currentSort.value = null
+                }
+            }
+
+            is SampleUiEvent.MovementBlockMove -> {
+                _people.update { currentPeople ->
+                    val personIndex = currentPeople.indexOfFirst { it.id == event.personId }
+                    if (personIndex < 0) return@update currentPeople
+
+                    val person = currentPeople[personIndex]
+                    val movements = person.movements.toMutableList()
+                    movements.applyRowBlockMove(
+                        move = event.move,
+                        // Mirrors the embedded table's rowKey and blockOf — see movementBlockId.
+                        keyOf = { it.date },
+                        blockOf = { it.movementBlockId },
+                    )
+                    if (movements == person.movements) return@update currentPeople
+
+                    currentPeople.toMutableList().apply {
+                        this[personIndex] = person.copy(movements = movements)
+                    }
                 }
             }
 
@@ -370,5 +581,20 @@ class SampleViewModel : ViewModel() {
                 }
             }
         }
+    }
+
+    /**
+     * First free name in the sequence [base], "[base] 2", "[base] 3"... Deterministic on purpose:
+     * the id doubles as the label, so a random or timestamped suffix would be unique but unreadable.
+     * Comparison is exact, matching the block identity rule (`blockOf` values compare with `==`).
+     */
+    private fun uniqueGroupId(
+        base: String,
+        takenGroupIds: Set<String>,
+    ): String {
+        if (base !in takenGroupIds) return base
+        var suffix = 2
+        while ("$base $suffix" in takenGroupIds) suffix++
+        return "$base $suffix"
     }
 }


### PR DESCRIPTION
## Summary
Adjacent rows sharing an identity (`blockOf: (T) -> Any?`) render and drag as **one unit** behind a
single handle. The drag is library-managed: the consumer never mutates its list mid-gesture and gets
one `RowBlockMove` on drop. Ships as `1.11.0`, together with a table-width fix.

## Highlights
- `rowBlocks = RowBlocks(blockOf, onCommit, blockHeader)` on `Table`, `EditableTable` and `table-paging`.
- Declared by identity, not index ranges — nothing to keep in sync with an async list.
- `onCommit` receives one `RowBlockMove(blockId, movedKeys, afterKey, beforeKey)` in stable row keys
  (lazy and embedded identical). No `onCommit` → display-only, drag disabled.
- Helpers: `applyRowBlockMove` (moves the whole block, incl. filter-hidden rows),
  `sortedWithinRowBlocks`, `filteredWholeRowBlocks`.
- Paging: bands over loaded runs, drop policy for unloaded anchors, drag survives page loads.
- Theming: `rowBlockSpacing`, `rowBlockContainerColor`; `TableCellScope.isRowBlockLeader` gates the handle.

## Notes
- Mutually exclusive with `groupBy` (blocks suppressed + warning + `rowBlocksSuppressedByGroupBy`;
  group-by menu item disabled while blocks are present).
- Requires a stable `rowKey`; the default positional key logs a warning.
- `TableRowContext.isGroup` deprecated → `isInRowBlock` (forwarder kept).
- Also fixes: table width freezing when `ColumnSpec.visible` changes after first render.

Verified on the desktop sample (block drags as one unit, any speed, both directions); unit / property /
compose tests green. `1.11.0`.