### PR TITLE
fix(core): count only the dividers the table actually draws

### DIFF
--- a/docs/superpowers/specs/2026-07-30-divider-aware-column-geometry-design.md
+++ b/docs/superpowers/specs/2026-07-30-divider-aware-column-geometry-design.md
@@ -1,0 +1,57 @@
+# Divider-Aware Column Geometry — Design
+
+## Goal
+
+Make every horizontal measurement agree with what the table paints, so a column boundary is where the
+resize strip is. Hiding the vertical dividers used to move the two apart.
+
+## Motivation
+
+A column boundary is computed in three places, and each one added `dimensions.dividerThickness` after
+every column unconditionally:
+
+- `TableState.computeTableWidth`, which the rows, header, footer and scroll range are all sized from,
+- `ColumnResizersOverlay`, which places the grab strips,
+- `ensureColumnFullyVisible`, which scrolls a column into view.
+
+`HeaderCell` and `TableCell` emit that divider only when `TableSettings.showVerticalDividers` is on.
+With it off the arithmetic counts dividers nobody draws, and the error accumulates: the strip for column
+*i* lands `i × dividerThickness` to the right of the boundary it belongs to. On a wide table the later
+strips sit on top of the next column's header — aiming at the visible boundary grabs nothing — and the
+scroll range carries a tail of empty space that is never rendered.
+
+Two settings escape the rule and are drawn whatever the flag says: the divider at the edge of a pinned
+block, either between the last left-pinned column and the scrolling ones, or before the first
+right-pinned one.
+
+## Non-goals
+
+- No change to what is drawn. This is arithmetic catching up with the painting, not a visual change.
+- No change to `TableSettings` or to any public signature.
+
+## Approach
+
+One internal function, `dividerWidthAfterColumn(columnIndex, totalVisibleColumns, settings, dimensions)`,
+returns the width the divider after a column actually occupies, mirroring the conditions the header and
+rows render under. All three call sites fold it in instead of a bare `dividerThickness`.
+`computeTableWidth` collapses to a single `foldIndexed` in the process — the pinned-column special case
+lives in the shared function now.
+
+A second defect surfaced while driving this: a resize gesture kept writing into a `TableState` that had
+been replaced. `rememberTableState` keys on `settings`, so changing any setting hands the table a new
+state holder, while `Modifier.pointerInput` is keyed on the column alone and its block outlives the
+composition that started it — the captured `onResize` went on updating the discarded state. Every value
+the gesture needs is now read through `rememberUpdatedState`: the boundary and width it starts from, and
+each callback.
+
+## Testing
+
+- `DividerWidthTest` covers the shared function: dividers shown, hidden, a left-pinned block, a
+  right-pinned block, and pinning every column (which pins none).
+- `ColumnGeometryTest` drives the table with dividers hidden — a drag at the visible boundary of a late
+  column must resize it, the last column must still resize, and scrolling a column into view must stop
+  at its real edge. All three fail on the previous arithmetic.
+- `ColumnResizeTest` gains a case asserting a drag lands on the state that replaced the one composed
+  first. It passes either way, so it documents the contract rather than covering the defect; the
+  stale-callback fix was confirmed by instrumenting the gesture and watching writes land in three
+  different state instances before, and one after.

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/component/header/ColumnResizersOverlay.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/component/header/ColumnResizersOverlay.kt
@@ -34,6 +34,7 @@ import kotlinx.collections.immutable.ImmutableList
 import ua.wwind.table.ColumnSpec
 import ua.wwind.table.config.TableDimensions
 import ua.wwind.table.state.currentTableState
+import ua.wwind.table.state.dividerWidthAfterColumn
 
 private const val OVERLAY_REACH_DP = 3
 
@@ -84,7 +85,8 @@ internal fun <T : Any, C, E> ColumnResizersOverlay(
                     onDoubleClick = onDoubleClick,
                 )
             }
-            cumulativeX += dimensions.dividerThickness
+            cumulativeX +=
+                dividerWidthAfterColumn(index, visibleColumns.size, state.settings, dimensions)
         }
     }
 }
