### PR TITLE
Update paging to 2.3.0 and declare its types stable to Compose

### DIFF
--- a/compose_compiler_config.conf
+++ b/compose_compiler_config.conf
@@ -1,0 +1,37 @@
+// Compose stability configuration.
+//
+// `ua.wwind.paging:paging-core` is built without the Compose compiler plugin — that is what keeps
+// it usable from plain Kotlin and free of a Compose runtime dependency. The Compose compiler only
+// infers stability for classes it compiles itself, so left alone it treats every type coming out of
+// that library as *unstable*. The paged `Table` overloads in `table-paging` take a `PagingData`,
+// and strong skipping compares an unstable parameter by instance rather than by value; since the
+// pagers publish a fresh snapshot per state change, those overloads recomposed on every emission
+// however little of the window had actually changed.
+//
+// Listing the types here tells the compiler otherwise, and the claim holds: each is an immutable
+// snapshot whose properties are `val`s fixed at construction, and the pagers publish a new instance
+// per state change instead of mutating the one already handed out. The list is upstream's, shipped
+// as `compose_compiler_config.conf` in White-Wind-LLC/paging-kmp since 2.3.0.
+//
+// `<_>` marks the type parameter as not affecting stability, which is what makes an entry apply to
+// `PagingData<YourRow>` for any row type. Your own row type still has to be stable in its own right
+// for a row to be skippable — which it is by default for a `data class` of `val`s compiled by the
+// plugin in your own module.
+//
+// Consumers of `table-paging` need this file in their own build too: it governs the module doing
+// the compiling, so wiring it here only covers the composables `table-paging` itself declares.
+// See docs/content/modules/table-paging.md.
+
+ua.wwind.paging.core.PagingData<_>
+ua.wwind.paging.core.PagingMap<_>
+ua.wwind.paging.core.DataPortion<_>
+
+ua.wwind.paging.core.LoadState
+ua.wwind.paging.core.LoadState.Loading
+ua.wwind.paging.core.LoadState.Success
+ua.wwind.paging.core.LoadState.Error
+
+// The sealed parent covers a parameter or a `remember` typed as `EntryState<T>`.
+// `EntryState.Success` is deliberately left out: it carries an item of the element type, and
+// whether that is safe to skip over is a question about that type, not about the paging library.
+ua.wwind.paging.core.EntryState<_>

