### PR TITLE
Key rows without resolving them (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+### Unreleased
+
+- Fixed: the table resolved a row for every key a lazy list asked for, and Compose asks over its
+  nearest range — 130 rows from the top of the list, against the twenty on screen. On a paged table
+  that turned a key lookup into a data read: `PagingMap.get` is what tells a pager where the viewport
+  is, so the table reported a viewport of ~130 rows, the pager streamed and cached around it, and the
+  rows actually being looked at were evicted and re-read in a loop (69 portion requests, 63 of them
+  cancelled, from a stationary viewport). A key that does not need the item no longer resolves one,
+  and the paged adapter answers a custom `rowKey` from the rows already loaded in the paging map —
+  the same row the accessor would return, minus the access the pager acts on. Building the list no
+  longer resolves a row the table is not rendering
+  ([#60](https://github.com/White-Wind-LLC/table/issues/60)).
+- Added: `rowKeyAt(index)` on the core table entry points — a key-by-index lookup that supersedes
+  `rowKey` wherever the table needs a key, so no row is resolved to produce one. Pass it (answering
+  the same key `rowKey` would) when a read from your loader has a side effect the table should not
+  trigger while keying rows. The paged overloads set it themselves and gained no parameter.
+- Updated: `ua.wwind.paging:paging-core` to 2.3.1 (from 2.3.0), which fixes the pager half of the
+  same loop — a window oscillating between the two ends of a read span wider than it
+  ([paging-kmp#45](https://github.com/White-Wind-LLC/paging-kmp/issues/45)). It is an
+  `implementation` dependency, so you declare your own version; either fix alone stops the loop.
+
 ### 2.3.0 — 2026-08-02
 
 The paged table stops recomposing on every pager emission. `paging-core` is built without the Compose

--- a/docs/content/modules/table-paging.md
+++ b/docs/content/modules/table-paging.md
@@ -15,6 +15,24 @@ fun PeoplePagingTable(paging: PagingData<Person>) {
 
 There is also `LazyListScope.handleLoadState(...)` to render loading/empty states.
 
+## Row keys never move the pager
+
+`PagingMap.get` is what tells a pager where the viewport is, and a lazy list asks for row keys over a
+range far wider than the viewport — Compose's nearest range is 130 rows from the top of the list,
+against the twenty or so on screen. A table that resolved a row to build each key therefore reported
+a viewport that wide, and the pager streamed and cached around it: with a window narrower than the
+range being read, the two ends evicted each other and the table reloaded forever.
+
+Nothing to configure — the adapter keys rows without touching the accessor the pager acts on:
+
+- the default positional key needs no row at all;
+- a `rowKey` of your own is answered from the rows already loaded in the paging map, so it sees
+  exactly what the accessor would return, minus the access.
+
+Keying the list no longer reports a viewport at all. The other half of that loop was a pager bug and
+is fixed in `paging-core` 2.3.1 ([paging-kmp#45](https://github.com/White-Wind-LLC/paging-kmp/issues/45));
+either fix alone stops the reload loop, and `table-paging` is built against 2.3.1.
+
 ## Row blocks
 
 The adapter forwards the same `rowBlocks: RowBlocks<T>?` parameter as the core table, with the same

--- a/docs/content/reference/core-api.md
+++ b/docs/content/reference/core-api.md
@@ -9,6 +9,12 @@
       from the public `TableIcons` set — see the [Custom header icons](../guides/custom-header-icons.md) guide),
       `strings`, `shape`, `border` (outer border; `null` = theme default, `TableDefaults.NoBorder` = no border).
     - **Scroll**: optional `verticalState`, `horizontalState`.
+    - **Row identity**: `rowKey(item, index)` keys a row; it defaults to the row's position, and the table
+      resolves no row to key one by position. `rowKeyAt(index)` is an optional key-by-index lookup that
+      supersedes `rowKey` wherever a key is needed and must answer the same key — pass it when resolving a row
+      has a side effect the table should not trigger for a key. A lazy list asks for keys over a range far wider
+      than the viewport (130 rows from the top of the list), so a source that loads on access — a pager — reads
+      keying through `itemAt` as a viewport many times the real one.
     - **Embedded content**: `embedded` flag and `rowEmbedded` slot let you render nested detail content or even a
       secondary table inside each row, while still reusing the same table state, filters and formatting rules.
 - **Composable `Table<T, C, E>`**: overload that accepts custom table data for headers, footers, and edit cells.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ slf4j = "2.0.18"
 
 # --- UI & UX ---
 reorderable = "3.1.0"
-paging = "2.3.0"
+paging = "2.3.1"
 colorpicker = "1.2.0"
 liquid = "1.1.1"
 fastscroller = "0.3.2"

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/Table.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/Table.kt
@@ -128,6 +128,13 @@ public fun <T : Any, C, E> EditableTable(
     modifier: Modifier = Modifier,
     placeholderRow: (@Composable () -> Unit)? = null,
     rowKey: (item: T?, index: Int) -> Any = DefaultRowKey,
+    /**
+     * Row key by index, superseding [rowKey] wherever a key is needed; it must answer the same key.
+     *
+     * Pass it when resolving a row has a side effect: a lazy list asks for keys over ~130 rows from
+     * the top of the list, and a paged source reads every one of those as a viewport position.
+     */
+    rowKeyAt: ((index: Int) -> Any)? = null,
     onRowClick: ((T) -> Unit)? = null,
     onRowLongClick: ((T) -> Unit)? = null,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)? = null,
@@ -169,12 +176,13 @@ public fun <T : Any, C, E> EditableTable(
 
     state.visibleColumns = visibleColumns
 
-    val source = rememberEffectiveRowSource(state, rowBlocks, rowKey, onRowMove, itemsCount, itemAt)
+    val source = rememberEffectiveRowSource(state, rowBlocks, rowKey, rowKeyAt, onRowMove, itemsCount, itemAt)
     val activeBlocks = source.blocks
     val effectiveOnRowMove = source.onRowMove
     val effectiveItemAt = source.itemAt
     val effectiveRowKey = source.rowKey
-    WarnRowBlocksMisuse(rowBlocks, rowKey, source.suppressedByGroupBy)
+    val effectiveRowKeyAt = source.rowKeyAt
+    WarnRowBlocksMisuse(rowBlocks, rowKey, rowKeyAt, source.suppressedByGroupBy)
 
     val rowUnits = activeBlocks?.units ?: remember(itemsCount) { buildRowUnitIndex(itemsCount, null) }
     state.rowUnits = rowUnits
@@ -273,6 +281,7 @@ public fun <T : Any, C, E> EditableTable(
                                 itemsCount = itemsCount,
                                 itemAt = effectiveItemAt,
                                 rowKey = effectiveRowKey,
+                                rowKeyAt = effectiveRowKeyAt,
                                 visibleColumns = visibleColumns,
                                 state = state,
                                 colors = colors,
@@ -378,6 +387,13 @@ public fun <T : Any, C> Table(
     modifier: Modifier = Modifier,
     placeholderRow: (@Composable () -> Unit)? = null,
     rowKey: (item: T?, index: Int) -> Any = DefaultRowKey,
+    /**
+     * Row key by index, superseding [rowKey] wherever a key is needed; it must answer the same key.
+     *
+     * Pass it when resolving a row has a side effect: a lazy list asks for keys over ~130 rows from
+     * the top of the list, and a paged source reads every one of those as a viewport position.
+     */
+    rowKeyAt: ((index: Int) -> Any)? = null,
     onRowClick: ((T) -> Unit)? = null,
     onRowLongClick: ((T) -> Unit)? = null,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)? = null,
@@ -408,6 +424,7 @@ public fun <T : Any, C> Table(
         modifier = modifier,
         placeholderRow = placeholderRow,
         rowKey = rowKey,
+        rowKeyAt = rowKeyAt,
         onRowClick = onRowClick,
         onRowLongClick = onRowLongClick,
         onRowMove = onRowMove,
@@ -478,6 +495,13 @@ public fun <T : Any, C, E> Table(
     modifier: Modifier = Modifier,
     placeholderRow: (@Composable () -> Unit)? = null,
     rowKey: (item: T?, index: Int) -> Any = DefaultRowKey,
+    /**
+     * Row key by index, superseding [rowKey] wherever a key is needed; it must answer the same key.
+     *
+     * Pass it when resolving a row has a side effect: a lazy list asks for keys over ~130 rows from
+     * the top of the list, and a paged source reads every one of those as a viewport position.
+     */
+    rowKeyAt: ((index: Int) -> Any)? = null,
     onRowClick: ((T) -> Unit)? = null,
     onRowLongClick: ((T) -> Unit)? = null,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)? = null,
@@ -508,6 +532,7 @@ public fun <T : Any, C, E> Table(
         modifier = modifier,
         placeholderRow = placeholderRow,
         rowKey = rowKey,
+        rowKeyAt = rowKeyAt,
         onRowClick = onRowClick,
         onRowLongClick = onRowLongClick,
         onRowMove = onRowMove,
@@ -635,6 +660,7 @@ private fun <T : Any, C, E> TableBodySection(
     itemsCount: Int,
     itemAt: (Int) -> T?,
     rowKey: (item: T?, index: Int) -> Any,
+    rowKeyAt: ((index: Int) -> Any)?,
     visibleColumns: ImmutableList<ColumnSpec<T, C, E>>,
     state: TableState<C>,
     colors: TableColors,
@@ -662,6 +688,7 @@ private fun <T : Any, C, E> TableBodySection(
                 itemsCount = itemsCount,
                 itemAt = itemAt,
                 rowKey = rowKey,
+                rowKeyAt = rowKeyAt,
                 visibleColumns = visibleColumns,
                 state = state,
                 colors = colors,
@@ -683,6 +710,7 @@ private fun <T : Any, C, E> TableBodySection(
                 itemsCount = itemsCount,
                 itemAt = itemAt,
                 rowKey = rowKey,
+                rowKeyAt = rowKeyAt,
                 visibleColumns = visibleColumns,
                 state = state,
                 colors = colors,

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/TableSetup.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/TableSetup.kt
@@ -27,13 +27,15 @@ import ua.wwind.table.state.TableState
 internal fun <T : Any> WarnRowBlocksMisuse(
     rowBlocks: RowBlocks<T>?,
     rowKey: (item: T?, index: Int) -> Any,
+    rowKeyAt: ((index: Int) -> Any)?,
     rowBlocksSuppressed: Boolean,
 ) {
     LaunchedEffect(rowBlocksSuppressed) {
         if (rowBlocksSuppressed) Logger.w { "rowBlocks ignored while groupBy is active" }
     }
-    LaunchedEffect(rowBlocks, rowKey) {
-        if (rowBlocks != null && rowKey === DefaultRowKey) {
+    // A declared rowKeyAt is the identity, so the default rowKey behind it says nothing.
+    LaunchedEffect(rowBlocks, rowKey, rowKeyAt) {
+        if (rowBlocks != null && rowKeyAt == null && rowKey === DefaultRowKey) {
             Logger.w {
                 "rowBlocks requires a stable rowKey: RowBlockMove anchors are row keys, " +
                     "and the default positional key cannot survive a move"
@@ -56,6 +58,7 @@ internal class EffectiveRowSource<T : Any>(
     val blocks: RowBlocksState<T>?,
     val itemAt: (Int) -> T?,
     val rowKey: (item: T?, index: Int) -> Any,
+    val rowKeyAt: ((index: Int) -> Any)?,
     val onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)?,
     val suppressedByGroupBy: Boolean,
 )
@@ -73,12 +76,20 @@ internal fun <T : Any, C> rememberEffectiveRowSource(
     state: TableState<C>,
     rowBlocks: RowBlocks<T>?,
     rowKey: (item: T?, index: Int) -> Any,
+    rowKeyAt: ((index: Int) -> Any)?,
     onRowMove: ((fromIndex: Int, toIndex: Int) -> Unit)?,
     itemsCount: Int,
     itemAt: (Int) -> T?,
 ): EffectiveRowSource<T> {
+    // rowKeyAt supersedes rowKey everywhere, block anchors included: one identity per table.
+    val declaredRowKey: (item: T?, index: Int) -> Any =
+        remember(rowKey, rowKeyAt) {
+            if (rowKeyAt == null) rowKey else { _, index -> rowKeyAt(index) }
+        }
     val blocksState =
-        rowBlocks?.let { blocks -> remember(blocks, rowKey) { RowBlocksState(blocks, rowKey) } }
+        rowBlocks?.let { blocks ->
+            remember(blocks, declaredRowKey) { RowBlocksState(blocks, declaredRowKey) }
+        }
     // Feed the state the same snapshot this composition renders: block extents are derived here,
     // never declared, so they cannot lag behind an asynchronously filtered list.
     blocksState?.reconcile(itemsCount, itemAt)
@@ -95,11 +106,20 @@ internal fun <T : Any, C> rememberEffectiveRowSource(
                 if (activeBlocks != null) activeBlocks::itemAt else itemAt
             },
         rowKey =
-            remember(activeBlocks, rowKey) {
+            remember(activeBlocks, declaredRowKey) {
                 if (activeBlocks == null) {
-                    rowKey
+                    declaredRowKey
                 } else {
-                    { item, viewIndex -> rowKey(item, activeBlocks.upstreamIndexOf(viewIndex)) }
+                    { item, viewIndex -> declaredRowKey(item, activeBlocks.upstreamIndexOf(viewIndex)) }
+                }
+            },
+        // Same view-to-upstream translation as `rowKey` above.
+        rowKeyAt =
+            remember(activeBlocks, rowKeyAt) {
+                if (activeBlocks == null || rowKeyAt == null) {
+                    rowKeyAt
+                } else {
+                    { viewIndex -> rowKeyAt(activeBlocks.upstreamIndexOf(viewIndex)) }
                 }
             },
         // Gate on blocksState, not activeBlocks: declaring rowBlocks retires onRowMove outright, and

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableBody.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/body/TableBody.kt
@@ -20,6 +20,7 @@ import sh.calvin.reorderable.ReorderableColumn
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import ua.wwind.table.ColumnSpec
+import ua.wwind.table.DefaultRowKey
 import ua.wwind.table.DefaultTableItemScope
 import ua.wwind.table.TableItemDragScope
 import ua.wwind.table.TableItemListDragScope
@@ -37,6 +38,7 @@ internal fun <T : Any, C, E> TableBody(
     itemsCount: Int,
     itemAt: (Int) -> T?,
     rowKey: (item: T?, index: Int) -> Any,
+    rowKeyAt: ((index: Int) -> Any)?,
     visibleColumns: ImmutableList<ColumnSpec<T, C, E>>,
     state: TableState<C>,
     colors: TableColors,
@@ -95,7 +97,7 @@ internal fun <T : Any, C, E> TableBody(
         // Stable per-row key, drawn from the same snapshot as everything else the drag reads. Also
         // serves as the nested within-block column's node identity.
         val keyOf: (Int) -> Any =
-            if (snap != null) snap::keyAt else { row -> rowKey(itemAt(row), row) }
+            if (snap != null) snap::keyAt else rowKeyResolver(rowKey, rowKeyAt, itemAt)
         items(
             count = units.unitCount,
             key = { unit -> keyOf(units.rowsOf(unit).first) },
@@ -227,6 +229,7 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
     itemsCount: Int,
     itemAt: (Int) -> T?,
     rowKey: (item: T?, index: Int) -> Any,
+    rowKeyAt: ((index: Int) -> Any)?,
     visibleColumns: ImmutableList<ColumnSpec<T, C, E>>,
     state: TableState<C>,
     colors: TableColors,
@@ -271,7 +274,7 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
     val currentOnRowMoveWithinBlock = rememberUpdatedState(hooks.onRowMoveWithinBlock)
 
     // Stable per-row key for the nested within-block column's node identity.
-    val rowKeyAt: (Int) -> Any = { i -> rowKey(itemAt(i), i) }
+    val keyOf: (Int) -> Any = rowKeyResolver(rowKey, rowKeyAt, itemAt)
 
     Column {
         if (rowReorderEnabled) {
@@ -283,7 +286,7 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
             ) { unitIndex, leadingItem, _ ->
                 val rows = rowUnits.rowsOf(unitIndex)
                 val isGroup = rowUnits.isGroup(unitIndex)
-                key(rowKey(leadingItem, rows.first)) {
+                key(keyOf(rows.first)) {
                     ReorderableItem {
                         val rowScope: TableItemScope =
                             remember(this) {
@@ -313,7 +316,7 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
                                         null
                                     },
                                 onWithinBlockDragStart = { currentOnBlockDragStarted.value?.invoke() },
-                                rowKeyAt = rowKeyAt,
+                                rowKeyAt = keyOf,
                                 withinBlockRefusalCount = withinBlockRefusalCount,
                                 itemAt = itemAt,
                                 visibleColumns = visibleColumns,
@@ -348,7 +351,7 @@ internal fun <T : Any, C, E> TableBodyEmbedded(
                         blockHeader = blockHeader,
                         onRowMoveWithinBlock = null,
                         onWithinBlockDragStart = null,
-                        rowKeyAt = rowKeyAt,
+                        rowKeyAt = keyOf,
                         withinBlockRefusalCount = withinBlockRefusalCount,
                         itemAt = itemAt,
                         visibleColumns = visibleColumns,
@@ -480,6 +483,23 @@ internal fun <T : Any, C, E> TableBodyRow(
         )
     }
 }
+
+/**
+ * Keys a row, resolving it only when the key cannot be had without it.
+ *
+ * A lazy list asks for keys over ~130 rows from the top of the list and rebuilds that map on every
+ * item-provider change, so keying through [itemAt] reads rows nobody is looking at (issue #60).
+ */
+private fun <T : Any> rowKeyResolver(
+    rowKey: (item: T?, index: Int) -> Any,
+    rowKeyAt: ((index: Int) -> Any)?,
+    itemAt: (Int) -> T?,
+): (Int) -> Any =
+    when {
+        rowKeyAt != null -> rowKeyAt
+        rowKey === DefaultRowKey -> { row -> row }
+        else -> { row -> rowKey(itemAt(row), row) }
+    }
 
 /**
  * The embedded engine's input list. A refused drop restores the view order, so the elements alone

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/RowKeyItemReadTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/RowKeyItemReadTest.kt
@@ -1,0 +1,113 @@
+package ua.wwind.table
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isLessThan
+import assertk.assertions.isNotNull
+import kotlinx.collections.immutable.persistentListOf
+import ua.wwind.table.state.rememberTableState
+import kotlin.test.Test
+
+private data class KeyedRow(
+    val id: Int,
+)
+
+private fun keyedColumns() =
+    tableColumns<KeyedRow, String, Unit> {
+        column("name", valueOf = { it.id }) {
+            header("Name")
+            width(120.dp, 120.dp)
+            resizable(false)
+            cell { item, _ -> Text("row-${item.id}") }
+        }
+    }
+
+/**
+ * A row read must mean "this row is on screen": Compose asks for keys over 130 rows from the top of
+ * the list, and a source that loads on access reads every one of those as a viewport (issue #60).
+ *
+ * The viewport holds ~6 of the 1000 rows; the bound absorbs what Compose lays out past it.
+ */
+@OptIn(ExperimentalTestApi::class)
+class RowKeyItemReadTest {
+    @Test
+    fun `the default rowKey resolves no row beyond the viewport`() =
+        runComposeUiTest {
+            val reads = mutableSetOf<Int>()
+            setContent {
+                val columns = remember { keyedColumns() }
+                val state = rememberTableState(columns = persistentListOf("name"))
+                Box(Modifier.size(400.dp, 320.dp)) {
+                    Table(
+                        itemsCount = 1000,
+                        itemAt = { index ->
+                            reads += index
+                            KeyedRow(index)
+                        },
+                        state = state,
+                        columns = columns,
+                    )
+                }
+            }
+            waitForIdle()
+            assertThat(reads).contains(0)
+            assertThat(reads.max()).isLessThan(60)
+        }
+
+    @Test
+    fun `a rowKeyAt resolves no row beyond the viewport`() =
+        runComposeUiTest {
+            val reads = mutableSetOf<Int>()
+            setContent {
+                val columns = remember { keyedColumns() }
+                val state = rememberTableState(columns = persistentListOf("name"))
+                Box(Modifier.size(400.dp, 320.dp)) {
+                    Table(
+                        itemsCount = 1000,
+                        itemAt = { index ->
+                            reads += index
+                            KeyedRow(index)
+                        },
+                        state = state,
+                        columns = columns,
+                        rowKeyAt = { index -> "key-$index" },
+                    )
+                }
+            }
+            waitForIdle()
+            assertThat(reads).contains(0)
+            assertThat(reads.max()).isLessThan(60)
+        }
+
+    @Test
+    fun `a plain rowKey still receives the item of a rendered row`() =
+        runComposeUiTest {
+            val keyed = mutableMapOf<Int, KeyedRow?>()
+            setContent {
+                val columns = remember { keyedColumns() }
+                val state = rememberTableState(columns = persistentListOf("name"))
+                Box(Modifier.size(400.dp, 320.dp)) {
+                    Table(
+                        itemsCount = 1000,
+                        itemAt = { index -> KeyedRow(index) },
+                        state = state,
+                        columns = columns,
+                        rowKey = { item, index ->
+                            keyed[index] = item
+                            item?.id ?: index
+                        },
+                    )
+                }
+            }
+            waitForIdle()
+            assertThat(keyed[0]).isNotNull()
+        }
+}

--- a/table-paging/build.gradle.kts
+++ b/table-paging/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("ua.wwind.convention.compose")
     id("ua.wwind.convention.logging")
     id("ua.wwind.convention.publishing")
+    id("ua.wwind.convention.test")
 }
 
 // `paging-core` ships without the Compose compiler plugin, so the compiler infers no stability for
@@ -23,6 +24,12 @@ kotlin {
         commonMain.dependencies {
             implementation(project(":table-core"))
             implementation(libs.paging.core)
+        }
+        commonTest.dependencies {
+            implementation(libs.compose.ui.test)
+        }
+        jvmTest.dependencies {
+            implementation(compose.desktop.currentOs)
         }
     }
 }

--- a/table-paging/src/commonMain/kotlin/ua/wwind/table/paging/Table.kt
+++ b/table-paging/src/commonMain/kotlin/ua/wwind/table/paging/Table.kt
@@ -8,7 +8,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Shape
@@ -53,6 +55,28 @@ private fun WarnOnDefaultRowKeyWithBlocks(
                 "rowBlocks requires a stable rowKey: RowBlockMove anchors are row keys, " +
                     "and the default positional key cannot survive a move"
             }
+        }
+    }
+}
+
+/**
+ * [rowKey] answered by index, without the access the pager acts on as a viewport position (#60).
+ *
+ * Loaded rows are already in the paging map, so reading `values` yields the same row the accessor
+ * would; an unloaded one is `null` either way.
+ */
+@Composable
+private fun <T : Any> rememberPagedRowKeyAt(
+    items: PagingData<T>?,
+    rowKey: (item: T?, index: Int) -> Any,
+): (index: Int) -> Any {
+    // Keyed on `items` this would be a new lookup per emission, rebuilding a block table's state.
+    val currentItems by rememberUpdatedState(items)
+    return remember<(Int) -> Any>(rowKey) {
+        if (rowKey === DefaultPagedRowKey) {
+            { index -> index }
+        } else {
+            { index -> rowKey(currentItems?.data?.values?.get(index), index) }
         }
     }
 }
@@ -123,6 +147,7 @@ public fun <T : Any, C, E> Table(
     WarnOnDefaultRowKeyWithBlocks(rowBlocks, rowKey)
     val itemsCount = remember(items) { items?.data?.size ?: 0 }
     val itemAt = remember(items) { { index: Int -> items?.data?.get(index)?.getOrNull() } }
+    val rowKeyAt = rememberPagedRowKeyAt(items, rowKey)
 
     Table(
         itemsCount = itemsCount,
@@ -133,6 +158,7 @@ public fun <T : Any, C, E> Table(
         modifier = modifier,
         placeholderRow = placeholderRow,
         rowKey = rowKey,
+        rowKeyAt = rowKeyAt,
         onRowClick = onRowClick,
         onRowLongClick = onRowLongClick,
         rowBlocks = rowBlocks,
@@ -211,6 +237,7 @@ public fun <T : Any, C> Table(
     WarnOnDefaultRowKeyWithBlocks(rowBlocks, rowKey)
     val itemsCount = remember(items) { items?.data?.size ?: 0 }
     val itemAt = remember(items) { { index: Int -> items?.data?.get(index)?.getOrNull() } }
+    val rowKeyAt = rememberPagedRowKeyAt(items, rowKey)
 
     Table(
         itemsCount = itemsCount,
@@ -220,6 +247,7 @@ public fun <T : Any, C> Table(
         modifier = modifier,
         placeholderRow = placeholderRow,
         rowKey = rowKey,
+        rowKeyAt = rowKeyAt,
         onRowClick = onRowClick,
         onRowLongClick = onRowLongClick,
         rowBlocks = rowBlocks,

--- a/table-paging/src/commonTest/kotlin/ua/wwind/table/paging/PagedRowKeyAccessTest.kt
+++ b/table-paging/src/commonTest/kotlin/ua/wwind/table/paging/PagedRowKeyAccessTest.kt
@@ -1,0 +1,106 @@
+package ua.wwind.table.paging
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isLessThan
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentMap
+import ua.wwind.paging.core.LoadState
+import ua.wwind.paging.core.PagingData
+import ua.wwind.paging.core.PagingMap
+import ua.wwind.table.state.rememberTableState
+import ua.wwind.table.tableColumns
+import kotlin.test.Test
+
+private data class Person(
+    val id: Int,
+)
+
+private const val TOTAL = 1000
+
+/** Every position is loaded, so an access can only come from the table asking for that row. */
+private fun pagingData(onGet: (Int) -> Unit): PagingData<Person> =
+    PagingData(
+        data =
+            PagingMap(
+                size = TOTAL,
+                values = (0 until TOTAL).associateWith { Person(it) }.toPersistentMap(),
+                onGet = onGet,
+            ),
+        loadState = LoadState.Success,
+        retry = {},
+    )
+
+private fun personColumns() =
+    tableColumns<Person, String, Unit> {
+        column("name", valueOf = { it.id }) {
+            header("Name")
+            width(120.dp, 120.dp)
+            resizable(false)
+            cell { item, _ -> Text("row-${item.id}") }
+        }
+    }
+
+/**
+ * `PagingMap.get` tells the pager where the viewport is, so only rendered rows may reach it — the
+ * key map spans 130 rows against the handful on screen (issue #60). A custom `rowKey` still needs
+ * its row, which the adapter takes from the map directly.
+ */
+@OptIn(ExperimentalTestApi::class)
+class PagedRowKeyAccessTest {
+    @Test
+    fun `a custom rowKey does not report a viewport past the rendered rows`() =
+        runComposeUiTest {
+            val accessed = mutableSetOf<Int>()
+            setContent {
+                val columns = remember { personColumns() }
+                val state = rememberTableState(columns = persistentListOf("name"))
+                val items = remember { pagingData { accessed += it } }
+                Box(Modifier.size(400.dp, 320.dp)) {
+                    Table(
+                        items = items,
+                        state = state,
+                        columns = columns,
+                        rowKey = { person, index -> person?.id ?: index },
+                    )
+                }
+            }
+            waitForIdle()
+            assertThat(accessed).contains(0)
+            assertThat(accessed.max()).isLessThan(60)
+        }
+
+    @Test
+    fun `a custom rowKey still keys rendered rows by their item`() =
+        runComposeUiTest {
+            val keys = mutableMapOf<Int, Any>()
+            setContent {
+                val columns = remember { personColumns() }
+                val state = rememberTableState(columns = persistentListOf("name"))
+                val items = remember { pagingData { } }
+                Box(Modifier.size(400.dp, 320.dp)) {
+                    Table(
+                        items = items,
+                        state = state,
+                        columns = columns,
+                        rowKey = { person, index ->
+                            val key = person?.let { "id-${it.id}" } ?: "placeholder-$index"
+                            keys[index] = key
+                            key
+                        },
+                    )
+                }
+            }
+            waitForIdle()
+            assertThat(keys[0]).isEqualTo("id-0")
+        }
+}


### PR DESCRIPTION
Closes #60.

## What was wrong

`TableBody` answered every key a lazy list asked for with `rowKey(itemAt(row), row)`. Compose builds its key/index map over the nearest range — `0 until 130` when `firstVisibleItem = 0` — and rebuilds it whenever the item provider changes, so a ~20-row viewport turned into a 130-row **data read**, repeated on every paging emission.

`PagingMap.get` is what tells the pager where the viewport is, so the table reported a viewport of ~130 rows; the pager centred its window and cache there, evicted the rows actually on screen, those rows were then read and pulled the window back. 69 portion requests, 63 cancelled, from a stationary viewport.

## What changed

- **Core** resolves a row only when the key cannot be had without one. The default positional key answers from the index alone (recognized by identity, as the block warning already does).
- **New `rowKeyAt: ((index: Int) -> Any)?`** on `EditableTable` and both `Table` overloads: a key-by-index lookup that supersedes `rowKey` *wherever* the table needs a key. It is the table's row identity when declared — `RowBlocksState` anchors on it too, so a block table cannot end up with list keys and move anchors disagreeing, and the "blocks need a stable rowKey" warning stays quiet when it is set.
- **`table-paging`** sets `rowKeyAt` for itself: a custom `rowKey` is answered from `PagingData.data.values` — the same row the accessor would return, minus the access the pager acts on; an unloaded row is `null` in both. Read through a `rememberUpdatedState` holder rather than keyed on `items`, so a block table does not rebuild its drag state on every emission.
- **paging-core 2.3.1** (from 2.3.0) — the pager half of the same loop, White-Wind-LLC/paging-kmp#45. Either fix alone stops it.

An earlier attempt marked such keys with a `fun interface RowKeyByIndex : (Any?, Int) -> Any`, which is nicer to pass but illegal on Kotlin/JS ("Implementing a function interface is prohibited in JavaScript"), hence the plain nullable parameter.

## Tests

New, both watched failing first (each reported exactly `129`, the issue's number):

- `RowKeyItemReadTest` (table-core) — a 1000-row table in a ~6-row viewport reads no index past the rendered rows, under the default key and under `rowKeyAt`; a third test holds the line that a plain `rowKey` still receives its row.
- `PagedRowKeyAccessTest` (table-paging, new test source set) — a `PagingMap` that records `onGet` shows a custom `rowKey` no longer reports a viewport past the rendered rows, and still keys rows by their item.

Max index touched for that viewport: **129 → 4**.

## Verification

`./gradlew qualityCheck` and `jvmTest compileCommonMainKotlinMetadata compileKotlinJs compileKotlinWasmJs compileKotlinIosSimulatorArm64` — all green.

## Follow-up, not in this PR

`RowBlocksState.reconcile` materializes the whole list (`List(itemsCount) { itemAt(it) }`), so a **paged table with `rowBlocks`** still reads every position through the notifying accessor on each composition. Different path from the key map, not part of #60 — worth its own issue.