@@ -111,15 +113,23 @@ private fun <C> ResizeHandle(
     val isHovered by interaction.collectIsHoveredAsState()
     val drag = remember(columnKey) { ColumnResizeDrag() }
 
-    // pointerInput is keyed on the column alone, so its block never sees a later composition:
-    // read the geometry a gesture starts from live, or every drag restarts from the first width.
+    // pointerInput is keyed on the column, so its block outlives the composition that started it:
+    // stale geometry restarts every drag from the first width, a stale callback writes to a dead state.
     val currentBoundaryX by rememberUpdatedState(boundaryX)
     val currentWidth by rememberUpdatedState(widthResolver(columnKey))
+    val currentMinWidth by rememberUpdatedState(minWidth)
+    val currentOnResize by rememberUpdatedState(onResize)
+    val currentOnResizeStart by rememberUpdatedState(onResizeStart)
+    val currentOnResizeEnd by rememberUpdatedState(onResizeEnd)
+    val currentOnDoubleClick by rememberUpdatedState(onDoubleClick)
 
     fun grow(deltaPx: Float) {
         val start = drag.startWidth ?: return
         drag.accumulatedPx += deltaPx
-        onResize(columnKey, (start + with(density) { drag.accumulatedPx.toDp() }).coerceAtLeast(minWidth))
+        currentOnResize(
+            columnKey,
+            (start + with(density) { drag.accumulatedPx.toDp() }).coerceAtLeast(currentMinWidth),
+        )
         val pullback = resizeScrollPullback(drag.boundaryPx, horizontalState.value, horizontalState.viewportSize)
         if (pullback > 0f) horizontalState.dispatchRawDelta(pullback)
     }
@@ -134,21 +144,21 @@ private fun <C> ResizeHandle(
                 .offset(x = boundaryX - reach, y = 0.dp)
                 .hoverable(interactionSource = interaction)
                 .pointerInput(columnKey) {
-                    detectTapGestures(onDoubleTap = { onDoubleClick(columnKey) })
-                }.combinedClickable(onDoubleClick = { onDoubleClick(columnKey) }) {}
+                    detectTapGestures(onDoubleTap = { currentOnDoubleClick(columnKey) })
+                }.combinedClickable(onDoubleClick = { currentOnDoubleClick(columnKey) }) {}
                 .pointerInput(columnKey) {
                     detectHorizontalDragGestures(
                         onDragStart = {
                             drag.begin(with(density) { currentBoundaryX.toPx() }, currentWidth)
-                            onResizeStart()
+                            currentOnResizeStart()
                         },
                         onDragEnd = {
                             drag.end()
-                            onResizeEnd()
+                            currentOnResizeEnd()
                         },
                         onDragCancel = {
                             drag.end()
-                            onResizeEnd()
+                            currentOnResizeEnd()
                         },
                     ) { change, dragAmount ->
                         val handleLeftPx = drag.boundaryPx - with(density) { reach.toPx() }

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/interaction/ViewportUtils.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/interaction/ViewportUtils.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import ua.wwind.table.ColumnSpec
 import ua.wwind.table.state.TableState
+import ua.wwind.table.state.dividerWidthAfterColumn
 
 /**
  * Ensure that the given [index] row becomes fully visible in the viewport (supports dynamic row heights).
@@ -163,11 +164,10 @@ public suspend fun <T : Any, C, E> ensureColumnFullyVisible(
 ) {
     val dimensions = state.dimensions
 
-    // Compute absolute left position of the target column within the content (px)
     var x = 0.dp
-    visibleColumns.take(targetColIndex).forEach { spec ->
-        val width = state.columns.resolveWidth(spec.key, spec)
-        x += width + dimensions.dividerThickness
+    visibleColumns.take(targetColIndex).forEachIndexed { index, spec ->
+        x += state.columns.resolveWidth(spec.key, spec) +
+            dividerWidthAfterColumn(index, visibleColumns.size, state.settings, dimensions)
     }
 
     val columnWidth = state.columns.resolveWidth(targetColKey, visibleColumns[targetColIndex])

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/state/ColumnGeometry.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/state/ColumnGeometry.kt
@@ -1,0 +1,31 @@
+package ua.wwind.table.state
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import ua.wwind.table.config.PinnedSide
+import ua.wwind.table.config.TableDimensions
+import ua.wwind.table.config.TableSettings
+
+/** Divider drawn after [columnIndex]; a phantom one shifts every boundary after it off its paint. */
+internal fun dividerWidthAfterColumn(
+    columnIndex: Int,
+    totalVisibleColumns: Int,
+    settings: TableSettings,
+    dimensions: TableDimensions,
+): Dp {
+    val pinnedCount =
+        if (settings.pinnedColumnsCount >= totalVisibleColumns) 0 else settings.pinnedColumnsCount
+    val bordersPinnedBlock =
+        pinnedCount > 0 &&
+            when (settings.pinnedColumnsSide) {
+                PinnedSide.Left -> columnIndex == pinnedCount - 1
+                PinnedSide.Right -> columnIndex == totalVisibleColumns - pinnedCount - 1
+            }
+
+    return when {
+        // A pinned block always draws its own edge, whatever the vertical-divider setting says.
+        bordersPinnedBlock -> dimensions.pinnedColumnDividerThickness
+        settings.showVerticalDividers -> dimensions.dividerThickness
+        else -> 0.dp
+    }
+}

--- a/table-core/src/commonMain/kotlin/ua/wwind/table/state/TableState.kt
+++ b/table-core/src/commonMain/kotlin/ua/wwind/table/state/TableState.kt
@@ -126,34 +126,11 @@ public class TableState<C>
             computeTableWidth(visibleColumns)
         }
 
-        /**
-         * Computes the total table width from visible columns and dividers.
-         */
-        private fun computeTableWidth(columnSpecs: List<ColumnSpec<*, C, *>>): Dp {
-            val effectivePinnedCount =
-                if (settings.pinnedColumnsCount >= columnSpecs.size) 0 else settings.pinnedColumnsCount
-
-            // Sum column widths (use stored widths, spec width or default)
-            val columnsTotal: Dp =
-                columnSpecs.fold(0.dp) { acc, spec ->
-                    val w = columns.resolveWidth(spec.key, spec)
-                    acc + w
-                }
-
-            // Calculate divider contribution:
-            // - If there are no pinned columns: each column has its regular divider (count = columns)
-            // - If there are pinned columns: all but one divider are regular, and one between pinned and scrollable is
-            //   thicker
-            val dividerTotal: Dp =
-                if (effectivePinnedCount == 0) {
-                    dimensions.dividerThickness * columnSpecs.size
-                } else {
-                    // total dividers = columns count, but one of them uses pinnedColumnDividerThickness
-                    dimensions.dividerThickness * (columnSpecs.size - 1) + dimensions.pinnedColumnDividerThickness
-                }
-
-            return columnsTotal + dividerTotal
-        }
+        private fun computeTableWidth(columnSpecs: List<ColumnSpec<*, C, *>>): Dp =
+            columnSpecs.foldIndexed(0.dp) { index, acc, spec ->
+                acc + columns.resolveWidth(spec.key, spec) +
+                    dividerWidthAfterColumn(index, columnSpecs.size, settings, dimensions)
+            }
 
         // Sorting
         public var sort: SortState<C>? by mutableStateOf(initialSort)

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/ColumnGeometryTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/ColumnGeometryTest.kt
@@ -1,0 +1,145 @@
+package ua.wwind.table
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isCloseTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isNotNull
+import kotlinx.collections.immutable.toImmutableList
+import ua.wwind.table.config.TableSettings
+import ua.wwind.table.state.TableState
+import ua.wwind.table.state.rememberTableState
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class ColumnGeometryTest {
+    private val keys = (0 until 8).map { "c$it" }
+
+    private val columns =
+        tableColumns<String, String, Unit> {
+            keys.forEach { key ->
+                column(key, valueOf = { it }) {
+                    header(key)
+                    width(30.dp, 100.dp)
+                    cell { _, _ -> Text(key) }
+                }
+            }
+        }
+
+    @Test
+    fun `scrolling a column into view stops at its real edge when dividers are hidden`() =
+        runComposeUiTest {
+            lateinit var state: TableState<String>
+            lateinit var horizontalState: ScrollState
+            setContent {
+                state =
+                    rememberTableState(
+                        columns = keys.toImmutableList(),
+                        settings = TableSettings(showVerticalDividers = false),
+                    )
+                horizontalState = rememberScrollState()
+                Box(Modifier.size(300.dp, 400.dp)) {
+                    Table(
+                        itemsCount = 1,
+                        itemAt = { "row" },
+                        state = state,
+                        columns = columns,
+                        horizontalState = horizontalState,
+                    )
+                }
+            }
+            waitForIdle()
+
+            state.selection.selectCell(rowIndex = 0, column = "c5")
+            waitForIdle()
+
+            val sixColumnsPastTheViewport = with(density) { (600.dp - 300.dp).toPx() }
+            assertThat(horizontalState.value.toFloat()).isCloseTo(sixColumnsPastTheViewport, 1f)
+        }
+
+    @Test
+    fun `the last column still resizes when vertical dividers are hidden`() =
+        runComposeUiTest {
+            lateinit var state: TableState<String>
+            lateinit var horizontalState: ScrollState
+            setContent {
+                state =
+                    rememberTableState(
+                        columns = keys.toImmutableList(),
+                        settings = TableSettings(showVerticalDividers = false),
+                    )
+                horizontalState = rememberScrollState()
+                Box(Modifier.size(300.dp, 400.dp)) {
+                    Table(
+                        itemsCount = 1,
+                        itemAt = { "row" },
+                        state = state,
+                        columns = columns,
+                        horizontalState = horizontalState,
+                    )
+                }
+            }
+            waitForIdle()
+            horizontalState.dispatchRawDelta(10_000f)
+            waitForIdle()
+
+            val boundaryPx = with(density) { (100.dp * 8).toPx() }
+            val grabX = boundaryPx - horizontalState.value - with(density) { 2.dp.toPx() }
+            val grabY = with(density) { (state.dimensions.headerHeight / 2).toPx() }
+
+            onRoot().performMouseInput {
+                moveTo(Offset(grabX, grabY))
+                press()
+                repeat(4) { moveBy(Offset(15f, 0f)) }
+                release()
+            }
+            waitForIdle()
+
+            val resized = state.columns.widths["c7"]
+            assertThat(resized).isNotNull()
+            assertThat(resized!!.value).isGreaterThan(100f)
+        }
+
+    @Test
+    fun `a grab strip sits on the boundary when vertical dividers are hidden`() =
+        runComposeUiTest {
+            lateinit var state: TableState<String>
+            setContent {
+                state =
+                    rememberTableState(
+                        columns = keys.toImmutableList(),
+                        settings = TableSettings(showVerticalDividers = false),
+                    )
+                Box(Modifier.size(900.dp, 400.dp)) {
+                    Table(itemsCount = 1, itemAt = { "row" }, state = state, columns = columns)
+                }
+            }
+            waitForIdle()
+
+            val boundaryAfterSevenColumns = with(density) { (100.dp * 7).toPx() }
+            val grabY = with(density) { (state.dimensions.headerHeight / 2).toPx() }
+
+            onRoot().performMouseInput {
+                moveTo(Offset(boundaryAfterSevenColumns - with(density) { 1.dp.toPx() }, grabY))
+                press()
+                repeat(4) { moveBy(Offset(15f, 0f)) }
+                release()
+            }
+            waitForIdle()
+
+            val resized = state.columns.widths["c6"]
+            assertThat(resized).isNotNull()
+            assertThat(resized!!.value).isGreaterThan(100f)
+        }
+}

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/ColumnResizeTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/ColumnResizeTest.kt
@@ -5,6 +5,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.ExperimentalTestApi
@@ -19,6 +23,7 @@ import assertk.assertions.isLessThan
 import assertk.assertions.isNotNull
 import kotlinx.collections.immutable.persistentListOf
 import ua.wwind.table.component.header.resizeScrollPullback
+import ua.wwind.table.config.TableSettings
 import ua.wwind.table.state.TableState
 import ua.wwind.table.state.rememberTableState
 import kotlin.test.Test
@@ -128,6 +133,44 @@ class ColumnResizeTest {
             val resized = state.columns.widths["b"]
             assertThat(resized).isNotNull()
             assertThat(resized!!.value).isLessThan(500f)
+        }
+
+    @Test
+    fun `a drag lands on the table state that replaced the one composed first`() =
+        runComposeUiTest {
+            var compact by mutableStateOf(false)
+            lateinit var state: TableState<String>
+
+            setContent {
+                val settings = remember(compact) { TableSettings(stripedRows = compact) }
+                state = rememberTableState(columns = persistentListOf("a", "b"), settings = settings)
+                Box(Modifier.size(1200.dp, 400.dp)) {
+                    Table(
+                        itemsCount = 1,
+                        itemAt = { "row" },
+                        state = state,
+                        columns = columns,
+                    )
+                }
+            }
+
+            waitForIdle()
+            compact = true
+            waitForIdle()
+
+            val boundaryPx = with(density) { 500.dp.toPx() }
+            val grabY = with(density) { (state.dimensions.headerHeight / 2).toPx() }
+            onRoot().performMouseInput {
+                moveTo(Offset(boundaryPx - with(density) { 1.dp.toPx() }, grabY))
+                press()
+                repeat(4) { moveBy(Offset(15f, 0f)) }
+                release()
+            }
+            waitForIdle()
+
+            val resized = state.columns.widths["a"]
+            assertThat(resized).isNotNull()
+            assertThat(resized!!.value).isGreaterThan(500f)
         }
 
     @Test

--- a/table-core/src/commonTest/kotlin/ua/wwind/table/state/DividerWidthTest.kt
+++ b/table-core/src/commonTest/kotlin/ua/wwind/table/state/DividerWidthTest.kt
@@ -1,0 +1,65 @@
+package ua.wwind.table.state
+
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import ua.wwind.table.config.PinnedSide
+import ua.wwind.table.config.TableDefaults
+import ua.wwind.table.config.TableSettings
+import kotlin.test.Test
+
+class DividerWidthTest {
+    private val dimensions = TableDefaults.standardDimensions()
+
+    private fun widths(
+        settings: TableSettings,
+        columns: Int = 8,
+    ) = (0 until columns).map { dividerWidthAfterColumn(it, columns, settings, dimensions) }
+
+    @Test
+    fun `every column carries a divider while they are shown`() {
+        val settings = TableSettings(showVerticalDividers = true)
+        assertThat(widths(settings)).isEqualTo(List(8) { dimensions.dividerThickness })
+    }
+
+    @Test
+    fun `no column carries a divider while they are hidden`() {
+        val settings = TableSettings(showVerticalDividers = false)
+        assertThat(widths(settings)).isEqualTo(List(8) { 0.dp })
+    }
+
+    @Test
+    fun `the last left-pinned column keeps its divider while the rest are hidden`() {
+        val settings =
+            TableSettings(
+                showVerticalDividers = false,
+                pinnedColumnsCount = 2,
+                pinnedColumnsSide = PinnedSide.Left,
+            )
+        val expected = List(8) { if (it == 1) dimensions.pinnedColumnDividerThickness else 0.dp }
+        assertThat(widths(settings)).isEqualTo(expected)
+    }
+
+    @Test
+    fun `the column before a right-pinned block keeps its divider while the rest are hidden`() {
+        val settings =
+            TableSettings(
+                showVerticalDividers = false,
+                pinnedColumnsCount = 2,
+                pinnedColumnsSide = PinnedSide.Right,
+            )
+        val expected = List(8) { if (it == 5) dimensions.pinnedColumnDividerThickness else 0.dp }
+        assertThat(widths(settings)).isEqualTo(expected)
+    }
+
+    @Test
+    fun `pinning every column pins none, so no divider survives hiding`() {
+        val settings =
+            TableSettings(
+                showVerticalDividers = false,
+                pinnedColumnsCount = 8,
+                pinnedColumnsSide = PinnedSide.Left,
+            )
+        assertThat(widths(settings)).isEqualTo(List(8) { 0.dp })
+    }
+}


### PR DESCRIPTION
A column boundary was computed in three places — the table width, the resize
strip overlay, and the scroll that brings a column into view — and all three
added a divider after every column unconditionally. The header and rows emit
that divider only while `showVerticalDividers` is on, so with it off the error
accumulated: the strip for column *i* landed `i * dividerThickness` right of its
boundary, on top of the next column's header, and aiming at the visible boundary
grabbed nothing. All three now fold in a shared `dividerWidthAfterColumn`, which
mirrors what the header renders — including the pinned-block edge, drawn
whatever the setting says.

A resize gesture also kept writing into a replaced table state: `pointerInput`
is keyed on the column and outlives the composition that started it, so after
any settings change the captured `onResize` updated a discarded holder and the
column stopped moving. The boundary, the width and every callback are now read
through `rememberUpdatedState`.

No public API or visual change. Covered by `DividerWidthTest` and
`ColumnGeometryTest`;