### PR TITLE
fix(core): pin the active-filters header and follow the boundary while resizing

### DIFF
--- a/docs/superpowers/specs/2026-07-30-last-column-resize-autoscroll-design.md
+++ b/docs/superpowers/specs/2026-07-30-last-column-resize-autoscroll-design.md
@@ -1,0 +1,96 @@
+# Resize Auto-Scroll at the Right Edge — Design
+
+## Goal
+
+Make the last column resizable in one gesture. Its boundary sits at the right edge of the content, so
+widening it used to be invisible and would run out of pointer travel within a few pixels.
+
+## Motivation
+
+`ColumnResizersOverlay` places a grab strip at each column boundary inside a `Box` of
+`state.tableWidth`, which lives in the horizontally scrolling content. The strip works — a drag on the
+last boundary did resize the column — but nothing followed it:
+
+- Widening moves the boundary further right in *content* coordinates while `horizontalState.value`
+  stays where it was, so the growth happens beyond the right edge of the viewport. The visible width
+  of the column does not change and the gesture reads as broken.
+- The pointer can only travel from the boundary to the edge of the window. When the table is scrolled
+  to the end that is a handful of pixels, and nothing at all when the table reaches the window edge.
+- After releasing, the boundary is off screen by however much the column grew, so the strip cannot be
+  grabbed again without scrolling right first.
+
+The practical workaround was to narrow the neighbouring columns until the last one had room, which is
+what the behaviour looked like from the outside: the last column "cannot be resized".
+
+## Non-goals
+
+- No trailing gutter after the last column. Reserved empty space would give a bounded amount of extra
+  travel and change how every table looks at rest; the scroll follows the boundary instead.
+- No change to `state.tableWidth`, which stays the sum of column widths and dividers.
+- No change to the resize model: widths are still accumulated raw deltas coerced to `ColumnSpec.minWidth`.
+
+## Approach
+
+Two rules, both driven from the resize gesture itself.
+
+**The boundary stays inside the viewport.** After every applied delta, `resizeScrollPullback` returns
+how far the boundary overshot the right edge, and that much is handed to
+`horizontalState.dispatchRawDelta`. The scroll range grows with the column, so the pull-back is always
+available. This is what makes the growth visible: the boundary stops at the edge and the columns to
+its left slide out of view instead.
+
+**A pointer with nowhere to go keeps the column growing.** `shouldGrowAtResizeEdge` reports whether the
+pointer is pushing right within 24dp of the right edge of the viewport. While it is, a `withFrameNanos`
+loop adds 200dp per second to the column and pulls the boundary back each frame, so holding at the edge
+grows the column continuously — the table scrolls under a pointer that has stopped moving. The loop is
+keyed on that condition, so it runs only while the pointer is parked at the edge and stops the moment
+the pointer moves away or the gesture ends.
+
+The direction is part of the condition, not an afterthought. Grabbing the last boundary puts the pointer
+inside the edge zone straight away, so a rule that looked only at position would read a small pull to the
+left as a pointer out of travel and widen the column the user is trying to narrow. A negative drag amount
+means shrinking, and shrinking is never out of room.
+
+Getting the pointer's position is why the strip moves from `Modifier.draggable` to
+`detectHorizontalDragGestures`: `draggable` reports deltas only, and a parked pointer produces none.
+The pointer's viewport X is derived from the strip's own geometry — boundary, reach and scroll offset —
+rather than from layout coordinates, so no extra measurement plumbing is needed.
+
+That swap carries one obligation. `pointerInput` is keyed on the column, so its block is composed once
+and never sees a later composition; the boundary and the current width a gesture starts from are read
+through `rememberUpdatedState`. Captured directly, every drag after the first would restart from the
+width the column had when the table was first laid out — the column would snap back before moving.
+
+`ColumnResizersOverlay` takes `horizontalState` and delegates each boundary to a private `ResizeHandle`,
+which owns the gesture and its `ColumnResizeDrag` state. The drag tracks the boundary in content pixels
+from where it started, because the `cumulativeX` composed alongside it goes stale as the column grows.
+
+**Settling.** Each pull-back dispatched during the drag is clamped by the scroll range the last
+*measured* width allowed, and the width applied on the final event is measured only afterwards. The
+released boundary can therefore sit a few pixels beyond the edge with no further event to correct it —
+and a boundary beyond the edge takes its grab strip out of reach, so the next drag has nothing to grab.
+Ending the gesture keeps the pull-back running for a few frames against the freshly composed boundary
+until nothing is left to chase.
+
+**Grab strips.** Inner boundaries keep their 3dp either side of the divider. The last one has no content
+to its right to hang over, so it takes that width back on the left and reaches 6dp in — the same strip
+width as every other boundary, rather than half of it.
+
+## Testing
+
+- `ColumnResizeScrollTest` covers both pure functions: a boundary inside, exactly at, and past the right
+  edge, a boundary scrolled out to the left, the edge-zone threshold, a pointer beyond the edge, one held
+  still, one pulling left, and an unmeasured viewport. The edge rule is tested here rather than through
+  the UI because a parked pointer keeps the frame loop running, and a composition that never idles cannot
+  finish a Compose UI test.
+- `ColumnResizeTest` (`runComposeUiTest`) scrolls a table wider than its viewport to the end, drags the
+  last boundary right with mouse input, and asserts three things: the column grew past its starting
+  width, `horizontalState.value` followed, and nothing is left to pull back once the gesture settled.
+  The first two fail without the pull-back, the third without the settling pass. A second case drags one
+  boundary twice and asserts the column keeps growing, which fails when the gesture reads its starting
+  geometry from the composition that first laid the strip out.
+
+## Out of scope
+
+The table still renders no scrollbar of its own, on any platform; horizontal scrolling remains a wheel
+or drag gesture.

