### PR TITLE
Release 2.1.1: portable FormatDialogContent + within-block reorder fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+### 2.1.1 — 2026-07-23
+
+- Added: `FormatDialogContent` — the conditional-formatting editor as portable content, so it can be hosted in any
+  container (a custom dialog host, a side panel, a split pane) instead of only the built-in `AlertDialog`.
+  `FormatDialog` is unchanged; both reuse the same internal title, buttons and body blocks.
+- Added: `FormatDialogColors` and `FormatDialogDefaults.colors()` (defaulting to the Material3 `AlertDialog`
+  defaults), and a `colors` parameter on `FormatDialog` and `FormatDialogContent`. `FormatDialogContent` applies the
+  title and text content colors itself; the container owns background and elevation.
+- Fixed: reordering a row within a block stopped committing once the block had been moved as a whole. The nested
+  reorderable's `onSettle` captured a stale base offset, so the move mapped outside the block and was rejected; the
+  base offset is now read live.
+- Fixed: the Condition tab of the formatting dialog centered its field list vertically, leaving a gap under the
+  tabs when the list was shorter than the dialog; the list now top-aligns.
+
+Compare: [v2.1.0...v2.1.1](https://github.com/White-Wind-LLC/table/compare/v2.1.0...v2.1.1)
+
 ### 2.1.0 — 2026-07-22
 
 `TableState` splits into state holders. It had grown to carry four unrelated jobs at once, and the detekt debt

--- a/docs/content/modules/table-format.md
+++ b/docs/content/modules/table-format.md
@@ -39,12 +39,40 @@ FormatDialog(
     getNewRule = { id -> TableFormatRule.new<PersonField, Person>(id, Person("", 0)) },
     getTitle = { field -> field.name },
     filters = { rule, onApply -> /* return list of FormatFilterData for fields */ emptyList() },
-    entries = PersonField.entries,
+    entries = PersonField.entries.toImmutableList(),
     key = Unit,
     strings = DefaultStrings,
     onDismissRequest = { /* ... */ },
 )
 ```
+
+## Hosting the editor in your own container
+
+`FormatDialog` renders the editor inside a Material3 `AlertDialog`. To host the same UI in your own container — a
+custom dialog wrapper, a side panel, a split pane — use `FormatDialogContent`, which renders the editor without a
+dialog. The container owns visibility, scrim, background and elevation; the content applies only its title/text
+colors. Give it a bounded‑height parent (the rule list scrolls inside), and pass `onDismissRequest = null` to hide
+the close button for embedded, non‑modal placements.
+
+```kotlin
+MyAdaptiveDialogHost(visible = show, onDismissRequest = { show = false }) {
+    FormatDialogContent(
+        rules = rules,
+        onRulesChange = { /* persist */ },
+        getNewRule = { id -> TableFormatRule.new<PersonField, Person>(id, Person("", 0)) },
+        getTitle = { it.name },
+        filters = { rule, onApply -> emptyList() },
+        entries = PersonField.entries.toImmutableList(),
+        key = Unit,
+        strings = DefaultStrings,
+        onDismissRequest = { show = false },
+    )
+}
+```
+
+Colors for both `FormatDialog` and `FormatDialogContent` come from `FormatDialogColors`, defaulting to
+`FormatDialogDefaults.colors()` (the Material3 `AlertDialog` defaults). `FormatDialogContent` applies the title and
+text content colors itself and leaves the container color and elevation to its parent.
 
 `rememberCustomization` merges base styles with matching rules into a resulting `TableCustomization` (background,
 content color, text style, alignment, etc.).
@@ -126,7 +154,7 @@ FormatDialog(
     getNewRule = { id -> TableFormatRule.new<PersonField, Person>(id, Person("", 0)) },
     getTitle = { it.name },
     filters = { rule, onApply -> emptyList() }, // build `FormatFilterData` list for your fields
-    entries = PersonField.values().toList(),
+    entries = PersonField.entries.toImmutableList(),
     key = Unit,
     strings = DefaultStrings,
     onDismissRequest = { show = false }
@@ -138,6 +166,8 @@ Public API highlights:
 - `rememberCustomization<T, C, FILTER>(rules, matches = ...) : TableCustomization<T, C>`.
 - `TableFormatRule<FIELD, FILTER>` with `columns: List<FIELD>`, `cellStyle: TableCellStyleConfig`, `filter: FILTER`.
 - `FormatDialog(...)` and `FormatDialogSettings` for UX tweaks.
+- `FormatDialogContent(...)` to host the same rule editor in any container (a dialog host, side panel, split pane).
+- `FormatDialogColors` / `FormatDialogDefaults.colors()` for dialog/content colors, via a `colors` parameter on both.
 - `FormatFilterData<E>` to describe per‑field filter controls in the dialog.
 - `FilterConstraint.isNullCheck()` extension function to check for IS_NULL/IS_NOT_NULL constraints.
 - `TableFilterState.isActive()` extension function to determine if a filter is active.

--- a/docs/superpowers/specs/2026-07-23-portable-format-dialog-content-design.md
+++ b/docs/superpowers/specs/2026-07-23-portable-format-dialog-content-design.md
@@ -1,0 +1,196 @@
+# Portable Format-Dialog Content — Design
+
+## Goal
+
+Expose the conditional-formatting UI as a **portable content composable** so a consumer can host it in any
+container it chooses — an adaptive dialog host, a side panel, a split pane — instead of only the built-in
+`AlertDialog`. Alongside it, expose explicit **color parameters** so the content themes correctly outside an
+`AlertDialog`. The existing `FormatDialog` stays source-compatible (the new `colors` parameter is optional and appended last).
+
+## Motivation
+
+`FormatDialog` hard-codes a Material3 `AlertDialog`. Two limitations follow:
+
+1. An application that wraps its dialogs in a custom host (window-derived sizing, corner resize,
+   dismiss-on-navigation, a house dialog shape) cannot apply that host to `FormatDialog`. The formatting dialog
+   then visibly diverges from every other dialog in that application.
+2. The formatting UI cannot be embedded anywhere but a modal — a side panel or a master/detail pane is impossible.
+
+There is also a hidden coupling: because the UI renders inside `AlertDialog`'s `title` / `text` slots, it silently
+relies on `AlertDialog` to inject `titleContentColor` / `textContentColor`. Those must become explicit for the
+content to render correctly in a bare container.
+
+## Non-goals
+
+- Restyling the nested `ColorPickerDialog` (a modal opened deep inside the design tab). Its call site is not
+  reachable by a consumer, so it needs an injected dialog-host renderer rather than content extraction — a
+  separate change (see [Out of scope](#out-of-scope)).
+- Any change to `FormatDialogSettings` (stays the behavior / highlight value holder).
+- Any change to `FormatDialog`'s default rendering.
+
+## Approach
+
+The three `AlertDialog` slots in `FormatDialog` (`title`, `confirmButton`, `text`) are three projections of one
+small state machine: `editItem` (list mode vs edit mode), `itemCopyIndex`, `lazyListState`. Everything else
+(`rulesState`, `currentTab`, reorderable state, the debounce effect) is local to the body.
+
+Extract those three projections into **internal blocks that share a small internal state holder**, then reuse the
+blocks from two public entry points:
+
+- `FormatDialog` — unchanged public shape; wires the blocks into an `AlertDialog`. Same container, same look;
+  existing consumers untouched.
+- `FormatDialogContent` — new; lays the same blocks out itself and lets the consumer supply the container.
+
+Both entry points reuse identical blocks, so there is no duplication and no drift. `FormatDialog` keeps its
+`AlertDialog`, so back-compat is total.
+
+## Public API
+
+### Colors
+
+Mirrors the existing `TableColors` / `TableDefaults.colors()` convention.
+
+```kotlin
+@Immutable
+public data class FormatDialogColors(
+    val containerColor: Color,
+    val titleContentColor: Color,
+    val textContentColor: Color,
+    val tonalElevation: Dp,
+)
+
+public object FormatDialogDefaults {
+    @Composable
+    public fun colors(
+        containerColor: Color = AlertDialogDefaults.containerColor,
+        titleContentColor: Color = AlertDialogDefaults.titleContentColor,
+        textContentColor: Color = AlertDialogDefaults.textContentColor,
+        tonalElevation: Dp = AlertDialogDefaults.TonalElevation,
+    ): FormatDialogColors = FormatDialogColors(containerColor, titleContentColor, textContentColor, tonalElevation)
+}
+```
+
+No `iconContentColor`: the formatting dialog has no icon slot; it would be a dead field (add later if a title icon
+is introduced).
+
+### `FormatDialogContent`
+
+```kotlin
+@Composable
+public fun <E : Enum<E>, FILTER> FormatDialogContent(
+    rules: ImmutableList<TableFormatRule<E, FILTER>>,
+    onRulesChange: (ImmutableList<TableFormatRule<E, FILTER>>) -> Unit,
+    getNewRule: (id: Long) -> TableFormatRule<E, FILTER>,
+    getTitle: @Composable (E) -> String,
+    filters: (TableFormatRule<E, FILTER>, onApply: (TableFormatRule<E, FILTER>) -> Unit) -> List<FormatFilterData<E>>,
+    entries: ImmutableList<E>,
+    key: Any,
+    strings: StringProvider,
+    modifier: Modifier = Modifier,
+    onDismissRequest: (() -> Unit)? = null,
+    colors: FormatDialogColors = FormatDialogDefaults.colors(),
+    settings: FormatDialogSettings = FormatDialogSettings(),
+    scrollbarRenderer: VerticalScrollbarRenderer? = null,
+)
+```
+
+- No `showDialog`, no `DialogProperties`: visibility and scrim belong to the container the consumer chooses.
+- `onDismissRequest = null` hides the close "X" (title X and edit-mode close) — for embedded / in-panel use where
+  "dismiss" is meaningless.
+- Consumes only the **content** colors (`titleContentColor`, `textContentColor`). `containerColor` /
+  `tonalElevation` are ignored here — the background and elevation belong to the parent container. KDoc states it.
+- Fills the space its parent gives and scrolls internally; the parent must provide a **bounded height**. KDoc
+  states it.
+
+Layout:
+
+```
+Column(modifier.fillMaxSize()) {
+    FormatDialogTitle(...)                              // pinned top, titleContentColor
+    HorizontalDivider()
+    CompositionLocalProvider(LocalContentColor provides colors.textContentColor) {
+        FormatDialogBody(Modifier.weight(1f).fillMaxWidth(), ...)   // scrolls
+    }
+    Row(Modifier.fillMaxWidth().padding(...), Arrangement.End) { FormatDialogButtons(...) }  // bottom bar
+}
+```
+
+### `FormatDialog` (additive only)
+
+Add `colors: FormatDialogColors = FormatDialogDefaults.colors()` as a new optional parameter; the rest of the
+public signature is unchanged. Internally rewritten to create the shared state and wire the blocks into
+`AlertDialog`'s `title` / `confirmButton` / `text` slots, passing `colors` into the corresponding `AlertDialog`
+color parameters. With defaults equal to `AlertDialogDefaults`, the rendered result is identical to today.
+
+## Content / container ownership
+
+| Concern | `FormatDialog` | `FormatDialogContent` |
+| --- | --- | --- |
+| Visibility / scrim | own (`showDialog` + `AlertDialog`) | container's |
+| Background + elevation | own `AlertDialog` (`containerColor`, `tonalElevation`) | container's (fields ignored) |
+| Title / text content color | applied by blocks | applied by blocks |
+| Size / resize / dismiss behavior | `AlertDialog` | container's |
+
+## Internal units
+
+- `FormatDialogState` (internal) — holds `editItem`, `itemCopyIndex`, `lazyListState`; created by a
+  `@Composable internal fun rememberFormatDialogState(settings, key)` that also runs the copy-scroll
+  `LaunchedEffect(itemCopyIndex)`. Both entry points create it identically.
+- `FormatDialogTitle` (internal) — title Row; renders the "X" only when `editItem == null` **and** a close
+  callback is present; applies `titleContentColor` explicitly (no reliance on an outer `AlertDialog`).
+- `FormatDialogButtons` (internal) — FAB "add" in list mode; save / delete / copy / close Row in edit mode;
+  operates on the `rules` param + `onRulesChange` + `getNewRule` (unchanged logic).
+- `FormatDialogBody` (internal, takes `modifier`) — list ↔ edit form; owns `rulesState`, `currentTab`, the
+  reorderable state and the debounce effect (unchanged logic, relocated).
+
+The three tab panels (`FormatDialogDesignTab`, `FormatDialogConditionTab`, `FormatDialogFieldTab`) are unchanged —
+they already communicate only through `item` / `onChange` and hold no cross-block state.
+
+## Backward compatibility
+
+- `FormatDialog`'s public signature changes only by gaining one optional `colors` parameter with a default equal
+  to today's implicit `AlertDialog` styling. Existing call sites compile and render unchanged.
+- The sample is untouched.
+- New public types (`FormatDialogColors`, `FormatDialogDefaults`, `FormatDialogContent`) are purely additive.
+
+## Consumer adoption
+
+A consumer that wants the formatting UI inside its own dialog host or an embedded region:
+
+1. Depend on the release that ships this (2.1.1).
+2. Replace the direct `FormatDialog(showDialog = …, …)` call with its own container gated on the same visibility
+   flag, hosting `FormatDialogContent(…)` inside. Pass the container's dismiss callback as `onDismissRequest`.
+3. For an embedded (non-modal) placement, pass `onDismissRequest = null` and give the content a bounded-height
+   parent.
+
+Default colors match `AlertDialog`, so a consumer whose container already uses `AlertDialogDefaults` for its
+surface needs no color overrides.
+
+## Testing
+
+- `:table-format` compiles; `:table-core:jvmTest` and the `table-format` tests stay green.
+- New Compose UI test over `FormatDialogContent`: renders the rule list; entering edit mode and pressing save
+  round-trips through `onRulesChange`; the close "X" is absent when `onDismissRequest = null` and present
+  otherwise.
+- Run the sample to confirm the default `FormatDialog` is visually unchanged.
+
+## Release
+
+- Ships in `2.1.1` from `main`, bundled with the pending within-block drag fix.
+- Additive API → minor/patch, no breaking change.
+- Kotlin toolchain unchanged (2.4.10), so consumers on the current line upgrade without a toolchain bump.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| `FormatDialogContent` self-layout: the body `LazyColumn` needs a bounded height via `weight(1f)`; an unbounded parent breaks it | KDoc the bounded-parent contract; the risk is isolated to the new path and cannot regress `FormatDialog` |
+| Content colors drift from `AlertDialog` in the content path | Colors are explicit (`FormatDialogColors`, defaults = `AlertDialogDefaults`); the blocks apply them, so both paths use one source |
+| The FAB "add" (list mode) sits in a bottom end-aligned row in the content path rather than `AlertDialog`'s action area | Matches `AlertDialog`'s `confirmButton` placement; verified against the default path in the sample |
+
+## Out of scope
+
+The nested `ColorPickerDialog` keeps its own chrome. It is opened deep inside the design tab, so content extraction
+does not fit. A future change can add an injected `DialogHostRenderer` (a fun-interface renderer threaded like
+`scrollbarRenderer`) that the library uses to wrap the picker, with the consumer supplying its own host. Additive,
+non-breaking, separate.

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/RowUnit.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/RowUnit.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
@@ -155,10 +156,12 @@ internal fun <T : Any, C, E> RowUnit(
         if (onRowMoveWithinBlock != null) {
             // Embedded-style: onSettle reports the net move at drop, so the settle applies once.
             val blockItems = EmbeddedUnitList(rows.map { itemAt(it) }, withinBlockRefusalCount)
+            // Read live: ReorderableColumn freezes onSettle, but a whole-block move shifts rows.first.
+            val blockBaseOffset = rememberUpdatedState(rows.first)
             ReorderableColumn(
                 list = blockItems,
                 onSettle = { fromLocal, toLocal ->
-                    onRowMoveWithinBlock(rows.first + fromLocal, rows.first + toLocal)
+                    onRowMoveWithinBlock(blockBaseOffset.value + fromLocal, blockBaseOffset.value + toLocal)
                 },
             ) { localIndex, _, _ ->
                 val rowIndex = rows.first + localIndex

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/RowBlocksWithinBlockDragTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/RowBlocksWithinBlockDragTest.kt
@@ -1,0 +1,214 @@
+package ua.wwind.table
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.collections.immutable.persistentListOf
+import ua.wwind.table.config.SelectionMode
+import ua.wwind.table.config.TableDefaults
+import ua.wwind.table.config.TableSettings
+import ua.wwind.table.state.rememberTableState
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class RowBlocksWithinBlockDragTest {
+    @Test
+    fun `within-block drag emits a within move`() =
+        runDragUiTest {
+            val withinMoves = mutableListOf<RowWithinBlockMove>()
+            setContent { WithinBlockTable(onWithinMove = { withinMoves += it }, onBlockMove = {}) }
+            waitForIdle()
+
+            dragHandleDown("handle-0")
+            waitForIdle()
+
+            assertThat(withinMoves.size).isEqualTo(1)
+            assertThat(withinMoves.single().movedKey).isEqualTo(0)
+        }
+
+    @Test
+    fun `within-block drag still emits after a whole-block move`() =
+        runDragUiTest {
+            val withinMoves = mutableListOf<RowWithinBlockMove>()
+            val blockMoves = mutableListOf<RowBlockMove>()
+            setContent { WithinBlockTable(onWithinMove = { withinMoves += it }, onBlockMove = { blockMoves += it }) }
+            waitForIdle()
+
+            // Drag the whole block past the standalone tail: it lands last, so its base view offset
+            // shifts from 0 to 3 while its members keep their internal order.
+            onNodeWithTag("block-handle-a", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(10) { moveBy(Offset(0f, 60f)) }
+                up()
+            }
+            waitForIdle()
+            assertThat(blockMoves.size).isEqualTo(1)
+
+            // A within-block drag must still reorder among the block's members after the block moved.
+            dragHandleDown("handle-0")
+            waitForIdle()
+
+            assertThat(withinMoves.size).isEqualTo(1)
+        }
+
+    @Test
+    fun `a list change during the within-block settle does not lose the move`() =
+        runDragUiTest {
+            val withinMoves = mutableListOf<RowWithinBlockMove>()
+            val itemsState =
+                mutableStateOf(
+                    listOf(
+                        BlockRow(0, "a"),
+                        BlockRow(1, "a"),
+                        BlockRow(2, "a"),
+                        BlockRow(3, null),
+                        BlockRow(4, null),
+                        BlockRow(5, null),
+                    ),
+                )
+            setContent {
+                val items by itemsState
+                WithinBlockTableHoisted(items = items, onWithinMove = { withinMoves += it })
+            }
+            waitForIdle()
+
+            // Park the settle at its drop animation, then land an SSE-style frame before it resolves:
+            // the frame reorders the standalone tail but keeps every row and key, exactly what the
+            // queue stream does mid-gesture. The move must survive the reconcile.
+            mainClock.autoAdvance = false
+            onNodeWithTag("handle-0", useUnmergedTree = true).performTouchInput {
+                down(center)
+                repeat(6) { moveBy(Offset(0f, 50f)) }
+                up()
+            }
+            mainClock.advanceTimeByFrame()
+            // The drop animation has not resolved yet, so the frame genuinely lands mid-settle.
+            assertThat(withinMoves.size).isEqualTo(0)
+            itemsState.value =
+                listOf(
+                    BlockRow(0, "a"),
+                    BlockRow(1, "a"),
+                    BlockRow(2, "a"),
+                    BlockRow(5, null),
+                    BlockRow(4, null),
+                    BlockRow(3, null),
+                )
+            mainClock.advanceTimeBy(2_000)
+            mainClock.autoAdvance = true
+            waitForIdle()
+
+            assertThat(withinMoves.size).isEqualTo(1)
+        }
+}
+
+@OptIn(ExperimentalTestApi::class)
+private fun ComposeUiTest.dragHandleDown(tag: String) {
+    onNodeWithTag(tag, useUnmergedTree = true).performTouchInput {
+        down(center)
+        repeat(6) { moveBy(Offset(0f, 50f)) }
+        up()
+    }
+}
+
+@Composable
+private fun WithinBlockTable(
+    onWithinMove: (RowWithinBlockMove) -> Unit,
+    onBlockMove: (RowBlockMove) -> Unit,
+) {
+    var items by remember {
+        mutableStateOf(
+            listOf(
+                BlockRow(0, "a"),
+                BlockRow(1, "a"),
+                BlockRow(2, "a"),
+                BlockRow(3, null),
+                BlockRow(4, null),
+                BlockRow(5, null),
+            ),
+        )
+    }
+    val columns = remember { blockColumns() }
+    val state =
+        rememberTableState(
+            columns = persistentListOf("handle", "name"),
+            settings = TableSettings(rowReorderEnabled = true, selectionMode = SelectionMode.Single),
+            dimensions = TableDefaults.compactDimensions(),
+        )
+    val blocks =
+        remember {
+            RowBlocks<BlockRow>(
+                blockOf = { it.block },
+                onCommit = { move ->
+                    onBlockMove(move)
+                    items =
+                        items.toMutableList().also {
+                            it.applyRowBlockMove(move, keyOf = { r -> r.id }, blockOf = { r -> r.block })
+                        }
+                },
+                onRowReorderWithinBlock = { move ->
+                    onWithinMove(move)
+                    items =
+                        items.toMutableList().also {
+                            it.applyRowReorderWithinBlock(move, keyOf = { r -> r.id }, blockOf = { r -> r.block })
+                        }
+                },
+                blockHeader = blockDragHeader,
+            )
+        }
+    Box(Modifier.size(400.dp, 640.dp)) {
+        Table(
+            itemsCount = items.size,
+            itemAt = { items.getOrNull(it) },
+            state = state,
+            columns = columns,
+            rowKey = stableRowKey,
+            rowBlocks = blocks,
+        )
+    }
+}
+
+@Composable
+private fun WithinBlockTableHoisted(
+    items: List<BlockRow>,
+    onWithinMove: (RowWithinBlockMove) -> Unit,
+) {
+    val columns = remember { blockColumns() }
+    val state =
+        rememberTableState(
+            columns = persistentListOf("handle", "name"),
+            settings = TableSettings(rowReorderEnabled = true, selectionMode = SelectionMode.Single),
+            dimensions = TableDefaults.compactDimensions(),
+        )
+    val blocks =
+        remember {
+            RowBlocks<BlockRow>(
+                blockOf = { it.block },
+                onCommit = {},
+                onRowReorderWithinBlock = { onWithinMove(it) },
+                blockHeader = blockDragHeader,
+            )
+        }
+    Box(Modifier.size(400.dp, 640.dp)) {
+        Table(
+            itemsCount = items.size,
+            itemAt = { items.getOrNull(it) },
+            state = state,
+            columns = columns,
+            rowKey = stableRowKey,
+            rowBlocks = blocks,
+        )
+    }
+}

--- a/table-format/build.gradle.kts
+++ b/table-format/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("ua.wwind.convention.kmp.target.all")
     id("ua.wwind.convention.compose")
     id("ua.wwind.convention.publishing")
+    id("ua.wwind.convention.test")
 }
 
 kotlin {
@@ -15,6 +16,12 @@ kotlin {
             implementation(libs.colorpicker)
             implementation(libs.reorderable)
             implementation(libs.kotlinx.datetime)
+        }
+        commonTest.dependencies {
+            implementation(libs.compose.ui.test)
+        }
+        jvmTest.dependencies {
+            implementation(compose.desktop.currentOs)
         }
     }
 }

--- a/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialog.kt
+++ b/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialog.kt
@@ -1,92 +1,21 @@
 package ua.wwind.table.format
 
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.Arrangement.SpaceBetween
-import androidx.compose.foundation.layout.Arrangement.spacedBy
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Add
-import androidx.compose.material.icons.rounded.Close
-import androidx.compose.material.icons.rounded.ContentCopy
-import androidx.compose.material.icons.rounded.Delete
-import androidx.compose.material.icons.rounded.DragIndicator
-import androidx.compose.material.icons.rounded.Save
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemDefaults
-import androidx.compose.material3.LocalTextStyle
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Tab
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.isUnspecified
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.mutate
-import kotlinx.collections.immutable.toImmutableList
-import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.drop
-import sh.calvin.reorderable.ReorderableItem
-import sh.calvin.reorderable.rememberReorderableLazyListState
-import ua.wwind.table.format.component.FormatDialogTabRow
-import ua.wwind.table.format.component.RuleTab
-import ua.wwind.table.format.component.TabData
-import ua.wwind.table.format.data.EditFormatRule
+import ua.wwind.table.format.component.rememberFormatDialogState
 import ua.wwind.table.format.data.FormatDialogSettings
 import ua.wwind.table.format.data.TableFormatRule
 import ua.wwind.table.format.scrollbar.VerticalScrollbarRenderer
-import ua.wwind.table.format.scrollbar.VerticalScrollbarState
 import ua.wwind.table.strings.StringProvider
-import ua.wwind.table.strings.UiString
-import kotlin.time.Duration.Companion.milliseconds
-
-// Rules are edited in place; wait for the edits to settle before reporting them upstream.
-private const val RULES_CHANGE_DEBOUNCE_MS = 1_000L
-
-// Above this perceived brightness a background takes black text, below it white.
-private const val LUMINANCE_THRESHOLD = 0.5
 
 /**
- * Nearly all of the complexity is optional slots: whether the dialog shows at all, the rule list
- * versus the edit form, which action buttons a new rule gets against an existing one, and the
- * `when` picking the current tab's content. The arms emit and return nothing, so
- * `CyclomaticComplexMethod` is suppressed rather than fixed.
+ * Modal editor for a table's conditional-formatting rules, rendered in a Material3 `AlertDialog`. Shares its title,
+ * buttons and body with [FormatDialogContent], which hosts the same editor in a caller-supplied container.
  */
-@Suppress("CyclomaticComplexMethod")
-@OptIn(FlowPreview::class)
 @Composable
+@Suppress("LongParameterList")
 public fun <E : Enum<E>, FILTER> FormatDialog(
     showDialog: Boolean,
     rules: ImmutableList<TableFormatRule<E, FILTER>>,
@@ -100,137 +29,18 @@ public fun <E : Enum<E>, FILTER> FormatDialog(
     onDismissRequest: () -> Unit,
     settings: FormatDialogSettings = FormatDialogSettings(),
     scrollbarRenderer: VerticalScrollbarRenderer? = null,
+    colors: FormatDialogColors = FormatDialogDefaults.colors(),
 ) {
     if (!showDialog) return
-    val lazyListState = rememberLazyListState()
-    var itemCopyIndex by remember { mutableStateOf<Int?>(null) }
-    LaunchedEffect(itemCopyIndex) {
-        itemCopyIndex?.let { index ->
-            lazyListState.animateScrollToItem(index)
-            delay(settings.copiedItemHighlightDuration)
-            itemCopyIndex = null
-        }
-    }
-    var editItem by remember { mutableStateOf<EditFormatRule<E, FILTER>?>(null) }
+    val state = rememberFormatDialogState<E, FILTER>(settings)
     AlertDialog(
         onDismissRequest = onDismissRequest,
-        confirmButton = {
-            if (editItem == null) {
-                FloatingActionButton(
-                    onClick = {
-                        val id = rules.maxByOrNull { it.id }?.id?.inc() ?: 0L
-                        editItem =
-                            EditFormatRule(
-                                rules.lastIndex + 1,
-                                getNewRule(id),
-                                true,
-                            )
-                    },
-                    shape = CircleShape,
-                ) {
-                    Icon(
-                        imageVector = Icons.Rounded.Add,
-                        contentDescription = "Add",
-                    )
-                }
-            }
-            editItem?.let { (index, item, isNew) ->
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = spacedBy(16.dp, Alignment.End),
-                ) {
-                    if (!isNew) {
-                        IconButton(
-                            onClick = {
-                                onRulesChange(
-                                    rules.toPersistentList().mutate { list ->
-                                        list.removeAt(index)
-                                    },
-                                )
-                                editItem = null
-                            },
-                        ) {
-                            Icon(
-                                imageVector = Icons.Rounded.Delete,
-                                contentDescription = "Delete",
-                                tint = MaterialTheme.colorScheme.error,
-                            )
-                        }
-                        IconButton(
-                            onClick = {
-                                val id = rules.maxByOrNull { it.id }?.id?.inc() ?: 0L
-                                val lastIndex = rules.lastIndex
-                                val itemCopy = item.copy(id = id)
-                                onRulesChange(
-                                    rules.toPersistentList().mutate { list ->
-                                        list.add(itemCopy)
-                                    },
-                                )
-                                editItem = null
-                                itemCopyIndex = lastIndex.inc()
-                            },
-                        ) {
-                            Icon(
-                                imageVector = Icons.Rounded.ContentCopy,
-                                contentDescription = "Copy",
-                            )
-                        }
-                    }
-                    IconButton(
-                        onClick = {
-                            editItem = null
-                        },
-                    ) {
-                        Icon(
-                            imageVector = Icons.Rounded.Close,
-                            contentDescription = "Close",
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                    IconButton(
-                        onClick = {
-                            onRulesChange(
-                                rules.toPersistentList().mutate { list ->
-                                    if (index in list.indices) {
-                                        list[index] = item
-                                    } else {
-                                        list.add(item)
-                                    }
-                                },
-                            )
-                            editItem = null
-                        },
-                    ) {
-                        Icon(
-                            imageVector = Icons.Rounded.Save,
-                            contentDescription = "Save",
-                        )
-                    }
-                }
-            }
-        },
-        title = {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = SpaceBetween,
-            ) {
-                Text(
-                    text = strings.get(UiString.FormatRules),
-                )
-                if (editItem == null) {
-                    IconButton(
-                        onClick = onDismissRequest,
-                    ) {
-                        Icon(
-                            imageVector = Icons.Rounded.Close,
-                            contentDescription = "Сlose",
-                        )
-                    }
-                }
-            }
-        },
+        containerColor = colors.containerColor,
+        titleContentColor = colors.titleContentColor,
+        textContentColor = colors.textContentColor,
+        tonalElevation = colors.tonalElevation,
+        confirmButton = { FormatDialogButtons(state, rules, onRulesChange, getNewRule) },
+        title = { FormatDialogTitle(state, strings, colors.titleContentColor, onDismissRequest) },
         properties =
             DialogProperties(
                 dismissOnBackPress = true,
@@ -238,261 +48,18 @@ public fun <E : Enum<E>, FILTER> FormatDialog(
                 usePlatformDefaultWidth = false,
             ),
         text = {
-            editItem?.let { (index, item) ->
-                var currentTab by remember { mutableStateOf(RuleTab.DESIGN) }
-                val data =
-                    remember {
-                        RuleTab.entries.map { TabData(it, it.uiString) }.toImmutableList()
-                    }
-                FormatDialogTabRow(
-                    currentItem = currentTab,
-                    onClick = { currentTab = it },
-                    list = data,
-                    createTab = { item, isSelected, onClick ->
-                        Tab(
-                            text = {
-                                Text(
-                                    text = strings.get(item.data),
-                                    modifier = Modifier.padding(top = 4.dp, end = 8.dp),
-                                    maxLines = 1,
-                                )
-                            },
-                            selected = isSelected,
-                            onClick = onClick,
-                        )
-                    },
-                    modifier =
-                        Modifier
-                            .fillMaxSize(),
-                ) {
-                    when (currentTab) {
-                        RuleTab.DESIGN -> {
-                            FormatDialogDesignTab(
-                                item = item,
-                                onChange = { newItem -> editItem = EditFormatRule(index, newItem) },
-                                strings = strings,
-                                scrollbarRenderer = scrollbarRenderer,
-                            )
-                        }
-
-                        RuleTab.CONDITION -> {
-                            FormatDialogConditionTab(
-                                item = item,
-                                getTitle = getTitle,
-                                filters = filters,
-                                onChange = { newItem -> editItem = EditFormatRule(index, newItem) },
-                                strings = strings,
-                                scrollbarRenderer = scrollbarRenderer,
-                            )
-                        }
-
-                        RuleTab.FIELD -> {
-                            FormatDialogFieldTab(
-                                item = item,
-                                entries = entries,
-                                getTitle = getTitle,
-                                onChange = { newItem -> editItem = EditFormatRule(index, newItem) },
-                                scrollbarRenderer = scrollbarRenderer,
-                            )
-                        }
-                    }
-                }
-            } ?: run {
-                var draggedItemIndex by remember { mutableStateOf<Int?>(null) }
-                var rulesState by remember(key) { mutableStateOf(rules) }
-                val currentOnRulesChange = rememberUpdatedState(onRulesChange)
-                LaunchedEffect(key) {
-                    snapshotFlow { rulesState }
-                        .drop(1)
-                        .debounce(RULES_CHANGE_DEBOUNCE_MS.milliseconds)
-                        .distinctUntilChanged()
-                        .collect { currentOnRulesChange.value(it) }
-                }
-                val state =
-                    rememberReorderableLazyListState(lazyListState) { from, to ->
-                        rulesState =
-                            rulesState.toPersistentList().mutate { list ->
-                                list.add(to.index, list.removeAt(from.index))
-                            }
-                    }
-                Box {
-                    LazyColumn(state = lazyListState, modifier = Modifier.fillMaxWidth()) {
-                        itemsIndexed(rulesState, key = { _, item -> item.id }) { index, item ->
-                            ReorderableItem(state = state, key = item.id) { isDragging ->
-                                val elevation =
-                                    animateDpAsState(if (isDragging) 16.dp else 0.dp)
-                                Surface(
-                                    shadowElevation = elevation.value,
-                                    tonalElevation = elevation.value,
-                                    modifier = Modifier.Companion.draggableHandle(),
-                                    onClick = {
-                                        editItem = EditFormatRule(index, item)
-                                    },
-                                ) {
-                                    ListItem(
-                                        overlineContent =
-                                            buildList {
-                                                if (item.cellStyle.textStyle !=
-                                                    null
-                                                ) {
-                                                    add(strings.get(UiString.FormatLabelTypography))
-                                                }
-                                                if (item.cellStyle.vertical !=
-                                                    null
-                                                ) {
-                                                    add(strings.get(UiString.FormatLabelVerticalAlignment))
-                                                }
-                                                if (item.cellStyle.horizontal !=
-                                                    null
-                                                ) {
-                                                    add(strings.get(UiString.FormatLabelHorizontalAlignment))
-                                                }
-                                                if (item.cellStyle.backgroundColor !=
-                                                    null
-                                                ) {
-                                                    add(strings.get(UiString.FormatBackgroundColor))
-                                                }
-                                                if (item.cellStyle.contentColor !=
-                                                    null
-                                                ) {
-                                                    add(strings.get(UiString.FormatContentColor))
-                                                }
-                                            }.takeIf { it.isNotEmpty() }?.let {
-                                                { Text(it.joinToString(", "), maxLines = 1) }
-                                            },
-                                        headlineContent = {
-                                            val style =
-                                                item.cellStyle.textStyle?.toTextStyle() ?: LocalTextStyle.current
-                                            val color = item.cellStyle.contentColor?.toColor() ?: Color.Unspecified
-                                            Text(
-                                                buildRuleTitle(
-                                                    rule = item,
-                                                    getFieldTitle = getTitle,
-                                                    filtersProvider = filters,
-                                                    strings = strings,
-                                                ),
-                                                maxLines = 1,
-                                                style = style,
-                                                color = color,
-                                            )
-                                        },
-                                        supportingContent =
-                                            item.columns
-                                                .map {
-                                                    getTitle(it)
-                                                }.takeIf { it.isNotEmpty() }
-                                                ?.let {
-                                                    { Text(it.joinToString(", "), maxLines = 1) }
-                                                },
-                                        leadingContent = {
-                                            Checkbox(
-                                                checked = item.enabled,
-                                                onCheckedChange = { enabled ->
-                                                    val itemIndex =
-                                                        rulesState.indexOfFirst { it == item }
-                                                    if (itemIndex != -1) {
-                                                        rulesState =
-                                                            rulesState.toPersistentList().mutate { list ->
-                                                                list[itemIndex] =
-                                                                    list[itemIndex].copy(
-                                                                        enabled = enabled,
-                                                                    )
-                                                            }
-                                                        onRulesChange(rulesState)
-                                                    }
-                                                },
-                                                enabled = !item.base,
-                                            )
-                                        },
-                                        trailingContent = {
-                                            Icon(
-                                                imageVector = Icons.Rounded.DragIndicator,
-                                                contentDescription = null,
-                                                modifier =
-                                                    Modifier
-                                                        .pointerInput(rulesState) {
-                                                            detectTapGestures(
-                                                                onPress = {
-                                                                    draggedItemIndex = rulesState.indexOf(item)
-                                                                    awaitRelease()
-                                                                    draggedItemIndex = null
-                                                                },
-                                                            )
-                                                        },
-                                            )
-                                        },
-                                        colors =
-                                            when {
-                                                index == itemCopyIndex -> {
-                                                    ListItemDefaults.colors(
-                                                        containerColor =
-                                                            if (settings.copiedItemHighlightColor.isUnspecified) {
-                                                                MaterialTheme.colorScheme.tertiaryContainer
-                                                            } else {
-                                                                settings.copiedItemHighlightColor
-                                                            },
-                                                    )
-                                                }
-
-                                                item.cellStyle.backgroundColor != null -> {
-                                                    val backgroundColor = item.cellStyle.backgroundColor.toColor()
-                                                    val contrastColor = backgroundColor.contrastColor()
-                                                    ListItemDefaults.colors(
-                                                        containerColor = backgroundColor,
-                                                        overlineColor = contrastColor,
-                                                        supportingColor = contrastColor,
-                                                        trailingIconColor = contrastColor,
-                                                        leadingIconColor = contrastColor,
-                                                    )
-                                                }
-
-                                                else -> {
-                                                    ListItemDefaults.colors()
-                                                }
-                                            },
-                                    )
-                                }
-                            }
-                            HorizontalDivider()
-                        }
-                    }
-                    scrollbarRenderer?.Render(
-                        modifier =
-                            Modifier
-                                .align(Alignment.TopEnd)
-                                .fillMaxHeight(),
-                        state = VerticalScrollbarState.LazyList(lazyListState),
-                    )
-                }
-            }
+            FormatDialogBody(
+                state = state,
+                rules = rules,
+                onRulesChange = onRulesChange,
+                getTitle = getTitle,
+                filters = filters,
+                entries = entries,
+                key = key,
+                strings = strings,
+                settings = settings,
+                scrollbarRenderer = scrollbarRenderer,
+            )
         },
     )
-}
-
-private fun Color.contrastColor(): Color {
-    val luminance = 0.299 * red + 0.587 * green + 0.114 * blue
-    return if (luminance > LUMINANCE_THRESHOLD) Color.Black else Color.White
-}
-
-@Composable
-private fun <E : Enum<E>, FILTER> buildRuleTitle(
-    rule: TableFormatRule<E, FILTER>,
-    getFieldTitle: @Composable (E) -> String,
-    filtersProvider: (
-        TableFormatRule<E, FILTER>,
-        onApply: (TableFormatRule<E, FILTER>) -> Unit,
-    ) -> List<FormatFilterData<E>>,
-    strings: StringProvider,
-): String {
-    val parts = mutableListOf<String>()
-    val filterItems = filtersProvider(rule) { }
-    for (filterData in filterItems) {
-        val built = buildFilterHeaderTitle(filterData = filterData, strings = strings)
-        if (built != null) {
-            val fieldTitle = getFieldTitle(filterData.field)
-            parts += "$fieldTitle $built"
-        }
-    }
-    return parts.takeIf { it.isNotEmpty() }?.joinToString(separator = " • ")
-        ?: strings.get(UiString.FormatAlwaysApply)
 }

--- a/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialogBody.kt
+++ b/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialogBody.kt
@@ -1,0 +1,326 @@
+package ua.wwind.table.format
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.DragIndicator
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isUnspecified
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.mutate
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
+import ua.wwind.table.format.component.FormatDialogState
+import ua.wwind.table.format.component.FormatDialogTabRow
+import ua.wwind.table.format.component.RuleTab
+import ua.wwind.table.format.component.TabData
+import ua.wwind.table.format.data.EditFormatRule
+import ua.wwind.table.format.data.FormatDialogSettings
+import ua.wwind.table.format.data.TableFormatRule
+import ua.wwind.table.format.scrollbar.VerticalScrollbarRenderer
+import ua.wwind.table.format.scrollbar.VerticalScrollbarState
+import ua.wwind.table.strings.StringProvider
+import ua.wwind.table.strings.UiString
+import kotlin.time.Duration.Companion.milliseconds
+
+// Rules are edited in place; wait for the edits to settle before reporting them upstream.
+private const val RULES_CHANGE_DEBOUNCE_MS = 1_000L
+
+// Above this perceived brightness a background takes black text, below it white.
+private const val LUMINANCE_THRESHOLD = 0.5
+
+@Suppress("CyclomaticComplexMethod", "LongParameterList", "LongMethod")
+@OptIn(FlowPreview::class)
+@Composable
+internal fun <E : Enum<E>, FILTER> FormatDialogBody(
+    state: FormatDialogState<E, FILTER>,
+    rules: ImmutableList<TableFormatRule<E, FILTER>>,
+    onRulesChange: (ImmutableList<TableFormatRule<E, FILTER>>) -> Unit,
+    getTitle: @Composable (E) -> String,
+    filters: (TableFormatRule<E, FILTER>, onApply: (TableFormatRule<E, FILTER>) -> Unit) -> List<FormatFilterData<E>>,
+    entries: ImmutableList<E>,
+    key: Any,
+    strings: StringProvider,
+    settings: FormatDialogSettings,
+    scrollbarRenderer: VerticalScrollbarRenderer?,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        state.editItem?.let { (index, item) ->
+            var currentTab by remember { mutableStateOf(RuleTab.DESIGN) }
+            val data =
+                remember {
+                    RuleTab.entries.map { TabData(it, it.uiString) }.toImmutableList()
+                }
+            FormatDialogTabRow(
+                currentItem = currentTab,
+                onClick = { currentTab = it },
+                list = data,
+                createTab = { tabItem, isSelected, onClick ->
+                    Tab(
+                        text = {
+                            Text(
+                                text = strings.get(tabItem.data),
+                                modifier = Modifier.padding(top = 4.dp, end = 8.dp),
+                                maxLines = 1,
+                            )
+                        },
+                        selected = isSelected,
+                        onClick = onClick,
+                    )
+                },
+                modifier =
+                    Modifier
+                        .fillMaxSize(),
+            ) {
+                when (currentTab) {
+                    RuleTab.DESIGN -> {
+                        FormatDialogDesignTab(
+                            item = item,
+                            onChange = { newItem -> state.editItem = EditFormatRule(index, newItem) },
+                            strings = strings,
+                            scrollbarRenderer = scrollbarRenderer,
+                        )
+                    }
+
+                    RuleTab.CONDITION -> {
+                        FormatDialogConditionTab(
+                            item = item,
+                            getTitle = getTitle,
+                            filters = filters,
+                            onChange = { newItem -> state.editItem = EditFormatRule(index, newItem) },
+                            strings = strings,
+                            scrollbarRenderer = scrollbarRenderer,
+                        )
+                    }
+
+                    RuleTab.FIELD -> {
+                        FormatDialogFieldTab(
+                            item = item,
+                            entries = entries,
+                            getTitle = getTitle,
+                            onChange = { newItem -> state.editItem = EditFormatRule(index, newItem) },
+                            scrollbarRenderer = scrollbarRenderer,
+                        )
+                    }
+                }
+            }
+        } ?: run {
+            var rulesState by remember(key) { mutableStateOf(rules) }
+            val currentOnRulesChange = rememberUpdatedState(onRulesChange)
+            LaunchedEffect(key) {
+                snapshotFlow { rulesState }
+                    .drop(1)
+                    .debounce(RULES_CHANGE_DEBOUNCE_MS.milliseconds)
+                    .distinctUntilChanged()
+                    .collect { currentOnRulesChange.value(it) }
+            }
+            val reorderableState =
+                rememberReorderableLazyListState(state.lazyListState) { from, to ->
+                    rulesState =
+                        rulesState.toPersistentList().mutate { list ->
+                            list.add(to.index, list.removeAt(from.index))
+                        }
+                }
+            Box {
+                LazyColumn(state = state.lazyListState, modifier = Modifier.fillMaxWidth()) {
+                    itemsIndexed(rulesState, key = { _, item -> item.id }) { index, item ->
+                        ReorderableItem(state = reorderableState, key = item.id) { isDragging ->
+                            val elevation =
+                                animateDpAsState(if (isDragging) 16.dp else 0.dp)
+                            Surface(
+                                shadowElevation = elevation.value,
+                                tonalElevation = elevation.value,
+                                modifier = Modifier.draggableHandle(),
+                                onClick = {
+                                    state.editItem = EditFormatRule(index, item)
+                                },
+                            ) {
+                                ListItem(
+                                    overlineContent =
+                                        buildList {
+                                            if (item.cellStyle.textStyle !=
+                                                null
+                                            ) {
+                                                add(strings.get(UiString.FormatLabelTypography))
+                                            }
+                                            if (item.cellStyle.vertical !=
+                                                null
+                                            ) {
+                                                add(strings.get(UiString.FormatLabelVerticalAlignment))
+                                            }
+                                            if (item.cellStyle.horizontal !=
+                                                null
+                                            ) {
+                                                add(strings.get(UiString.FormatLabelHorizontalAlignment))
+                                            }
+                                            if (item.cellStyle.backgroundColor !=
+                                                null
+                                            ) {
+                                                add(strings.get(UiString.FormatBackgroundColor))
+                                            }
+                                            if (item.cellStyle.contentColor !=
+                                                null
+                                            ) {
+                                                add(strings.get(UiString.FormatContentColor))
+                                            }
+                                        }.takeIf { it.isNotEmpty() }?.let {
+                                            { Text(it.joinToString(", "), maxLines = 1) }
+                                        },
+                                    headlineContent = {
+                                        val style =
+                                            item.cellStyle.textStyle?.toTextStyle() ?: LocalTextStyle.current
+                                        val color = item.cellStyle.contentColor?.toColor() ?: Color.Unspecified
+                                        Text(
+                                            buildRuleTitle(
+                                                rule = item,
+                                                getFieldTitle = getTitle,
+                                                filtersProvider = filters,
+                                                strings = strings,
+                                            ),
+                                            maxLines = 1,
+                                            style = style,
+                                            color = color,
+                                        )
+                                    },
+                                    supportingContent =
+                                        item.columns
+                                            .map {
+                                                getTitle(it)
+                                            }.takeIf { it.isNotEmpty() }
+                                            ?.let {
+                                                { Text(it.joinToString(", "), maxLines = 1) }
+                                            },
+                                    leadingContent = {
+                                        Checkbox(
+                                            checked = item.enabled,
+                                            onCheckedChange = { enabled ->
+                                                val itemIndex =
+                                                    rulesState.indexOfFirst { it == item }
+                                                if (itemIndex != -1) {
+                                                    rulesState =
+                                                        rulesState.toPersistentList().mutate { list ->
+                                                            list[itemIndex] =
+                                                                list[itemIndex].copy(
+                                                                    enabled = enabled,
+                                                                )
+                                                        }
+                                                    onRulesChange(rulesState)
+                                                }
+                                            },
+                                            enabled = !item.base,
+                                        )
+                                    },
+                                    trailingContent = {
+                                        Icon(
+                                            imageVector = Icons.Rounded.DragIndicator,
+                                            contentDescription = null,
+                                        )
+                                    },
+                                    colors =
+                                        when {
+                                            index == state.itemCopyIndex -> {
+                                                ListItemDefaults.colors(
+                                                    containerColor =
+                                                        if (settings.copiedItemHighlightColor.isUnspecified) {
+                                                            MaterialTheme.colorScheme.tertiaryContainer
+                                                        } else {
+                                                            settings.copiedItemHighlightColor
+                                                        },
+                                                )
+                                            }
+
+                                            item.cellStyle.backgroundColor != null -> {
+                                                val backgroundColor = item.cellStyle.backgroundColor.toColor()
+                                                val contrastColor = backgroundColor.contrastColor()
+                                                ListItemDefaults.colors(
+                                                    containerColor = backgroundColor,
+                                                    overlineColor = contrastColor,
+                                                    supportingColor = contrastColor,
+                                                    trailingIconColor = contrastColor,
+                                                    leadingIconColor = contrastColor,
+                                                )
+                                            }
+
+                                            else -> {
+                                                ListItemDefaults.colors()
+                                            }
+                                        },
+                                )
+                            }
+                        }
+                        HorizontalDivider()
+                    }
+                }
+                scrollbarRenderer?.Render(
+                    modifier =
+                        Modifier
+                            .align(Alignment.TopEnd)
+                            .fillMaxHeight(),
+                    state = VerticalScrollbarState.LazyList(state.lazyListState),
+                )
+            }
+        }
+    }
+}
+
+private fun Color.contrastColor(): Color {
+    val luminance = 0.299 * red + 0.587 * green + 0.114 * blue
+    return if (luminance > LUMINANCE_THRESHOLD) Color.Black else Color.White
+}
+
+@Composable
+private fun <E : Enum<E>, FILTER> buildRuleTitle(
+    rule: TableFormatRule<E, FILTER>,
+    getFieldTitle: @Composable (E) -> String,
+    filtersProvider: (
+        TableFormatRule<E, FILTER>,
+        onApply: (TableFormatRule<E, FILTER>) -> Unit,
+    ) -> List<FormatFilterData<E>>,
+    strings: StringProvider,
+): String {
+    val parts = mutableListOf<String>()
+    val filterItems = filtersProvider(rule) { }
+    for (filterData in filterItems) {
+        val built = buildFilterHeaderTitle(filterData = filterData, strings = strings)
+        if (built != null) {
+            val fieldTitle = getFieldTitle(filterData.field)
+            parts += "$fieldTitle $built"
+        }
+    }
+    return parts.takeIf { it.isNotEmpty() }?.joinToString(separator = " • ")
+        ?: strings.get(UiString.FormatAlwaysApply)
+}

--- a/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialogButtons.kt
+++ b/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialogButtons.kt
@@ -1,0 +1,131 @@
+package ua.wwind.table.format
+
+import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.ContentCopy
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Save
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.mutate
+import kotlinx.collections.immutable.toPersistentList
+import ua.wwind.table.format.component.FormatDialogState
+import ua.wwind.table.format.data.EditFormatRule
+import ua.wwind.table.format.data.TableFormatRule
+
+@Composable
+@Suppress("LongMethod")
+internal fun <E : Enum<E>, FILTER> FormatDialogButtons(
+    state: FormatDialogState<E, FILTER>,
+    rules: ImmutableList<TableFormatRule<E, FILTER>>,
+    onRulesChange: (ImmutableList<TableFormatRule<E, FILTER>>) -> Unit,
+    getNewRule: (id: Long) -> TableFormatRule<E, FILTER>,
+) {
+    val edit = state.editItem
+    if (edit == null) {
+        FloatingActionButton(
+            onClick = {
+                val id = rules.maxByOrNull { it.id }?.id?.inc() ?: 0L
+                state.editItem =
+                    EditFormatRule(
+                        rules.lastIndex + 1,
+                        getNewRule(id),
+                        true,
+                    )
+            },
+            shape = CircleShape,
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Add,
+                contentDescription = "Add",
+            )
+        }
+    } else {
+        val (index, item, isNew) = edit
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = spacedBy(16.dp, Alignment.End),
+        ) {
+            if (!isNew) {
+                IconButton(
+                    onClick = {
+                        onRulesChange(
+                            rules.toPersistentList().mutate { list ->
+                                if (index in list.indices) list.removeAt(index)
+                            },
+                        )
+                        state.editItem = null
+                    },
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Delete,
+                        contentDescription = "Delete",
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                }
+                IconButton(
+                    onClick = {
+                        val id = rules.maxByOrNull { it.id }?.id?.inc() ?: 0L
+                        val lastIndex = rules.lastIndex
+                        val itemCopy = item.copy(id = id)
+                        onRulesChange(
+                            rules.toPersistentList().mutate { list ->
+                                list.add(itemCopy)
+                            },
+                        )
+                        state.editItem = null
+                        state.itemCopyIndex = lastIndex.inc()
+                    },
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.ContentCopy,
+                        contentDescription = "Copy",
+                    )
+                }
+            }
+            IconButton(
+                onClick = {
+                    state.editItem = null
+                },
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Close,
+                    contentDescription = "Close",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            IconButton(
+                onClick = {
+                    onRulesChange(
+                        rules.toPersistentList().mutate { list ->
+                            if (index in list.indices) {
+                                list[index] = item
+                            } else {
+                                list.add(item)
+                            }
+                        },
+                    )
+                    state.editItem = null
+                },
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Save,
+                    contentDescription = "Save",
+                )
+            }
+        }
+    }
+}

--- a/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialogColors.kt
+++ b/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialogColors.kt
@@ -1,0 +1,37 @@
+package ua.wwind.table.format
+
+import androidx.compose.material3.AlertDialogDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+
+/**
+ * Colors for the format dialog and its portable content; mirrors the color parameters of Material3 `AlertDialog`.
+ * [FormatDialog] uses all four; [FormatDialogContent] applies only [titleContentColor] and [textContentColor] and
+ * leaves [containerColor] / [tonalElevation] to its host container.
+ */
+@Immutable
+public data class FormatDialogColors(
+    public val containerColor: Color,
+    public val titleContentColor: Color,
+    public val textContentColor: Color,
+    public val tonalElevation: Dp,
+)
+
+/** Default factory for [FormatDialogColors], resolving to the Material3 `AlertDialog` defaults. */
+public object FormatDialogDefaults {
+    @Composable
+    public fun colors(
+        containerColor: Color = AlertDialogDefaults.containerColor,
+        titleContentColor: Color = AlertDialogDefaults.titleContentColor,
+        textContentColor: Color = AlertDialogDefaults.textContentColor,
+        tonalElevation: Dp = AlertDialogDefaults.TonalElevation,
+    ): FormatDialogColors =
+        FormatDialogColors(
+            containerColor = containerColor,
+            titleContentColor = titleContentColor,
+            textContentColor = textContentColor,
+            tonalElevation = tonalElevation,
+        )
+}

--- a/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialogConditionTab.kt
+++ b/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialogConditionTab.kt
@@ -92,7 +92,7 @@ public fun <E : Enum<E>, FILTER> FormatDialogConditionTab(
 ) {
     Box(
         modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
+        contentAlignment = Alignment.TopCenter,
     ) {
         val listState = rememberLazyListState()
         Box {

--- a/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialogContent.kt
+++ b/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialogContent.kt
@@ -1,0 +1,76 @@
+package ua.wwind.table.format
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import ua.wwind.table.format.component.rememberFormatDialogState
+import ua.wwind.table.format.data.FormatDialogSettings
+import ua.wwind.table.format.data.TableFormatRule
+import ua.wwind.table.format.scrollbar.VerticalScrollbarRenderer
+import ua.wwind.table.strings.StringProvider
+
+/**
+ * Conditional-formatting UI as portable content: host it in any container (a custom dialog host, a side panel, a
+ * split pane) instead of only [FormatDialog]. The container owns visibility, scrim, background and elevation; this
+ * composable applies only [FormatDialogColors.titleContentColor] and [FormatDialogColors.textContentColor] from
+ * [colors]. The host MUST impose a bounded height (a fixed height or a fill-height container): the rule list is a
+ * vertical viewport, so an unbounded-height parent (e.g. a scrolling Column) throws at composition. [key] resets the
+ * in-flight edit list when it changes. Pass [onDismissRequest] `= null` (the default) to hide the close button for
+ * embedded, non-modal placements.
+ */
+@Composable
+@Suppress("LongParameterList")
+public fun <E : Enum<E>, FILTER> FormatDialogContent(
+    rules: ImmutableList<TableFormatRule<E, FILTER>>,
+    onRulesChange: (ImmutableList<TableFormatRule<E, FILTER>>) -> Unit,
+    getNewRule: (id: Long) -> TableFormatRule<E, FILTER>,
+    getTitle: @Composable (E) -> String,
+    filters: (TableFormatRule<E, FILTER>, onApply: (TableFormatRule<E, FILTER>) -> Unit) -> List<FormatFilterData<E>>,
+    entries: ImmutableList<E>,
+    key: Any,
+    strings: StringProvider,
+    modifier: Modifier = Modifier,
+    onDismissRequest: (() -> Unit)? = null,
+    colors: FormatDialogColors = FormatDialogDefaults.colors(),
+    settings: FormatDialogSettings = FormatDialogSettings(),
+    scrollbarRenderer: VerticalScrollbarRenderer? = null,
+) {
+    val state = rememberFormatDialogState<E, FILTER>(settings)
+    Column(modifier = modifier.fillMaxSize()) {
+        FormatDialogTitle(state, strings, colors.titleContentColor, onDismissRequest)
+        HorizontalDivider()
+        CompositionLocalProvider(LocalContentColor provides colors.textContentColor) {
+            FormatDialogBody(
+                state = state,
+                rules = rules,
+                onRulesChange = onRulesChange,
+                getTitle = getTitle,
+                filters = filters,
+                entries = entries,
+                key = key,
+                strings = strings,
+                settings = settings,
+                scrollbarRenderer = scrollbarRenderer,
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.End,
+        ) {
+            FormatDialogButtons(state, rules, onRulesChange, getNewRule)
+        }
+    }
+}

--- a/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialogTitle.kt
+++ b/table-format/src/commonMain/kotlin/ua/wwind/table/format/FormatDialogTitle.kt
@@ -1,0 +1,46 @@
+package ua.wwind.table.format
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import ua.wwind.table.format.component.FormatDialogState
+import ua.wwind.table.strings.StringProvider
+import ua.wwind.table.strings.UiString
+
+@Composable
+internal fun <E : Enum<E>, FILTER> FormatDialogTitle(
+    state: FormatDialogState<E, FILTER>,
+    strings: StringProvider,
+    titleContentColor: Color,
+    onDismissRequest: (() -> Unit)?,
+) {
+    CompositionLocalProvider(LocalContentColor provides titleContentColor) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = strings.get(UiString.FormatRules),
+                style = MaterialTheme.typography.headlineSmall,
+            )
+            if (state.editItem == null && onDismissRequest != null) {
+                IconButton(onClick = onDismissRequest) {
+                    Icon(imageVector = Icons.Rounded.Close, contentDescription = "Close")
+                }
+            }
+        }
+    }
+}

--- a/table-format/src/commonMain/kotlin/ua/wwind/table/format/component/FormatDialogState.kt
+++ b/table-format/src/commonMain/kotlin/ua/wwind/table/format/component/FormatDialogState.kt
@@ -1,0 +1,36 @@
+package ua.wwind.table.format.component
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
+import ua.wwind.table.format.data.EditFormatRule
+import ua.wwind.table.format.data.FormatDialogSettings
+
+/** Transient UI state shared by the three format-dialog blocks: edited rule, just-copied index, list scroll state. */
+internal class FormatDialogState<E : Enum<E>, FILTER>(
+    val lazyListState: LazyListState,
+) {
+    var editItem: EditFormatRule<E, FILTER>? by mutableStateOf(null)
+    var itemCopyIndex: Int? by mutableStateOf(null)
+}
+
+@Composable
+internal fun <E : Enum<E>, FILTER> rememberFormatDialogState(
+    settings: FormatDialogSettings,
+): FormatDialogState<E, FILTER> {
+    val lazyListState = rememberLazyListState()
+    val state = remember { FormatDialogState<E, FILTER>(lazyListState) }
+    LaunchedEffect(state.itemCopyIndex) {
+        val index = state.itemCopyIndex ?: return@LaunchedEffect
+        lazyListState.animateScrollToItem(index)
+        delay(settings.copiedItemHighlightDuration)
+        state.itemCopyIndex = null
+    }
+    return state
+}

--- a/table-format/src/commonTest/kotlin/ua/wwind/table/format/FormatDialogContentTest.kt
+++ b/table-format/src/commonTest/kotlin/ua/wwind/table/format/FormatDialogContentTest.kt
@@ -1,0 +1,71 @@
+package ua.wwind.table.format
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import ua.wwind.table.format.data.TableFormatRule
+import ua.wwind.table.strings.DefaultStrings
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class FormatDialogContentTest {
+    private enum class TestField { A, B }
+
+    private fun emptyRules(): ImmutableList<TableFormatRule<TestField, Unit>> = persistentListOf()
+
+    @Test
+    fun `saving a new rule emits it through onRulesChange`() =
+        runComposeUiTest {
+            val changes = mutableListOf<ImmutableList<TableFormatRule<TestField, Unit>>>()
+            setContent {
+                FormatDialogContent(
+                    rules = emptyRules(),
+                    onRulesChange = { changes.add(it) },
+                    getNewRule = { id -> TableFormatRule.new<TestField, Unit>(id, Unit) },
+                    getTitle = { it.name },
+                    filters = { _, _ -> emptyList() },
+                    entries = TestField.entries.toImmutableList(),
+                    key = 0,
+                    strings = DefaultStrings,
+                    onDismissRequest = {},
+                )
+            }
+            onNodeWithContentDescription("Add").performClick()
+            waitForIdle()
+            onNodeWithContentDescription("Save").performClick()
+            waitForIdle()
+
+            assertThat(changes).hasSize(1)
+            assertThat(changes.single().size).isEqualTo(1)
+        }
+
+    @Test
+    fun `close affordance is hidden when onDismissRequest is null`() =
+        runComposeUiTest {
+            setContent {
+                FormatDialogContent(
+                    rules = emptyRules(),
+                    onRulesChange = {},
+                    getNewRule = { id -> TableFormatRule.new<TestField, Unit>(id, Unit) },
+                    getTitle = { it.name },
+                    filters = { _, _ -> emptyList() },
+                    entries = TestField.entries.toImmutableList(),
+                    key = 0,
+                    strings = DefaultStrings,
+                    onDismissRequest = null,
+                )
+            }
+            waitForIdle()
+            onAllNodesWithContentDescription("Add").assertCountEquals(1)
+            onAllNodesWithContentDescription("Close").assertCountEquals(0)
+        }
+}

--- a/table-format/src/commonTest/kotlin/ua/wwind/table/format/InfraSmokeTest.kt
+++ b/table-format/src/commonTest/kotlin/ua/wwind/table/format/InfraSmokeTest.kt
@@ -1,0 +1,12 @@
+package ua.wwind.table.format
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class InfraSmokeTest {
+    @Test
+    fun `test source set compiles and runs`() {
+        assertThat(1 + 1).isEqualTo(2)
+    }
+}


### PR DESCRIPTION
## Summary
- **`FormatDialogContent`** — the conditional-formatting editor as portable content, hostable in any container (a custom dialog host, a side panel, a split pane). `FormatDialog` is unchanged; both reuse the same internal title/buttons/body blocks.
- **`FormatDialogColors` / `FormatDialogDefaults.colors()`** — explicit colors (defaulting to the Material3 `AlertDialog` values), exposed via an appended `colors` parameter on both entry points.
- **Fix** — within-block row reorder stopped committing after the block was moved as a whole (the nested reorderable captured a stale base offset); the offset is now read live.
- **Fix** — the Condition tab's field list top-aligns instead of vertically centering.

## Compatibility
Additive and source-compatible — `colors` is optional and appended last, so existing (incl. positional) calls keep compiling.

## Tests
New `table-format` test source set + Compose UI tests for `FormatDialogContent`; `:table-core` / `:table-format` suites green; detekt + spotless clean.