--- a/docs/content/modules/table-paging.md
+++ b/docs/content/modules/table-paging.md
@@ -66,3 +66,35 @@ Table(
 
 As in the core table, blocks require a stable `rowKey` (the default positional key triggers a
 warning), and `RowBlocks` should be held in `remember`.
+
+## Compose stability
+
+`paging-core` is built without the Compose compiler plugin — that is what keeps it usable from
+plain Kotlin and free of a Compose runtime dependency. The compiler only infers stability for
+classes it compiles itself, so left alone it treats `PagingData` and everything around it as
+**unstable**, and strong skipping then compares such a parameter by instance instead of by value.
+The pagers publish a fresh snapshot per state change, so a composable taking one recomposes on
+every emission however little of the window actually changed.
+
+`table-paging` declares those types stable for its own compilation, so the `Table` overloads above
+are already covered. A stability configuration only governs the module doing the compiling, so if
+your own composables take a `PagingData` — a screen, a view-model-bound wrapper, a `LazyColumn`
+using `handleLoadState` — you need the same file in your build.
+
+`paging-core` ships it as
+[`compose_compiler_config.conf`](https://github.com/White-Wind-LLC/paging-kmp/blob/main/compose_compiler_config.conf)
+since 2.3.0. Copy it into your repository and point the Compose compiler at it from every module
+that touches a pager:
+
+```kotlin
+composeCompiler {
+    stabilityConfigurationFiles.add(
+        rootProject.layout.projectDirectory.file("compose_compiler_config.conf"),
+    )
+}
+```
+
+Your row type still has to be stable in its own right for a row to be skippable, which it is by
+default for a `data class` of `val`s compiled in your own module. To check what the compiler makes
+of it, set `composeCompiler { reportsDestination.set(...) }` and read the generated
+`*-composables.txt`: `items` should read `stable items: PagingData<T>?`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ slf4j = "2.0.18"
 
 # --- UI & UX ---
 reorderable = "3.1.0"
-paging = "2.2.7"
+paging = "2.3.0"
 colorpicker = "1.2.0"
 liquid = "1.1.1"
 fastscroller = "0.3.2"

--- a/table-paging/build.gradle.kts
+++ b/table-paging/build.gradle.kts
@@ -6,6 +6,18 @@ plugins {
     id("ua.wwind.convention.publishing")
 }
 
+// `paging-core` ships without the Compose compiler plugin, so the compiler infers no stability for
+// its types: `PagingData` counted as unstable, and strong skipping falls back to comparing an
+// unstable parameter by instance. The pagers publish a fresh snapshot per state change, so the
+// paged `Table` overloads recomposed on every emission even when the window they render was
+// unchanged. Declaring the types stable puts `items` back on value comparison — see the file for
+// why that claim is sound.
+composeCompiler {
+    stabilityConfigurationFiles.add(
+        rootProject.layout.projectDirectory.file("compose_compiler_config.conf"),
+    )
+}
+
 kotlin {
     sourceSets {
         commonMain.dependencies {


### PR DESCRIPTION
Bumps `ua.wwind.paging:paging-core` from 2.2.7 to [2.3.0](https://github.com/White-Wind-LLC/paging-kmp/releases/tag/v2.3.0).

## Breaking changes in the release, and why none reach this repo

- **`Pager` gained `keyDebounceMs` and `concurrency` between `cacheSize` and `readData`.** Only calls passing `readData` as the fourth *positional* argument break. Nothing in this repo constructs a `Pager` — `table-paging` consumes `PagingData` and never creates one.
- **`Pager` now fetches up to `concurrency` (default 4) chunks in parallel.** A consumer-side behaviour change; the table adapter is unaffected.
- **`macosX64` dropped.** This project builds jvm / js / wasmJs / android / ios, no macOS targets.

The types `table-paging` actually consumes — `PagingData`, `PagingMap`, `LoadState`, `EntryState.getOrNull()` — changed only in formatting between the two versions, so no adapter code needed touching. The toolchain versions 2.3.0 bumped to (Kotlin 2.4.10, coroutines 1.11.0, Compose Multiplatform 1.11.1, collections-immutable 0.5.1, Kermit 2.1.0) are already what this repo is on.

## What the release does bring here: Compose stability

`paging-core` is built without the Compose compiler plugin — that is what keeps it usable from plain Kotlin and free of a Compose runtime dependency. The compiler infers stability only for classes it compiles itself, so it treated `PagingData` as **unstable**. Strong skipping compares an unstable parameter by instance rather than by value, and the pagers publish a fresh snapshot per state change, so the paged `Table` overloads recomposed on every emission however little of the window had actually changed.

2.3.0 ships a `compose_compiler_config.conf` declaring those types stable. This PR copies it to the repo root and wires it into `table-paging`.

Verified with a Compose compiler report, both directions:

| | report line |
|---|---|
| without the config | `unstable items: PagingData<T>?` |
| with the config | `stable items: PagingData<T>?` |

## Consumer-facing note

A stability configuration governs only the module doing the compiling. Wiring it here covers the `Table` overloads `table-paging` declares; a consumer whose own composables take a `PagingData` needs the same file in their own build. `docs/content/modules/table-paging.md` gains a **Compose stability** section saying so, with the snippet and how to verify it.

## Verification

- `./gradlew :table-paging:compileKotlinJvm :table-paging:compileKotlinJs :table-paging:compileKotlinWasmJs qualityCheck` — BUILD SUCCESSFUL
- `:table-paging:dependencies` confirms `ua.wwind.paging:paging-core:2.3.0` resolves

No CHANGELOG entry: no public API of this library changed, and the version is not being renumbered here.