--- a/docs/superpowers/specs/2026-07-30-viewport-pinned-active-filters-design.md
+++ b/docs/superpowers/specs/2026-07-30-viewport-pinned-active-filters-design.md
@@ -1,0 +1,76 @@
+# Viewport-Pinned Active-Filters Header — Design
+
+## Goal
+
+Keep the active-filters chips row readable at every horizontal scroll offset. The chips report which
+filters are currently applied, so a table wide enough to scroll must not be able to carry them off
+screen.
+
+## Motivation
+
+`Table` applies `horizontalScroll(horizontalState)` to the single `Box` that wraps everything it
+renders, and `ActiveFiltersHeader` was the first child of the `Column` inside that `Box`, sized with
+`Modifier.width(state.tableWidth)`.
+
+Two consequences followed from being scrolled content rather than a sibling of the scroll container:
+
+1. The chips are laid out from the left edge of the **content**, so scrolling a wide table to the
+   right translated them past the left edge of the viewport. The row was still there — it rendered as
+   an empty strip — and the only way to read the applied filters was to scroll all the way back.
+2. The row was as wide as the table, not as wide as the viewport, so the `‹` / `›` overflow buttons in
+   `TableActiveFilters` measured against the wrong width and effectively never appeared.
+
+A separate defect lived in the same file: `TableActiveFilters` returns early when no filter is active,
+but the surrounding `Column` still emitted its `HorizontalDivider`, leaving a stray rule above the
+header of an unfiltered table.
+
+## Non-goals
+
+- The fast-filters row stays scrolled with the columns. Each of its fields belongs to one column and
+  has to stay aligned with it; pinning it would break that correspondence.
+- No change to `TableActiveFilters` itself — it is public, and consumers place it on their own.
+- No horizontal scrollbar. The table still exposes no scrollbar of its own on any platform.
+
+## Approach
+
+Move the header out of the scroll container so it is a sibling of it rather than its content:
+
+```kotlin
+Surface(shape, border, modifier) {
+    Column {
+        if (settings.showActiveFiltersHeader) ActiveFiltersHeader(…)
+        Box(modifier = scrollAreaModifier(embedded, innerModifier)) {
+            Column { TableHeader(…); body }
+            if (showPinnedFooter) PinnedFooterOverlay(…)
+        }
+    }
+}
+```
+
+`innerModifier` — which carries `horizontalScroll`, drag-to-scroll and `clipToBounds` — now applies
+only to the `Box`, so nothing above it can be translated by the scroll state.
+
+Two width decisions come out of this, both extracted into private helpers so `EditableTable` keeps its
+cyclomatic budget:
+
+- `activeFiltersModifier(embedded, tableWidth)` — `fillMaxWidth()` normally, `width(tableWidth)` when
+  `embedded`. An embedded table is measured with an unbounded width by the scrolling parent that hosts
+  it, so `fillMaxWidth` has nothing finite to fill there.
+- `scrollAreaModifier(embedded, innerModifier)` — `weight(1f)` for a bounded table so the scroll area
+  claims the height the header left over; the bare modifier when `embedded`, where the table renders at
+  its intrinsic height.
+
+`ActiveFiltersHeader` gains a `modifier` parameter, drops its own `state.tableWidth` reads, and returns
+early when no filter is active so the divider goes with the chips.
+
+## Testing
+
+`ActiveFiltersHeaderTest` (`runComposeUiTest`) renders a table twice as wide as its viewport, applies a
+text filter, scrolls `horizontalState` to the end and asserts the chip is still displayed. The test
+fails on the previous layout and passes on this one. A second case asserts no chips row exists while no
+filter is active.
+
+## Out of scope
+
+Column resizing at the right edge of the table is a separate change; see
+`2026-07-30-last-column-resize-autoscroll-design.md`.

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/Table.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/Table.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
@@ -240,71 +242,78 @@ public fun <T : Any, C, E> EditableTable(
                     }
                 }
 
-            Box(modifier = innerModifier) {
-                Column {
-                    if (state.settings.showActiveFiltersHeader) {
-                        ActiveFiltersHeader(columns = columns, state = state, strings = strings)
-                    }
-
-                    TableHeader(
+            Column {
+                if (state.settings.showActiveFiltersHeader) {
+                    ActiveFiltersHeader(
                         columns = columns,
                         state = state,
-                        tableData = tableData,
-                        headerColor = colors.headerContainerColor,
-                        headerContentColor = colors.headerContentColor,
-                        rowContainerColor = colors.rowContainerColor,
-                        dimensions = dimensions,
                         strings = strings,
-                        icons = icons,
-                        horizontalState = horizontalState,
+                        modifier = activeFiltersModifier(embedded, state.tableWidth),
                     )
-
-                    val bodyContent: @Composable () -> Unit = {
-                        TableBodySection(
-                            embedded = embedded,
-                            itemsCount = itemsCount,
-                            itemAt = effectiveItemAt,
-                            rowKey = effectiveRowKey,
-                            visibleColumns = visibleColumns,
-                            state = state,
-                            colors = colors,
-                            customization = customization,
-                            tableData = tableData,
-                            rowEmbedded = rowEmbedded,
-                            placeholderRow = placeholderRow,
-                            onRowClick = onRowClick,
-                            onRowLongClick = onRowLongClick,
-                            onRowMove = effectiveOnRowMove,
-                            blocks = activeBlocks,
-                            onContextMenu = onContextMenuHandler,
-                            rowUnits = rowUnits,
-                            verticalState = verticalState,
-                            horizontalState = horizontalState,
-                            requestTableFocus = { tableFocusRequester.requestFocus() },
-                            enableScrolling = enableScrolling,
-                            pinnedFooterHeight = pinnedFooterHeight,
-                        )
-                    }
-
-                    // SelectionContainer is disabled while a row is in edit mode to avoid
-                    // cross-hierarchy text selection issues with popup-based editors on Desktop.
-                    if (state.settings.enableTextSelection && state.editing.rowIndex == null) {
-                        SelectionContainer { bodyContent() }
-                    } else {
-                        bodyContent()
-                    }
                 }
 
-                if (showPinnedFooter) {
-                    PinnedFooterOverlay(
-                        state = state,
-                        visibleColumns = visibleColumns,
-                        columns = columns,
-                        tableData = tableData,
-                        colors = colors,
-                        horizontalState = horizontalState,
-                        modifier = Modifier.align(Alignment.BottomStart),
-                    )
+                Box(modifier = scrollAreaModifier(embedded, innerModifier)) {
+                    Column {
+                        TableHeader(
+                            columns = columns,
+                            state = state,
+                            tableData = tableData,
+                            headerColor = colors.headerContainerColor,
+                            headerContentColor = colors.headerContentColor,
+                            rowContainerColor = colors.rowContainerColor,
+                            dimensions = dimensions,
+                            strings = strings,
+                            icons = icons,
+                            horizontalState = horizontalState,
+                        )
+
+                        val bodyContent: @Composable () -> Unit = {
+                            TableBodySection(
+                                embedded = embedded,
+                                itemsCount = itemsCount,
+                                itemAt = effectiveItemAt,
+                                rowKey = effectiveRowKey,
+                                visibleColumns = visibleColumns,
+                                state = state,
+                                colors = colors,
+                                customization = customization,
+                                tableData = tableData,
+                                rowEmbedded = rowEmbedded,
+                                placeholderRow = placeholderRow,
+                                onRowClick = onRowClick,
+                                onRowLongClick = onRowLongClick,
+                                onRowMove = effectiveOnRowMove,
+                                blocks = activeBlocks,
+                                onContextMenu = onContextMenuHandler,
+                                rowUnits = rowUnits,
+                                verticalState = verticalState,
+                                horizontalState = horizontalState,
+                                requestTableFocus = { tableFocusRequester.requestFocus() },
+                                enableScrolling = enableScrolling,
+                                pinnedFooterHeight = pinnedFooterHeight,
+                            )
+                        }
+
+                        // SelectionContainer is disabled while a row is in edit mode to avoid
+                        // cross-hierarchy text selection issues with popup-based editors on Desktop.
+                        if (state.settings.enableTextSelection && state.editing.rowIndex == null) {
+                            SelectionContainer { bodyContent() }
+                        } else {
+                            bodyContent()
+                        }
+                    }
+
+                    if (showPinnedFooter) {
+                        PinnedFooterOverlay(
+                            state = state,
+                            visibleColumns = visibleColumns,
+                            columns = columns,
+                            tableData = tableData,
+                            colors = colors,
+                            horizontalState = horizontalState,
+                            modifier = Modifier.align(Alignment.BottomStart),
+                        )
+                    }
                 }
             }
         }
@@ -549,6 +558,18 @@ private fun rememberBlockParentScrollConnection(): NestedScrollConnection =
             ): Velocity = available
         }
     }
+
+/** Viewport-wide, except when embedded: that parent measures with an unbounded width. */
+private fun activeFiltersModifier(
+    embedded: Boolean,
+    tableWidth: Dp,
+): Modifier = if (embedded) Modifier.width(tableWidth) else Modifier.fillMaxWidth()
+
+/** An embedded table renders at its intrinsic height; a scrolling one claims what the header left. */
+private fun ColumnScope.scrollAreaModifier(
+    embedded: Boolean,
+    innerModifier: Modifier,
+): Modifier = if (embedded) innerModifier else Modifier.weight(1f).then(innerModifier)
 
 /**
  * Resolves the border stroke based on the provided border parameter and table defaults.

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/ActiveFiltersHeader.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/ActiveFiltersHeader.kt
@@ -1,13 +1,13 @@
 package ua.wwind.table.component
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import kotlinx.collections.immutable.ImmutableList
 import ua.wwind.table.ColumnSpec
 import ua.wwind.table.TableActiveFilters
+import ua.wwind.table.filter.data.isActive
 import ua.wwind.table.state.TableState
 import ua.wwind.table.strings.StringProvider
 
@@ -16,15 +16,16 @@ internal fun <T : Any, C, E> ActiveFiltersHeader(
     columns: ImmutableList<ColumnSpec<T, C, E>>,
     state: TableState<C>,
     strings: StringProvider,
+    modifier: Modifier = Modifier,
 ) {
-    Column {
+    if (state.filters.none { (_, filter) -> filter.isActive() }) return
+    Column(modifier = modifier) {
         TableActiveFilters(
             columns = columns,
             state = state,
             strings = strings,
-            modifier = Modifier.width(state.tableWidth),
             includeClearAllChip = true,
         )
-        HorizontalDivider(modifier = Modifier.width(state.tableWidth))
+        HorizontalDivider()
     }
 }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/TableHeader.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/TableHeader.kt
@@ -98,6 +98,7 @@ internal fun <T : Any, C, E> TableHeader(
                         visibleColumns = derived.visibleColumns,
                         widthResolver = { key -> derived.widthMap[key] ?: dimensions.defaultColumnWidth },
                         dimensions = dimensions,
+                        horizontalState = horizontalState,
                         onResize = { key, newWidth -> state.columns.resize(key, ColumnWidthAction.Set(newWidth)) },
                         onResizeStart = { isResizing = true },
                         onResizeEnd = { isResizing = false },

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/header/ColumnResizeScroll.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/header/ColumnResizeScroll.kt
@@ -1,0 +1,16 @@
+package ua.wwind.table.component.header
+
+/** How far a resize boundary overshot the right edge of the viewport; 0 while it is still visible. */
+internal fun resizeScrollPullback(
+    boundaryPx: Float,
+    scrollValue: Int,
+    viewportPx: Int,
+): Float = (boundaryPx - scrollValue - viewportPx).coerceAtLeast(0f)
+
+/** Whether the pointer is pushing right within [zonePx] of the viewport edge, out of travel. */
+internal fun shouldGrowAtResizeEdge(
+    dragAmount: Float,
+    pointerViewportPx: Float,
+    viewportPx: Int,
+    zonePx: Float,
+): Boolean = dragAmount >= 0f && viewportPx > 0 && pointerViewportPx >= viewportPx - zonePx

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/header/ColumnResizersOverlay.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/header/ColumnResizersOverlay.kt
@@ -1,11 +1,10 @@
 package ua.wwind.table.component.header
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.gestures.draggable
-import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
@@ -15,12 +14,16 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
@@ -32,13 +35,26 @@ import ua.wwind.table.ColumnSpec
 import ua.wwind.table.config.TableDimensions
 import ua.wwind.table.state.currentTableState
 
-private const val OVERLAY_THICKNESS_DP = 6
+private const val OVERLAY_REACH_DP = 3
+
+/** The last strip has no room to hang over the boundary, so it takes that width back on the left. */
+private const val LAST_OVERLAY_REACH_DP = 6
+
+private const val EDGE_ZONE_DP = 24
+private const val EDGE_GROWTH_DP_PER_SECOND = 200f
+
+private const val NANOS_PER_SECOND = 1_000_000_000f
+
+/** Frames the released gesture is given for layout to catch up before the scroll stops chasing it. */
+private const val SETTLE_FRAMES = 8
 
 @Composable
+@Suppress("LongParameterList")
 internal fun <T : Any, C, E> ColumnResizersOverlay(
     visibleColumns: ImmutableList<ColumnSpec<T, C, E>>,
     widthResolver: (C) -> Dp,
     dimensions: TableDimensions,
+    horizontalState: ScrollState,
     onResize: (key: C, newWidth: Dp) -> Unit,
     onResizeStart: () -> Unit = {},
     onResizeEnd: () -> Unit = {},
@@ -46,71 +62,204 @@ internal fun <T : Any, C, E> ColumnResizersOverlay(
 ) {
     val state = currentTableState()
     Box(modifier = Modifier.width(state.tableWidth)) {
-        val density = LocalDensity.current
-
-        // Compute absolute X offsets (in Dp) for each column boundary divider
         var cumulativeX: Dp = 0.dp
 
         visibleColumns.forEachIndexed { index, spec ->
-            val currentWidth = widthResolver(spec.key)
-            cumulativeX += currentWidth
+            cumulativeX += widthResolver(spec.key)
 
             if (spec.resizable) {
-                // Resize handle at absolute position cumulativeX
-                var dragStartWidth by remember(spec.key) { mutableStateOf<Dp?>(null) }
-                var accumulatedDeltaPx by remember(spec.key) { mutableFloatStateOf(0f) }
-
-                val interaction = remember(spec.key) { MutableInteractionSource() }
-                val isHovered = interaction.collectIsHoveredAsState().value
-                val overlayOffset =
-                    if (index == visibleColumns.size - 1) OVERLAY_THICKNESS_DP else OVERLAY_THICKNESS_DP / 2
-
-                Box(
-                    modifier =
-                        Modifier
-                            .fillMaxHeight()
-                            // Absolute placement at boundary
-                            .offset(x = cumulativeX - overlayOffset.dp, y = 0.dp)
-                            .hoverable(interactionSource = interaction)
-                            .pointerInput(spec.key) {
-                                detectTapGestures(onDoubleTap = { onDoubleClick(spec.key) })
-                            }.combinedClickable(onDoubleClick = { onDoubleClick(spec.key) }) {}
-                            .draggable(
-                                state =
-                                    rememberDraggableState { delta ->
-                                        accumulatedDeltaPx += delta
-
-                                        val baseWidth = dragStartWidth ?: currentWidth
-                                        val totalDeltaDp = with(density) { accumulatedDeltaPx.toDp() }
-                                        val newWidth =
-                                            (baseWidth + totalDeltaDp).coerceAtLeast(spec.minWidth)
-                                        onResize(spec.key, newWidth)
-                                    },
-                                orientation = Orientation.Horizontal,
-                                onDragStarted = {
-                                    dragStartWidth = widthResolver(spec.key)
-                                    accumulatedDeltaPx = 0f
-                                    onResizeStart()
-                                },
-                                onDragStopped = {
-                                    dragStartWidth = null
-                                    accumulatedDeltaPx = 0f
-                                    onResizeEnd()
-                                },
-                            ).pointerHoverIcon(PointerIcon.Hand)
-                            .width(dimensions.dividerThickness + OVERLAY_THICKNESS_DP.dp)
-                            .background(
-                                color =
-                                    if (isHovered) {
-                                        MaterialTheme.colorScheme.outline.copy(alpha = 0.9f)
-                                    } else {
-                                        androidx.compose.ui.graphics.Color.Transparent
-                                    },
-                            ),
+                val isLast = index == visibleColumns.size - 1
+                ResizeHandle(
+                    columnKey = spec.key,
+                    boundaryX = cumulativeX,
+                    minWidth = spec.minWidth,
+                    reach = if (isLast) LAST_OVERLAY_REACH_DP.dp else OVERLAY_REACH_DP.dp,
+                    overhang = if (isLast) 0.dp else OVERLAY_REACH_DP.dp,
+                    dividerThickness = dimensions.dividerThickness,
+                    widthResolver = widthResolver,
+                    horizontalState = horizontalState,
+                    onResize = onResize,
+                    onResizeStart = onResizeStart,
+                    onResizeEnd = onResizeEnd,
+                    onDoubleClick = onDoubleClick,
                 )
             }
-            // Advance past the divider thickness to align subsequent handles
             cumulativeX += dimensions.dividerThickness
         }
+    }
+}
+
+/** Grab strip [reach] wide to the left of one column boundary; dragging resizes and scrolls after it. */
+@Composable
+@Suppress("LongParameterList")
+private fun <C> ResizeHandle(
+    columnKey: C,
+    boundaryX: Dp,
+    minWidth: Dp,
+    reach: Dp,
+    overhang: Dp,
+    dividerThickness: Dp,
+    widthResolver: (C) -> Dp,
+    horizontalState: ScrollState,
+    onResize: (key: C, newWidth: Dp) -> Unit,
+    onResizeStart: () -> Unit,
+    onResizeEnd: () -> Unit,
+    onDoubleClick: (key: C) -> Unit,
+) {
+    val density = LocalDensity.current
+    val interaction = remember(columnKey) { MutableInteractionSource() }
+    val isHovered by interaction.collectIsHoveredAsState()
+    val drag = remember(columnKey) { ColumnResizeDrag() }
+
+    // pointerInput is keyed on the column alone, so its block never sees a later composition:
+    // read the geometry a gesture starts from live, or every drag restarts from the first width.
+    val currentBoundaryX by rememberUpdatedState(boundaryX)
+    val currentWidth by rememberUpdatedState(widthResolver(columnKey))
+
+    fun grow(deltaPx: Float) {
+        val start = drag.startWidth ?: return
+        drag.accumulatedPx += deltaPx
+        onResize(columnKey, (start + with(density) { drag.accumulatedPx.toDp() }).coerceAtLeast(minWidth))
+        val pullback = resizeScrollPullback(drag.boundaryPx, horizontalState.value, horizontalState.viewportSize)
+        if (pullback > 0f) horizontalState.dispatchRawDelta(pullback)
+    }
+
+    GrowWhileHeldAtEdge(drag, ::grow)
+    SettleScrollAfterDrag(drag, horizontalState) { with(density) { currentBoundaryX.toPx() } }
+
+    Box(
+        modifier =
+            Modifier
+                .fillMaxHeight()
+                .offset(x = boundaryX - reach, y = 0.dp)
+                .hoverable(interactionSource = interaction)
+                .pointerInput(columnKey) {
+                    detectTapGestures(onDoubleTap = { onDoubleClick(columnKey) })
+                }.combinedClickable(onDoubleClick = { onDoubleClick(columnKey) }) {}
+                .pointerInput(columnKey) {
+                    detectHorizontalDragGestures(
+                        onDragStart = {
+                            drag.begin(with(density) { currentBoundaryX.toPx() }, currentWidth)
+                            onResizeStart()
+                        },
+                        onDragEnd = {
+                            drag.end()
+                            onResizeEnd()
+                        },
+                        onDragCancel = {
+                            drag.end()
+                            onResizeEnd()
+                        },
+                    ) { change, dragAmount ->
+                        val handleLeftPx = drag.boundaryPx - with(density) { reach.toPx() }
+                        drag.onDrag(
+                            dragAmount = dragAmount,
+                            pointerViewportPx = handleLeftPx - horizontalState.value + change.position.x,
+                            viewportPx = horizontalState.viewportSize,
+                            zonePx = with(density) { EDGE_ZONE_DP.dp.toPx() },
+                        )
+                        grow(dragAmount)
+                    }
+                }.pointerHoverIcon(PointerIcon.Hand)
+                .width(reach + dividerThickness + overhang)
+                .background(
+                    color =
+                        if (isHovered) {
+                            MaterialTheme.colorScheme.outline.copy(alpha = 0.9f)
+                        } else {
+                            Color.Transparent
+                        },
+                ),
+    )
+}
+
+@Composable
+private fun GrowWhileHeldAtEdge(
+    drag: ColumnResizeDrag,
+    grow: (Float) -> Unit,
+) {
+    val ratePx = with(LocalDensity.current) { EDGE_GROWTH_DP_PER_SECOND.dp.toPx() }
+    val currentGrow by rememberUpdatedState(grow)
+    LaunchedEffect(drag.holdingAtEdge) {
+        if (!drag.holdingAtEdge) return@LaunchedEffect
+        var previousNanos = withFrameNanos { it }
+        while (true) {
+            val nanos = withFrameNanos { it }
+            currentGrow(ratePx * ((nanos - previousNanos) / NANOS_PER_SECOND))
+            previousNanos = nanos
+        }
+    }
+}
+
+/** Mid-drag pull-backs are clamped by the last measured scroll range, so the release needs chasing. */
+@Composable
+private fun SettleScrollAfterDrag(
+    drag: ColumnResizeDrag,
+    horizontalState: ScrollState,
+    boundaryPx: () -> Float,
+) {
+    val currentBoundaryPx by rememberUpdatedState(boundaryPx)
+    LaunchedEffect(drag.settling) {
+        if (!drag.settling) return@LaunchedEffect
+        var frames = 0
+        while (frames < SETTLE_FRAMES) {
+            withFrameNanos { }
+            val pullback =
+                resizeScrollPullback(currentBoundaryPx(), horizontalState.value, horizontalState.viewportSize)
+            if (pullback <= 0f) break
+            horizontalState.dispatchRawDelta(pullback)
+            frames++
+        }
+        drag.settled()
+    }
+}
+
+/** One resize gesture. Tracks the boundary from drag start: the composed `cumulativeX` goes stale. */
+private class ColumnResizeDrag {
+    var startWidth: Dp? by mutableStateOf(null)
+        private set
+
+    /** True while the pointer has run out of travel at the right edge and the column must grow on its own. */
+    var holdingAtEdge: Boolean by mutableStateOf(false)
+        private set
+
+    /** True until the scroll has caught up with the width the released gesture left behind. */
+    var settling: Boolean by mutableStateOf(false)
+        private set
+
+    var accumulatedPx: Float by mutableFloatStateOf(0f)
+
+    private var startBoundaryPx: Float = 0f
+
+    val boundaryPx: Float get() = startBoundaryPx + accumulatedPx
+
+    fun begin(
+        boundaryPx: Float,
+        width: Dp,
+    ) {
+        startBoundaryPx = boundaryPx
+        startWidth = width
+        accumulatedPx = 0f
+        settling = false
+    }
+
+    fun end() {
+        startWidth = null
+        accumulatedPx = 0f
+        holdingAtEdge = false
+        settling = true
+    }
+
+    fun settled() {
+        settling = false
+    }
+
+    fun onDrag(
+        dragAmount: Float,
+        pointerViewportPx: Float,
+        viewportPx: Int,
+        zonePx: Float,
+    ) {
+        holdingAtEdge = shouldGrowAtResizeEdge(dragAmount, pointerViewportPx, viewportPx, zonePx)
     }
 }

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/ActiveFiltersHeaderTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/ActiveFiltersHeaderTest.kt
@@ -1,0 +1,102 @@
+package ua.wwind.table
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isGreaterThan
+import kotlinx.collections.immutable.persistentListOf
+import ua.wwind.table.config.TableSettings
+import ua.wwind.table.filter.data.FilterConstraint
+import ua.wwind.table.filter.data.TableFilterState
+import ua.wwind.table.filter.data.TableFilterType
+import ua.wwind.table.state.TableState
+import ua.wwind.table.state.rememberTableState
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class ActiveFiltersHeaderTest {
+    private val columns =
+        tableColumns<String, String, Unit> {
+            column("a", valueOf = { it }) {
+                header("A")
+                width(500.dp, 500.dp)
+                resizable(false)
+                filter(TableFilterType.TextTableFilter())
+                cell { item, _ -> Text(item) }
+            }
+            column("b", valueOf = { it }) {
+                header("B")
+                width(500.dp, 500.dp)
+                resizable(false)
+                cell { _, _ -> Text("cell-b") }
+            }
+        }
+
+    @Test
+    fun `an active filter chip stays on screen after the table is scrolled right`() =
+        runComposeUiTest {
+            lateinit var state: TableState<String>
+            lateinit var horizontalState: ScrollState
+
+            setContent {
+                state =
+                    rememberTableState(
+                        columns = persistentListOf("a", "b"),
+                        settings = TableSettings(showActiveFiltersHeader = true),
+                    )
+                horizontalState = rememberScrollState()
+                Box(Modifier.size(600.dp, 400.dp)) {
+                    Table(
+                        itemsCount = 1,
+                        itemAt = { "row" },
+                        state = state,
+                        columns = columns,
+                        horizontalState = horizontalState,
+                    )
+                }
+            }
+
+            waitForIdle()
+            state.setFilter("a", TableFilterState(FilterConstraint.CONTAINS, listOf("x")))
+            waitForIdle()
+            onNodeWithText("A:", substring = true).assertIsDisplayed()
+
+            horizontalState.dispatchRawDelta(10_000f)
+            waitForIdle()
+
+            assertThat(horizontalState.value).isGreaterThan(0)
+            onNodeWithText("A:", substring = true).assertIsDisplayed()
+        }
+
+    @Test
+    fun `no chips row is rendered while no filter is active`() =
+        runComposeUiTest {
+            setContent {
+                val state =
+                    rememberTableState(
+                        columns = persistentListOf("a", "b"),
+                        settings = TableSettings(showActiveFiltersHeader = true),
+                    )
+                Box(Modifier.size(600.dp, 400.dp)) {
+                    Table(
+                        itemsCount = 1,
+                        itemAt = { "row" },
+                        state = state,
+                        columns = columns,
+                    )
+                }
+            }
+
+            waitForIdle()
+            onNodeWithText("Clear").assertDoesNotExist()
+        }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/ColumnResizeTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/ColumnResizeTest.kt
@@ -1,0 +1,172 @@
+package ua.wwind.table
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isLessThan
+import assertk.assertions.isNotNull
+import kotlinx.collections.immutable.persistentListOf
+import ua.wwind.table.component.header.resizeScrollPullback
+import ua.wwind.table.state.TableState
+import ua.wwind.table.state.rememberTableState
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class ColumnResizeTest {
+    private val columns =
+        tableColumns<String, String, Unit> {
+            column("a", valueOf = { it }) {
+                header("A")
+                width(100.dp, 500.dp)
+                cell { item, _ -> Text(item) }
+            }
+            column("b", valueOf = { it }) {
+                header("B")
+                width(100.dp, 500.dp)
+                cell { _, _ -> Text("cell-b") }
+            }
+        }
+
+    @Test
+    fun `dragging the last boundary right widens the column and scrolls after it`() =
+        runComposeUiTest {
+            lateinit var state: TableState<String>
+            lateinit var horizontalState: ScrollState
+
+            setContent {
+                state = rememberTableState(columns = persistentListOf("a", "b"))
+                horizontalState = rememberScrollState()
+                Box(Modifier.size(600.dp, 400.dp)) {
+                    Table(
+                        itemsCount = 1,
+                        itemAt = { "row" },
+                        state = state,
+                        columns = columns,
+                        horizontalState = horizontalState,
+                    )
+                }
+            }
+
+            waitForIdle()
+            horizontalState.dispatchRawDelta(10_000f)
+            waitForIdle()
+
+            val scrollBeforeResize = horizontalState.value
+            val divider = state.dimensions.dividerThickness
+            val boundaryPx = with(density) { (state.tableWidth - divider).toPx() }
+            val grabX = boundaryPx - scrollBeforeResize - with(density) { 2.dp.toPx() }
+            val grabY = with(density) { (state.dimensions.headerHeight / 2).toPx() }
+
+            onRoot().performMouseInput {
+                moveTo(Offset(grabX, grabY))
+                press()
+                repeat(4) { moveBy(Offset(20f, 0f)) }
+                release()
+            }
+            waitForIdle()
+
+            val resized = state.columns.widths["b"]
+            assertThat(resized).isNotNull()
+            assertThat(resized!!.value).isGreaterThan(500f)
+            assertThat(horizontalState.value).isGreaterThan(scrollBeforeResize)
+
+            val boundaryAfter = with(density) { (state.tableWidth - divider).toPx() }
+            assertThat(
+                resizeScrollPullback(boundaryAfter, horizontalState.value, horizontalState.viewportSize),
+            ).isEqualTo(0f)
+        }
+
+    @Test
+    fun `a small drag left at the right edge narrows the last column`() =
+        runComposeUiTest {
+            lateinit var state: TableState<String>
+            lateinit var horizontalState: ScrollState
+
+            setContent {
+                state = rememberTableState(columns = persistentListOf("a", "b"))
+                horizontalState = rememberScrollState()
+                Box(Modifier.size(600.dp, 400.dp)) {
+                    Table(
+                        itemsCount = 1,
+                        itemAt = { "row" },
+                        state = state,
+                        columns = columns,
+                        horizontalState = horizontalState,
+                    )
+                }
+            }
+
+            waitForIdle()
+            horizontalState.dispatchRawDelta(10_000f)
+            waitForIdle()
+
+            val divider = state.dimensions.dividerThickness
+            val boundaryPx = with(density) { (state.tableWidth - divider).toPx() }
+            val grabX = boundaryPx - horizontalState.value - with(density) { 2.dp.toPx() }
+            val grabY = with(density) { (state.dimensions.headerHeight / 2).toPx() }
+
+            onRoot().performMouseInput {
+                moveTo(Offset(grabX, grabY))
+                press()
+                repeat(4) { moveBy(Offset(-20f, 0f)) }
+                release()
+            }
+            waitForIdle()
+
+            val resized = state.columns.widths["b"]
+            assertThat(resized).isNotNull()
+            assertThat(resized!!.value).isLessThan(500f)
+        }
+
+    @Test
+    fun `a second drag continues from the width the first one left`() =
+        runComposeUiTest {
+            lateinit var state: TableState<String>
+
+            setContent {
+                state = rememberTableState(columns = persistentListOf("a", "b"))
+                Box(Modifier.size(1200.dp, 400.dp)) {
+                    Table(
+                        itemsCount = 1,
+                        itemAt = { "row" },
+                        state = state,
+                        columns = columns,
+                    )
+                }
+            }
+
+            waitForIdle()
+            val grabY = with(density) { (state.dimensions.headerHeight / 2).toPx() }
+
+            fun dragBoundaryRight() {
+                val boundaryPx = with(density) { (state.columns.widths["a"] ?: 500.dp).toPx() }
+                onRoot().performMouseInput {
+                    moveTo(Offset(boundaryPx - with(density) { 1.dp.toPx() }, grabY))
+                    press()
+                    repeat(4) { moveBy(Offset(10f, 0f)) }
+                    release()
+                }
+                waitForIdle()
+            }
+
+            dragBoundaryRight()
+            val afterFirst = state.columns.widths["a"]
+            assertThat(afterFirst).isNotNull()
+            assertThat(afterFirst!!.value).isGreaterThan(500f)
+
+            dragBoundaryRight()
+            assertThat(state.columns.widths["a"]!!.value).isGreaterThan(afterFirst.value)
+        }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/component/header/ColumnResizeScrollTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/component/header/ColumnResizeScrollTest.kt
@@ -1,0 +1,56 @@
+package ua.wwind.table.component.header
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+class ColumnResizeScrollTest {
+    @Test
+    fun `a boundary inside the viewport needs no scrolling`() {
+        assertThat(resizeScrollPullback(boundaryPx = 400f, scrollValue = 0, viewportPx = 600)).isEqualTo(0f)
+    }
+
+    @Test
+    fun `a boundary exactly at the right edge needs no scrolling`() {
+        assertThat(resizeScrollPullback(boundaryPx = 600f, scrollValue = 0, viewportPx = 600)).isEqualTo(0f)
+    }
+
+    @Test
+    fun `a boundary past the right edge is pulled back by the overshoot`() {
+        assertThat(resizeScrollPullback(boundaryPx = 1000f, scrollValue = 300, viewportPx = 600)).isEqualTo(100f)
+    }
+
+    @Test
+    fun `a boundary scrolled out to the left is not pulled back`() {
+        assertThat(resizeScrollPullback(boundaryPx = 100f, scrollValue = 800, viewportPx = 600)).isEqualTo(0f)
+    }
+
+    @Test
+    fun `the edge zone starts one zone width before the right edge`() {
+        assertThat(shouldGrowAtResizeEdge(4f, pointerViewportPx = 575f, viewportPx = 600, zonePx = 24f)).isFalse()
+        assertThat(shouldGrowAtResizeEdge(4f, pointerViewportPx = 576f, viewportPx = 600, zonePx = 24f)).isTrue()
+    }
+
+    @Test
+    fun `a pointer beyond the right edge keeps growing the column`() {
+        assertThat(shouldGrowAtResizeEdge(4f, pointerViewportPx = 900f, viewportPx = 600, zonePx = 24f)).isTrue()
+    }
+
+    @Test
+    fun `a pointer pulling left at the edge shrinks instead of growing`() {
+        assertThat(shouldGrowAtResizeEdge(-4f, pointerViewportPx = 900f, viewportPx = 600, zonePx = 24f)).isFalse()
+        assertThat(shouldGrowAtResizeEdge(-1f, pointerViewportPx = 598f, viewportPx = 600, zonePx = 24f)).isFalse()
+    }
+
+    @Test
+    fun `a pointer held still at the edge keeps growing the column`() {
+        assertThat(shouldGrowAtResizeEdge(0f, pointerViewportPx = 598f, viewportPx = 600, zonePx = 24f)).isTrue()
+    }
+
+    @Test
+    fun `an unmeasured viewport has no edge zone`() {
+        assertThat(shouldGrowAtResizeEdge(4f, pointerViewportPx = 0f, viewportPx = 0, zonePx = 24f)).isFalse()
+    }
+}


### PR DESCRIPTION
Description:


Two fixes to the table header.

**Active-filters header.** It was laid out inside the horizontally scrolling
content at the full table width, so scrolling a wide table right carried the chips
off the left edge. It is now a sibling of the scroll container, sized to the
viewport. Its divider no longer renders alone above an unfiltered table.

**Last column resize.** Its boundary sits at the right edge of the content, so
widening it happened off screen and the pointer ran out of travel within a few
pixels. The scroll now follows the boundary, holding at the edge keeps the column
growing, and a released gesture keeps chasing the boundary until it is back in view.

No public API change. Covered by `ActiveFiltersHeaderTest`, `ColumnResizeTest` and
`ColumnResizeScrollTest`;